### PR TITLE
Disable dead code

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -262,7 +262,7 @@ rdpCopyBox_a8r8g8b8_to_a8b8g8r8(rdpClientCon *clientCon,
 }
 
 /******************************************************************************/
-int
+static int
 a8r8g8b8_to_r5g6b5_box(char *s8, int src_stride,
                        char *d8, int dst_stride,
                        int width, int height)
@@ -324,7 +324,7 @@ rdpCopyBox_a8r8g8b8_to_r5g6b5(rdpClientCon *clientCon,
 }
 
 /******************************************************************************/
-int
+static int
 a8r8g8b8_to_a1r5g5b5_box(char *s8, int src_stride,
                          char *d8, int dst_stride,
                          int width, int height)
@@ -386,7 +386,7 @@ rdpCopyBox_a8r8g8b8_to_a1r5g5b5(rdpClientCon *clientCon,
 }
 
 /******************************************************************************/
-int
+static int
 a8r8g8b8_to_r3g3b2_box(char *s8, int src_stride,
                        char *d8, int dst_stride,
                        int width, int height)

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -74,6 +74,7 @@ e GXor,           DPo
 f GXset           1
 */
 
+#if 0
 static int g_rdp_opcodes[16] =
 {
     0x00, /* GXclear        0x0 0 */
@@ -93,6 +94,7 @@ static int g_rdp_opcodes[16] =
     0x77, /* GXnand         0xe NOT src OR NOT dst */
     0xff  /* GXset          0xf 1 */
 };
+#endif
 
 static int
 rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon);
@@ -1298,6 +1300,7 @@ rdpClientConPreCheck(rdpPtr dev, rdpClientCon *clientCon, int in_size)
     return rv;
 }
 
+#if 0
 /******************************************************************************/
 int
 rdpClientConFillRect(rdpPtr dev, rdpClientCon *clientCon,
@@ -1653,6 +1656,7 @@ rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
 
     return 0;
 }
+#endif
 
 /******************************************************************************/
 int
@@ -1686,6 +1690,7 @@ rdpClientConSetCursorEx(rdpPtr dev, rdpClientCon *clientCon,
     return 0;
 }
 
+#if 0
 /******************************************************************************/
 int
 rdpClientConCreateOsSurface(rdpPtr dev, rdpClientCon *clientCon,
@@ -1991,6 +1996,7 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 
     return 0;
 }
+#endif
 
 /******************************************************************************/
 static CARD32
@@ -2246,6 +2252,7 @@ rdpClientConGetScreenImageRect(rdpPtr dev, rdpClientCon *clientCon,
     id->shmem_lineBytes = clientCon->shmem_lineBytes;
 }
 
+#if 0
 /******************************************************************************/
 void
 rdpClientConGetPixmapImageRect(rdpPtr dev, rdpClientCon *clientCon,
@@ -2374,6 +2381,7 @@ rdpClientConSendArea(rdpPtr dev, rdpClientCon *clientCon,
         }
     }
 }
+#endif
 
 /******************************************************************************/
 int

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1272,7 +1272,7 @@ rdpClientConEndUpdate(rdpPtr dev, rdpClientCon *clientCon)
 }
 
 /******************************************************************************/
-int
+static int
 rdpClientConPreCheck(rdpPtr dev, rdpClientCon *clientCon, int in_size)
 {
     int rv;

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -219,7 +219,7 @@ set_pixel_safe(char *data, int x, int y, int width, int height, int bpp,
 }
 
 /******************************************************************************/
-void
+static void
 rdpSpriteSetCursorCon(rdpClientCon *clientCon,
                       DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
                       int x, int y)

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -205,6 +205,7 @@ GetTextBoundingBox(DrawablePtr pDrawable, FontPtr font, int x, int y,
     }
 }
 
+#if 0
 /******************************************************************************/
 int
 rdpDrawItemAdd(rdpPtr dev, rdpPixmapRec *priv, struct rdp_draw_item *di)
@@ -230,6 +231,7 @@ rdpDrawItemAdd(rdpPtr dev, rdpPixmapRec *priv, struct rdp_draw_item *di)
 
     return 0;
 }
+#endif
 
 /******************************************************************************/
 int

--- a/module/rdpFillPolygon.c
+++ b/module/rdpFillPolygon.c
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
-void
+static void
 rdpFillPolygonOrg(DrawablePtr pDrawable, GCPtr pGC,
                   int shape, int mode, int count,
                   DDXPointPtr pPts)

--- a/module/rdpPolyGlyphBlt.c
+++ b/module/rdpPolyGlyphBlt.c
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
-void
+static void
 rdpPolyGlyphBltOrg(DrawablePtr pDrawable, GCPtr pGC,
                    int x, int y, unsigned int nglyph,
                    CharInfoPtr *ppci, pointer pglyphBase)

--- a/module/rdpPolySegment.c
+++ b/module/rdpPolySegment.c
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
-void
+static void
 rdpPolySegmentOrg(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment *pSegs)
 {
     GC_OP_VARS;

--- a/module/rdpSetSpans.c
+++ b/module/rdpSetSpans.c
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
-void
+static void
 rdpSetSpansOrg(DrawablePtr pDrawable, GCPtr pGC, char *psrc,
                DDXPointPtr ppt, int *pwidth, int nspans, int fSorted)
 {

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -534,7 +534,7 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
 }
 
 /******************************************************************************/
-void
+static void
 rdpkeybDeviceInit(DeviceIntPtr pDevice, KeySymsPtr pKeySyms, CARD8 *pModMap)
 {
     int i;


### PR DESCRIPTION
I wasted some time today trying to improve code in xorgxrdp that is not actually called. To prevent such waste of time in the future, I decided to find all dead code and comment if out with `#if 0` - `#endif`, Good editors will show such code as disabled.

Maybe somebody with a good knowledge of the code could remove the code that is not going to be used and leave the code that could still be useful. Disabling the code is the first step in that direction.

I also made functions without declarations static, so that it can be easily detected if they ever become unnecessary.