### PR TITLE
Use absolute path in PKG_CONFIG_PATH to fix "make distcheck"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 env:
   global:
-    - PKG_CONFIG_PATH=xrdp/pkgconfig
+    - PKG_CONFIG_PATH=`pwd`/xrdp/pkgconfig
 
 install:
   - git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git xrdp


### PR DESCRIPTION
"make distcheck" runs in a subdirectory, so it could not find xrdp headers using relative path.