### PR TITLE
Improve cleanup code

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1205,6 +1205,15 @@ int
 rdpClientConDeinit(rdpPtr dev)
 {
     LLOGLN(0, ("rdpClientConDeinit:"));
+
+    if (dev->clientConTail != NULL)
+    {
+        LLOGLN(0, ("rdpClientConDeinit: disconnecting only clientCon"));
+        rdpClientConDisconnect(dev, dev->clientConTail);
+        dev->clientConHead = NULL;
+        dev->clientConTail = NULL;
+    }
+
     if (dev->listen_sck != 0)
     {
         rdpClientConRemoveEnabledDevice(dev->listen_sck);

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1209,6 +1209,7 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->listen_sck);
         g_sck_close(dev->listen_sck);
+        LLOGLN(0, ("rdpClientConDeinit: deleting file %s", dev->uds_data));
         unlink(dev->uds_data);
     }
     return 0;

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -43,7 +43,6 @@ cursor
 #include <X11/Xarch.h>
 
 #include "rdp.h"
-#include "rdpMain.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
 #include "rdpCursor.h"
@@ -354,5 +353,4 @@ void
 rdpSpriteDeviceCursorCleanup(DeviceIntPtr pDev, ScreenPtr pScr)
 {
     LLOGLN(10, ("rdpSpriteDeviceCursorCleanup:"));
-    xorgxrdpDownDown(pScr);
 }

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -45,6 +45,7 @@ misc draw calls
 #include "rdpMisc.h"
 #include "rdpGlyphs.h"
 #include "rdpReg.h"
+#include "rdpMain.h"
 
 #define LOG_LEVEL 1
 #define LLOGLN(_level, _args) \
@@ -364,6 +365,7 @@ rdpCloseScreen(int index, ScreenPtr pScreen)
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(index, pScreen);
     dev->pScreen->CloseScreen = rdpCloseScreen;
+    xorgxrdpDownDown(pScreen);
     return rv;
 }
 
@@ -381,6 +383,7 @@ rdpCloseScreen(ScreenPtr pScreen)
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(pScreen);
     dev->pScreen->CloseScreen = rdpCloseScreen;
+    xorgxrdpDownDown(pScreen);
     return rv;
 }
 

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -75,22 +75,13 @@ int
 rdpUnregisterInputCallback(rdpInputEventProcPtr proc)
 {
     int index;
-    char text[256];
 
     LLOGLN(0, ("rdpUnregisterInputCallback: proc %p", proc));
     for (index = 0; index < MAX_INPUT_PROC; index++)
     {
         if (g_input_proc[index].proc == proc)
         {
-            if (index == 0)
-            {
-                /* hack to cleanup
-                   remove when xrdpdevTearDown is working */
-                g_sprintf(text, "/tmp/.xrdp/xrdp_display_%s", display);
-                LLOGLN(0, ("rdpUnregisterInputCallback: deleting file %s", text));
-                unlink(text);
-            }
-            g_input_proc[index].proc = 0; 
+            g_input_proc[index].proc = 0;
             return 0;
         }
     }

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -533,6 +533,9 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     dev->privateKeyRecGC = rdpAllocateGCPrivate(pScreen, sizeof(rdpGCRec));
     dev->privateKeyRecPixmap = rdpAllocatePixmapPrivate(pScreen, sizeof(rdpPixmapRec));
 
+    dev->CloseScreen = pScreen->CloseScreen;
+    pScreen->CloseScreen = rdpCloseScreen;
+
     dev->CopyWindow = pScreen->CopyWindow;
     pScreen->CopyWindow = rdpCopyWindow;
 


### PR DESCRIPTION
This PR improves the cleanup when Xorg exits. Changes are mostly for code quality. A few hacks have been removed. The screen-related cleanup doesn't depend on the cursor or input code anymore. Valgrind won't complain of leaked file descriptors.

The teardown function is not called for non-input devices. That's still the case. The xorgxrdp module has a function `xorgxrdpTearDown` that is not called. Hopefully we fix teardown one day, and then it will be called. Another function, `xorgxrdpDownDown` is called manually to do the cleanup.

`xorgxrdpDownDown` was called from the cursor code. It is strange and unreliable. Older RHEL 6 based systems don't call that function.

Instead, `xorgxrdpDownDown` should be called from `rdpCloseScreen`. It turns out that `rdpCloseScreen` was not properly registered (no code was using `rdpCloseScreen` except `rdpCloseScreen` itself), so the let's fix it.

Now that `xorgxrdpDownDown` is working reliably, we can remove a hack that removes `/tmp/.xrdp/xrdp_display_$DISPLAY` when the keyboard device is unregistered. That file (actually, UNIX socket) is already removed in the cleanup code, I just needed to add logging.

Finally, Valgrind complains that a file descriptor was left open. To fix it, close the client connection socket (if it's open) in addition to the listening socket.