### PR TITLE
Use xnfalloc() and xnfcalloc() for memory allocation

### DIFF
--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -91,9 +91,9 @@ g_hexdump(void *p, long len);
 
 /* glib-style memory allocation macros */
 #define g_new(struct_type, n_structs) \
-    (struct_type *) malloc(sizeof(struct_type) * (n_structs))
+    (struct_type *) xnfalloc(sizeof(struct_type) * (n_structs))
 #define g_new0(struct_type, n_structs) \
-    (struct_type *) calloc((n_structs), sizeof(struct_type))
+    (struct_type *) xnfcalloc((n_structs), sizeof(struct_type))
 
 
 #if defined(X_BYTE_ORDER)


### PR DESCRIPTION
Those functions make the X server exit if memory allocation fails.