### PR TITLE
Suppress useless debug messages from rdpRRGetPanning

### DIFF
--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -269,7 +269,8 @@ rdpRRGetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
     BoxRec totalAreaRect;
     BoxRec trackingAreaRect;
 
-    LLOGLN(0, ("rdpRRGetPanning: %p", crtc));
+    LLOGLN(10, ("rdpRRGetPanning: totalArea %p trackingArea %p border %p",
+                totalArea, trackingArea, border));
 
     if (!g_panning)
     {


### PR DESCRIPTION
Lower debug level to 10. Print pointers that are actually used by the
function. Don't print crtc, it's not used.