### PR TITLE
Enable silent rules by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ(2.59)
 AC_INIT([xrdpmod], [0.1.0], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.6 foreign])
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL


### PR DESCRIPTION
It's important that compile warnings are not buried in the noise. It is always possible to run `make V=1` to find the actual command line.