### PR TITLE
Use correct notation for NASM preprocessor

### DIFF
--- a/module/amd64/yv12_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/yv12_to_rgb32_amd64_sse2.asm
@@ -130,7 +130,7 @@ do8:
 PROC yv12_to_rgb32_amd64_sse2
 %else
 PROC _yv12_to_rgb32_amd64_sse2
-#endif
+%endif
     push rbx
     push rsi
     push rdi

--- a/module/x86/yv12_to_rgb32_x86_sse2.asm
+++ b/module/x86/yv12_to_rgb32_x86_sse2.asm
@@ -125,7 +125,7 @@ do8:
 
 %ifidn __OUTPUT_FORMAT__,elf
 PROC yv12_to_rgb32_x86_sse2
-#else
+%else
 PROC _yv12_to_rgb32_x86_sse2
 %endif
     push ebx


### PR DESCRIPTION
That's another compile fix for an issue caused by the latest patches. NASM uses `%` rather than `#` for the preprocessor.