### PR TITLE
disable execstack explicitly for libxorgxrdp

### DIFF
--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -32,7 +32,7 @@ AM_CFLAGS = \
 
 libxorgxrdp_la_LTLIBRARIES = libxorgxrdp.la
 
-libxorgxrdp_la_LDFLAGS = -module -avoid-version
+libxorgxrdp_la_LDFLAGS = -module -avoid-version -Wl,-z,noexecstack
 
 libxorgxrdp_ladir = $(moduledir)
 


### PR DESCRIPTION
rpmlint reports a warning about execstack.

  xorg-x11-drv-xrdp.x86_64: W: executable-stack
  /usr/lib64/xorg/modules/libxorgxrdp.so The binary declares the stack
  as executable.  Executable stack is usually an error as it is only
  needed if the code contains GCC trampolines or similar constructs
  which uses code on the stack.  One common source for needlessly
  executable stack cases are object files built from assembler files
  which don't define a proper .note.GNU-stack section.

It is better to disable needless executable stack.
