### PR TITLE
Stop using g_free(), remove g_malloc() and g_free()

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -947,7 +947,7 @@ rdpCapture2(rdpClientCon *clientCon,
                 out_rect_index++;
                 if (out_rect_index >= RDP_MAX_TILES)
                 {
-                    g_free(*out_rects);
+                    free(*out_rects);
                     *out_rects = NULL;
                     rdpRegionUninit(&temp_reg);
                     rdpRegionUninit(&lin_reg);

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -284,7 +284,7 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
             }
         }
     }
-    g_free(clientCon->osBitmaps);
+    free(clientCon->osBitmaps);
 
     plcli = NULL;
     pcli = dev->clientConHead;
@@ -327,7 +327,7 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
     }
     free_stream(clientCon->out_s);
     free_stream(clientCon->in_s);
-    g_free(clientCon);
+    free(clientCon);
     return 0;
 }
 
@@ -826,7 +826,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
         if (clientCon->client_info.offscreen_cache_entries > 0)
         {
             clientCon->maxOsBitmaps = clientCon->client_info.offscreen_cache_entries;
-            g_free(clientCon->osBitmaps);
+            free(clientCon->osBitmaps);
             clientCon->osBitmaps = (struct rdpup_os_bitmap *)
                         g_new0(struct rdpup_os_bitmap, clientCon->maxOsBitmaps);
         }
@@ -2173,7 +2173,7 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
         rdpClientConSendPaintRectShmEx(clientCon->dev, clientCon, &id,
                                        clientCon->dirtyRegion,
                                        rects, num_rects);
-        g_free(rects);
+        free(rects);
     }
     else
     {

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -259,7 +259,7 @@ rdpDrawItemRemove(rdpPtr dev, rdpPixmapRec *priv, struct rdp_draw_item *di)
     {
         if (di->u.line.segs != NULL)
         {
-            g_free(di->u.line.segs);
+            free(di->u.line.segs);
         }
     }
 
@@ -269,7 +269,7 @@ rdpDrawItemRemove(rdpPtr dev, rdpPixmapRec *priv, struct rdp_draw_item *di)
     }
 
     rdpRegionDestroy(di->reg);
-    g_free(di);
+    free(di);
     return 0;
 }
 

--- a/module/rdpGlyphs.c
+++ b/module/rdpGlyphs.c
@@ -61,13 +61,13 @@ rdpGlyphDeleteRdpText(struct rdp_text *rtext)
     {
         if (rtext->chars[index] != NULL)
         {
-            g_free(rtext->chars[index]->data);
-            g_free(rtext->chars[index]);
+            free(rtext->chars[index]->data);
+            free(rtext->chars[index]);
         }
     }
     rdpRegionDestroy(rtext->reg);
     rdpGlyphDeleteRdpText(rtext->next);
-    g_free(rtext);
+    free(rtext);
     return 0;
 }
 

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -138,33 +138,6 @@ g_sck_send(int sck, void *ptr, int len, int flags)
 }
 
 /*****************************************************************************/
-void *
-g_malloc(int size, int zero)
-{
-    char *rv;
-
-    rv = (char *)malloc(size);
-    if (zero)
-    {
-        if (rv != 0)
-        {
-            memset(rv, 0, size);
-        }
-    }
-    return rv;
-}
-
-/*****************************************************************************/
-void
-g_free(void *ptr)
-{
-    if (ptr != 0)
-    {
-        free(ptr);
-    }
-}
-
-/*****************************************************************************/
 void
 g_sprintf(char *dest, const char *format, ...)
 {

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -53,10 +53,6 @@ extern _X_EXPORT void
 g_sleep(int msecs);
 extern _X_EXPORT int
 g_sck_send(int sck, void *ptr, int len, int flags);
-extern _X_EXPORT void *
-g_malloc(int size, int zero);
-extern _X_EXPORT void
-g_free(void *ptr);
 extern _X_EXPORT void
 g_sprintf(char *dest, const char *format, ...);
 extern _X_EXPORT int
@@ -167,7 +163,7 @@ do {                                                    \
 do {                                         \
     if ((v) > (s)->size)                     \
     {                                        \
-        g_free((s)->data);                   \
+        free((s)->data);                   \
         (s)->data = g_new(char, (v));        \
         (s)->size = (v);                     \
     }                                        \
@@ -274,9 +270,9 @@ do {                                                          \
 do {                       \
     if ((s) != 0)          \
     {                      \
-        g_free((s)->data); \
+        free((s)->data); \
     }                      \
-    g_free((s));           \
+    free((s));           \
 } while (0)
 
 #endif

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -116,7 +116,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     pScreen->mmWidth = mmWidth;
     pScreen->mmHeight = mmHeight;
     screenPixmap = pScreen->GetScreenPixmap(pScreen);
-    g_free(dev->pfbMemory_alloc);
+    free(dev->pfbMemory_alloc);
     dev->pfbMemory_alloc = g_new0(char, dev->sizeInBytes + 16);
     dev->pfbMemory = (char *) RDPALIGN(dev->pfbMemory_alloc, 16);
     if (screenPixmap != 0)

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -451,7 +451,7 @@ rdpDeferredXvCleanup(OsTimerPtr timer, CARD32 now, pointer arg)
     dev = (rdpPtr) arg;
     dev->xv_timer_scheduled = 0;
     dev->xv_data_bytes = 0;
-    g_free(dev->xv_data);
+    free(dev->xv_data);
     dev->xv_data = 0;
     return 0;
 }
@@ -494,7 +494,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     index = width * height * 4 + drw_w * drw_h * 4 + 64;
     if (index > dev->xv_data_bytes)
     {
-        g_free(dev->xv_data);
+        free(dev->xv_data);
         dev->xv_data = g_new(char, index);
         if (dev->xv_data == NULL)
         {


### PR DESCRIPTION
Xorg uses malloc() and free() without any wrappers, and so should
xorgxrdp.

g_free() is equivalent to free(). C standard requires free() to take no
action on NULL argument.