### PR TITLE
Mark stack non-executable in *.asm files

### DIFF
--- a/module/amd64/a8r8g8b8_to_a8b8g8r8_box_amd64_sse2.asm
+++ b/module/amd64/a8r8g8b8_to_a8b8g8r8_box_amd64_sse2.asm
@@ -21,6 +21,10 @@
 ;amd64 SSE2
 ;
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c1 times 4 dd 0xFF00FF00

--- a/module/amd64/a8r8g8b8_to_nv12_box_amd64_sse2.asm
+++ b/module/amd64/a8r8g8b8_to_nv12_box_amd64_sse2.asm
@@ -25,6 +25,10 @@
 ;   width should be multile of 8 and > 0
 ;   height should be even and > 0
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 
     align 16

--- a/module/amd64/cpuid_amd64.asm
+++ b/module/amd64/cpuid_amd64.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 SECTION .text
 

--- a/module/amd64/i420_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/i420_to_rgb32_amd64_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/amd64/uyvy_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/uyvy_to_rgb32_amd64_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/amd64/yuy2_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/yuy2_to_rgb32_amd64_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/amd64/yv12_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/yv12_to_rgb32_amd64_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/x86/a8r8g8b8_to_a8b8g8r8_box_x86_sse2.asm
+++ b/module/x86/a8r8g8b8_to_a8b8g8r8_box_x86_sse2.asm
@@ -21,6 +21,10 @@
 ;x86 SSE2 32 bit
 ;
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c1 times 4 dd 0xFF00FF00

--- a/module/x86/a8r8g8b8_to_nv12_box_x86_sse2.asm
+++ b/module/x86/a8r8g8b8_to_nv12_box_x86_sse2.asm
@@ -25,6 +25,10 @@
 ;   width should be multile of 8 and > 0
 ;   height should be even and > 0
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 
     align 16

--- a/module/x86/cpuid_x86.asm
+++ b/module/x86/cpuid_x86.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 SECTION .text
 

--- a/module/x86/i420_to_rgb32_x86_sse2.asm
+++ b/module/x86/i420_to_rgb32_x86_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/x86/uyvy_to_rgb32_x86_sse2.asm
+++ b/module/x86/uyvy_to_rgb32_x86_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/x86/yuy2_to_rgb32_x86_sse2.asm
+++ b/module/x86/yuy2_to_rgb32_x86_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128

--- a/module/x86/yv12_to_rgb32_x86_sse2.asm
+++ b/module/x86/yv12_to_rgb32_x86_sse2.asm
@@ -33,6 +33,10 @@
 ;   4096    -1616    -2378
 ;   4096     9324     0
 
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 SECTION .data
 align 16
 c128 times 8 dw 128


### PR DESCRIPTION
This is a more portable alternative to #11 

The fix is described at https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart

The fix was tested by running the command that rpmlint runs: `readelf -W -S -l -d -s libxorgxrdp.so` and checking that "E" is not in the flag column for the GNU_STACK headers.
