### PR TITLE
#endif typo on amd64

### DIFF
--- a/module/amd64/yv12_to_rgb32_amd64_sse2.asm
+++ b/module/amd64/yv12_to_rgb32_amd64_sse2.asm
@@ -130,7 +130,7 @@ do8:
 PROC yv12_to_rgb32_amd64_sse2
 %else
 PROC _yv12_to_rgb32_amd64_sse2
-#endif
+%endif
     push rbx
     push rsi
     push rdi


### PR DESCRIPTION
This small typo is causing compilation problems on amd64_sse2.