### PR TITLE
log stream size not only length and connection count

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -396,8 +396,9 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
 
         if (len > s->size)
         {
-            LLOGLN(0, ("rdpClientConSendMsg: overrun error len %d count %d",
-                   len, clientCon->count));
+            LLOGLN(0, ("rdpClientConSendMsg: overrun error len, %d "
+                       "stream size %d, client count %d",
+                       len, s->size, clientCon->count));
         }
 
         s_pop_layer(s, iso_hdr);


### PR DESCRIPTION
I believe it makes it easier to debug buffer overrun #9, #62.