### PR TITLE
Compilation issue: typo fix in rdpClientConAddEnabledDevice name

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -177,7 +177,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
         clientCon->begin = FALSE;
         dev->conNumber++;
         clientCon->conNumber = dev->conNumber;
-        rdpCLientConAddEnabledDevice(pScreen, clientCon->sck);
+        rdpClientConAddEnabledDevice(pScreen, clientCon->sck);
     }
 
 #if 1


### PR DESCRIPTION
One small fixup for the latest patches. With it, xorgxrdp compiles without warnings and works on Fedora 25.