### PR TITLE
Memory leak fix - free result of XkbGetCoreMap()

### DIFF
--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -826,6 +826,8 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
                                       NULL, serverClient);
             }
         }
+        free(keySyms->map);
+        free(keySyms);
     }
     else
     {


### PR DESCRIPTION
There was no function to do it nicely. Just do what Xorg does.
https://github.com/mirror/xserver/blob/master/dix/devices.c#L1901