### PR TITLE
Fix for Raspberry PI 3 Model B

### DIFF
--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -151,7 +151,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     {
         return FALSE;
     }
-    if (pScrn->numEntities != 1)
+    if (pScrn->numEntities == 0)
     {
         return FALSE;
     }


### PR DESCRIPTION
On "Raspberry PI 3 Model B", pScrn->numEntities equal 2.
