### PR TITLE
Use xDpi and yDpi instead of monitorResolution

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -85,7 +85,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XRDP_i420 \
 ((12 << 24) | (65 << 16) | (0 << 12) | (0 << 8) | (0 << 4) | 0)
 
-#define PixelToMM(_size) (((_size) * 254 + (monitorResolution) * 5) / ((monitorResolution) * 10))
+#define PixelToMM(_size, _dpi) (((_size) * 254 + (_dpi) * 5) / ((_dpi) * 10))
 
 #define RDPMIN(_val1, _val2) ((_val1) < (_val2) ? (_val1) : (_val2))
 #define RDPMAX(_val1, _val2) ((_val1) < (_val2) ? (_val2) : (_val1))

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -595,6 +595,7 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
                                  int width, int height, int bpp)
 {
     RRScreenSizePtr pSize;
+    ScrnInfoPtr pScrn;
     int mmwidth;
     int mmheight;
     int bytes;
@@ -654,8 +655,9 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
     }
     clientCon->shmRegion = rdpRegionCreate(NullBox, 0);
 
-    mmwidth = PixelToMM(width);
-    mmheight = PixelToMM(height);
+    pScrn = xf86Screens[dev->pScreen->myNum];
+    mmwidth = PixelToMM(width, pScrn->xDpi);
+    mmheight = PixelToMM(height, pScrn->yDpi);
 
     if ((dev->width != width) || (dev->height != height))
     {

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -58,10 +58,12 @@ rdpRRRegisterSize(ScreenPtr pScreen, int width, int height)
     int mmwidth;
     int mmheight;
     RRScreenSizePtr pSize;
+    ScrnInfoPtr pScrn;
 
     LLOGLN(0, ("rdpRRRegisterSize: width %d height %d", width, height));
-    mmwidth = PixelToMM(width);
-    mmheight = PixelToMM(height);
+    pScrn = xf86Screens[pScreen->myNum];
+    mmwidth = PixelToMM(width, pScrn->xDpi);
+    mmheight = PixelToMM(height, pScrn->yDpi);
     pSize = RRRegisterSize(pScreen, width, height, mmwidth, mmheight);
     /* Tell RandR what the current config is */
     RRSetCurrentConfig(pScreen, RR_Rotate_0, 0, pSize);

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -293,11 +293,13 @@ rdpResizeSession(rdpPtr dev, int width, int height)
     int mmwidth;
     int mmheight;
     RRScreenSizePtr pSize;
+    ScrnInfoPtr pScrn;
     Bool ok;
 
     LLOGLN(0, ("rdpResizeSession: width %d height %d", width, height));
-    mmwidth = PixelToMM(width);
-    mmheight = PixelToMM(height);
+    pScrn = xf86Screens[dev->pScreen->myNum];
+    mmwidth = PixelToMM(width, pScrn->xDpi);
+    mmheight = PixelToMM(height, pScrn->yDpi);
 
     ok = TRUE;
     if ((dev->width != width) || (dev->height != height))


### PR DESCRIPTION
monitorResolution is 0 if DPI is not specified on the Xorg command line, so it should not be used without checking.

This patch respects the horizontal and the vertical DPI in case they are different.
