### PR TITLE
Provide reasonable hTotal, vTotal and dotClock for the display mode

### DIFF
--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -326,11 +326,15 @@ rdpRRAddOutput(rdpPtr dev, const char *aname, int x, int y, int width, int heigh
     RROutputPtr output;
     xRRModeInfo modeInfo;
     char name[64];
+    const int vfreq = 50;
 
     sprintf (name, "%dx%d", width, height);
     memset (&modeInfo, 0, sizeof(modeInfo));
     modeInfo.width = width;
     modeInfo.height = height;
+    modeInfo.hTotal = width;
+    modeInfo.vTotal = height;
+    modeInfo.dotClock = vfreq * width * height;
     modeInfo.nameLength = strlen(name);
     mode = RRModeGet(&modeInfo, name);
     if (mode == 0)


### PR DESCRIPTION
gtk3 programs crash when they divide dotClock by hTotal and vTotal to
calculate the refresh rate.

That is not an issue if Xorg supports RandR 1.5, but may be an issue for
older versions of Xorg.