### PR TITLE
Make README.md user friendlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,65 +5,72 @@
 # xorgxrdp
 
 ## Overview
-**xorgxrdp** is a collection of modules to be used with the pre-existing X.Org
+
+**xorgxrdp** is a collection of modules to be used with a pre-existing X.Org
 install to make the X server act like X11rdp. Unlike X11rdp, you don't have to
-recompile the whole X Window System. Instead, additional drivers are installed
-to a location where the existing Xorg installation would pick them.
+recompile the whole X Window System. Instead, additional modules are installed to
+a location where the existing Xorg installation would pick them.
 
 xorgxrdp is to be used together with [xrdp](https://github.com/neutrinolabs/xrdp)
 and X.Org Server. It is pretty useless using xorgxrdp alone.
+
+## Features
+
+xorgxrdp supports screen resizing. When an RDP client connects, the screen is
+resized to the size supplied by the client.
+
+xorgxrdp uses 24 bits per pixel internally. xrdp translates the color depth for
+the RDP client as requested. RDP clients can disconnect and reconnect to the same
+session even if they use different color depths.
 
 ## Compiling
 
 ### Pre-requisites
 
-To compile from the packaged sources, you would need basic build tools - a
-compiler (**gcc** or **clang**) and the **make** program. Additionally, you
-would need **nasm** (Netwide Assembler) and the headers for X Window System
+To compile xorgxrdp from the packaged sources, you need basic build tools - a
+compiler (**gcc** or **clang**) and the **make** program. Additionally, you would
+need **nasm** (Netwide Assembler) and the development package for X Window System
 (look for **xserver-xorg-dev**, **xorg-x11-server-sdk** or
 **xorg-x11-server-devel** in your distro).
 
-To compile from the checked out directory, you would additionally need
-*autoconf**, **automake**, **libtool** and **pkgconfig**.
+To compile xorgxrdp from a checked out git repository, you would additionally
+need **autoconf**, **automake**, **libtool** and **pkgconfig**.
 
-### Get the source & build it
+### Get the source and build it
 
-xorgxrdp requires xrdp header files. There are different procedures to build
-xorgxrdp whether you have installed xrdp headers or not.
+xorgxrdp requires a header file from xrdp. So it's preferred that xrdp is
+compiled and installed first.
 
-If you have already installed xrdp,
+If compiling from the packaged source, unpack the tarball and change to the
+resulting directory.
 
-```
-git clone https://github.com/neutrinolabs/xorgxrdp.git
-cd xorgxrdp
-./bootstrap && ./configure && make
-```
+If compiling from a checked out repository, run `./bootstrap` first to create
+`configure` and other required files.
 
-If you haven't installed xrdp and don't want to install xrdp,
+Then run following commands to compile and install xorgxrdp:
 
 ```
-git clone https://github.com/neutrinolabs/xorgxrdp.git
-cd xorgxrdp
-git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git xrdp
-sed -e 's|@VERSION@|0.9.0|g' -e "s|@abs_top_srcdir@|`pwd`/xrdp|g" \
-    xrdp/pkgconfig/xrdp-uninstalled.pc.in > xrdp/pkgconfig/xrdp-uninstalled.pc
-./bootstrap && env PKG_CONFIG_PATH=xrdp/pkgconfig ./configure && make
+./configure
+make
+sudo make install
+```
+
+If you don't want to install xrdp first, you can compile xorgxrdp against xrdp
+sources by specifying XRDP_CFLAGS on the `configure` command line.
+
+```
+./configure XRDP_CFLAGS=-I/path/to/xrdp/common
 ```
 
 ## Usage
 
-As mentioned abobe, xorgxrdp is to be used together with xrdp and X.Org Server.
-You would need X.Org Server (**xserver-xorg-core** or **xorg-x11-server-Xorg**).
-xorgxrdp will be ignited automatically by xrdp (xrdp-sesman, speaking more
-accurately) so usually you don't need to run xorgxrdp manually except in case of
-debugging.
+When logging in to xrdp using an RDP client, make sure to select Xorg on the
+login screen. xrdp will tell xrdp-sesman to start Xorg with the configuration
+file that activates the xorgxrdp modules.
 
-In case of debugging, this is a typical example to run Xorg with xorgxrdp.
-Additional options may be required depending on your distro.
-
-```
-Xorg :10 -config xrdp/xorg.conf
-```
+Make sure your system has the X.Org server (typically **xserver-xorg-core** or
+**xorg-x11-server-Xorg** package). Check that Xorg is in the standard path
+(normally in `/usr/bin`).
 
 ## Contributing
 
@@ -71,3 +78,11 @@ First off, thanks for taking your time for improve xorgxrdp.
 
 If you contribute to xorgxrdp, checkout **devel** branch and make changes to
 the branch. Please make pull requests also versus **devel** branch.
+
+To debug xorgxrdp, you can run Xorg with xorgxrdp manually:
+
+```
+Xorg :10 -config xrdp/xorg.conf
+```
+
+See also the `tests` directory for the tests that exercise xorgxrdp modules.


### PR DESCRIPTION
Don't use any complex scripts in README. Give information to the users who
downloaded the tarball, not only to those who cloned the repository. Describe
features. Document installation. Move debugging to contributing, it's not part of
standard usage. Mention "tests" directory.