### PR TITLE
Correctly silence nasm compilation

### DIFF
--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -91,7 +91,7 @@ $(EXTRA_SOURCES)
 
 nasm_verbose = $(nasm_verbose_@AM_V@)
 nasm_verbose_ = $(nasm_verbose_@AM_DEFAULT_V@)
-nasm_verbose_0 = @
+nasm_verbose_0 = @echo "  NASM     $@";
 
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --mode=compile \

--- a/module/nasm_lt.sh
+++ b/module/nasm_lt.sh
@@ -53,5 +53,4 @@ if [ "$o_opt" != yes ] ; then
     outfile="-o `echo $infile | sed -e 's%^.*/%%' -e 's%\.[^.]*$%%'`.o"
     command="$command $outfile"
 fi
-echo $command
 exec $command


### PR DESCRIPTION
Remove output from nasm_lt.sh, print "NASM" and target name when silent
rules are enabled.