### PR TITLE
Memory leak fix - free result of XkbGetCoreMap()

### DIFF
--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -826,6 +826,8 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
                                       NULL, serverClient);
             }
         }
+        free(keySyms->map);
+        free(keySyms);
     }
     else
     {


### PR DESCRIPTION
There is no nice function or macro for that. Do what Xorg code does.