### PR TITLE
Require autoconf >= 2.65

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script
 
-AC_PREREQ(2.59)
+AC_PREREQ(2.65)
 AC_INIT([xorgxrdp], [0.2.0], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests])


### PR DESCRIPTION
EL6's autoconf is 2.63. bootstrap fails with autoconf < 2.65.
Users can install autoconf 2.68 from EPEL.

```
$ rpm -qa |grep autoconf
autoconf268-2.68-2.el6.noarch
autoconf-2.63-5.1.el6.noarch
$ git clone --branch devel  https://github.com/neutrinolabs/xorgxrdp.git
$ cd xorgxrdp
$ ./bootstrap
/usr/bin/autoconf
/usr/bin/automake
/usr/bin/libtool
/usr/bin/pkg-config
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
/usr/bin/m4:configure.ac:13: recursion limit of 1024 exceeded, use -L<N> to change it
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal: autom4te failed with exit status: 1
autoreconf: aclocal failed with exit status: 1
```

Let user know what should be done, explicitly require autoconf >=2.65.
The message "Autoconf version 2.65 or higher is required" should help users.

```
$ ./bootstrap
/usr/bin/autoconf
/usr/bin/automake
/usr/bin/libtool
/usr/bin/pkg-config
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
configure.ac:3: error: Autoconf version 2.65 or higher is required
configure.ac:3: the top level
autom4te: /usr/bin/m4 failed with exit status: 63
aclocal: autom4te failed with exit status: 63
autoreconf: aclocal failed with exit status: 63
```

Actually, `sed -i -e 's|^autoreconf |autoreconf268 |' bootstrap` would help in this case.