### PR TITLE
Add support for new API in RegisterBlockAndWakeupHandlers()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,14 @@ fi
 AM_CONDITIONAL(WITH_SIMD_AMD64, [test x$simd_arch = xx86_64])
 AM_CONDITIONAL(WITH_SIMD_X86, [test x$simd_arch = xi386])
 
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS $XORG_SERVER_CFLAGS"
+AC_CHECK_TYPES([ServerBlockHandlerProcPtr], , , [
+#include <xorg-server.h>
+#include <xf86.h>
+])
+CFLAGS="$save_CFLAGS"
+
 AC_CONFIG_FILES([Makefile
                  module/Makefile
                  xrdpdev/Makefile

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -399,13 +399,21 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
 
 /******************************************************************************/
 static void
+#if defined(HAVE_SERVERBLOCKHANDLERPROCPTR)
 rdpBlockHandler1(pointer blockData, OSTimePtr pTimeout, pointer pReadmask)
+#else
+rdpBlockHandler1(void *blockData, void *pTimeout)
+#endif
 {
 }
 
 /******************************************************************************/
 static void
+#if defined(HAVE_SERVERBLOCKHANDLERPROCPTR)
 rdpWakeupHandler1(pointer blockData, int result, pointer pReadmask)
+#else
+rdpWakeupHandler1(void *blockData, int result)
+#endif
 {
     rdpClientConCheck((ScreenPtr)blockData);
 }


### PR DESCRIPTION
ServerBlockHandlerProcPtr was introduced for the new signature of the block handler. Changes to the wakeup handler were made in the came commit. Test if type ServerBlockHandlerProcPtr is defined. If yes, use the new API.