### PR TITLE
Determine 64-bit and 32-bit systems by the pointer size in the compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,27 +38,29 @@ AC_ARG_WITH([simd],
     AC_HELP_STRING([--without-simd],[Omit SIMD extensions.]))
 if test "x${with_simd}" != "xno"; then
   # Check if we're on a supported CPU
-  AC_MSG_CHECKING([if we have SIMD optimisations for cpu type])
   case "$host_cpu" in
-    x86_64 | amd64)
-      AC_MSG_RESULT([yes (x86_64)])
+    x86_64 | amd64 | i*86 | x86 | ia32)
       AC_PROG_NASM
-      simd_arch=x86_64
-    ;;
-    i*86 | x86 | ia32)
-      AC_MSG_RESULT([yes (i386)])
-      AC_PROG_NASM
-      simd_arch=i386
-    ;;
+      case "$ptr_size" in
+        8)
+          simd_arch=x86_64
+          AC_MSG_NOTICE([Using x86_64 SIMD instructions])
+          AC_DEFINE([RFX_USE_ACCEL_AMD64], [1], [Use x86_64 SIMD instructions])
+          ;;
+        4)
+          simd_arch=i386
+          AC_MSG_NOTICE([Using i386 SIMD instructions])
+          AC_DEFINE([RFX_USE_ACCEL_X86], [1], [Use x86 SIMD instructions])
+          ;;
+        *)
+          AC_MSG_ERROR([Unexpected pointer size: $ptr_size])
+          ;;
+      esac
+      ;;
     *)
-      AC_MSG_RESULT([no ("$host_cpu")])
       AC_MSG_WARN([SIMD support not available for this CPU.  Performance will suffer.])
-      with_simd=no;
     ;;
   esac
-  if test "x${with_simd}" != "xno"; then
-    AC_DEFINE([WITH_SIMD], [1], [Use accelerated SIMD routines.])
-  fi
 fi
 
 AM_CONDITIONAL(WITH_SIMD_AMD64, [test x$simd_arch = xx86_64])

--- a/m4/nasm.m4
+++ b/m4/nasm.m4
@@ -6,14 +6,18 @@ AC_DEFUN([AC_PROG_NASM],[
 AC_CHECK_PROGS(NASM, [nasm nasmw yasm])
 test -z "$NASM" && AC_MSG_ERROR([no nasm (Netwide Assembler) found])
 
+AC_CHECK_SIZEOF([int *])
+ptr_size="$ac_cv_sizeof_int_p"
+
 AC_MSG_CHECKING([for object file format of host system])
+objfmt="unknown"
 case "$host_os" in
   cygwin* | mingw* | pw32* | interix*)
-    case "$host_cpu" in
-      x86_64)
+    case "$ptr_size" in
+      8)
         objfmt='Win64-COFF'
         ;;
-      *)
+      4)
         objfmt='Win32-COFF'
         ;;
     esac
@@ -31,11 +35,11 @@ case "$host_os" in
     objfmt='a.out'
   ;;
   linux*)
-    case "$host_cpu" in
-      x86_64)
+    case "$ptr_size" in
+      8)
         objfmt='ELF64'
         ;;
-      *)
+      4)
         objfmt='ELF'
         ;;
     esac
@@ -44,43 +48,40 @@ case "$host_os" in
     if echo __ELF__ | $CC -E - | grep __ELF__ > /dev/null; then
       objfmt='BSD-a.out'
     else
-      case "$host_cpu" in
-        x86_64 | amd64)
+      case "$ptr_size" in
+        8)
           objfmt='ELF64'
           ;;
-        *)
+        4)
           objfmt='ELF'
           ;;
       esac
     fi
   ;;
   solaris* | sunos* | sysv* | sco*)
-    case "$host_cpu" in
-      x86_64)
+    case "$ptr_size" in
+      8)
         objfmt='ELF64'
         ;;
-      *)
+      4)
         objfmt='ELF'
         ;;
     esac
   ;;
   darwin* | rhapsody* | nextstep* | openstep* | macos*)
-    case "$host_cpu" in
-      x86_64)
+    case "$ptr_size" in
+      8)
         objfmt='Mach-O64'
         ;;
-      *)
+      4)
         objfmt='Mach-O'
         ;;
     esac
   ;;
-  *)
-    objfmt='ELF ?'
-  ;;
 esac
 
 AC_MSG_RESULT([$objfmt])
-if test "$objfmt" = 'ELF ?'; then
+if test "$objfmt" = 'unknown'; then
   objfmt='ELF'
   AC_MSG_WARN([unexpected host system. assumed that the format is $objfmt.])
 fi


### PR DESCRIPTION
This makes it possible to compile 32-bit assembly by using "-m32" flag to
gcc.

Don't call unknown file format "ELF ?", call it "unknown".

Don't define WITH_SIMD, it's never used.