### PR TITLE
Use makefiles in arch-specific directories, simplify test build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,8 @@ AM_CONDITIONAL(WITH_SIMD_X86, [test x$simd_arch = xi386])
 
 AC_CONFIG_FILES([Makefile
                  module/Makefile
+                 module/amd64/Makefile
+                 module/x86/Makefile
                  tests/Makefile
                  tests/yuv2rgb/Makefile
                  xrdpdev/Makefile

--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -1,28 +1,18 @@
 EXTRA_DIST = nasm_lt.sh
-
-EXTRA_SOURCES =
 EXTRA_FLAGS =
+SUBDIRS =
+ASMLIB =
 
 if WITH_SIMD_AMD64
-EXTRA_SOURCES += amd64/cpuid_amd64.asm \
-  amd64/yv12_to_rgb32_amd64_sse2.asm \
-  amd64/i420_to_rgb32_amd64_sse2.asm \
-  amd64/yuy2_to_rgb32_amd64_sse2.asm \
-  amd64/uyvy_to_rgb32_amd64_sse2.asm \
-  amd64/a8r8g8b8_to_a8b8g8r8_box_amd64_sse2.asm \
-  amd64/a8r8g8b8_to_nv12_box_amd64_sse2.asm
 EXTRA_FLAGS += -DSIMD_USE_ACCEL=1
+SUBDIRS += amd64
+ASMLIB += amd64/libxorgxrdp-asm.la
 endif
 
 if WITH_SIMD_X86
-EXTRA_SOURCES += x86/cpuid_x86.asm \
-  x86/yv12_to_rgb32_x86_sse2.asm \
-  x86/i420_to_rgb32_x86_sse2.asm \
-  x86/yuy2_to_rgb32_x86_sse2.asm \
-  x86/uyvy_to_rgb32_x86_sse2.asm \
-  x86/a8r8g8b8_to_a8b8g8r8_box_x86_sse2.asm \
-  x86/a8r8g8b8_to_nv12_box_x86_sse2.asm
 EXTRA_FLAGS += -DSIMD_USE_ACCEL=1
+SUBDIRS += x86
+ASMLIB += x86/libxorgxrdp-asm.la
 endif
 
 AM_CFLAGS = \
@@ -86,15 +76,6 @@ rdpFillPolygon.c rdpPolyFillRect.c rdpPolyFillArc.c rdpPolyText8.c \
 rdpPolyText16.c rdpImageText8.c rdpImageText16.c rdpImageGlyphBlt.c \
 rdpPolyGlyphBlt.c rdpPushPixels.c rdpCursor.c rdpMain.c rdpRandR.c \
 rdpMisc.c rdpReg.c rdpComposite.c rdpGlyphs.c rdpPixmap.c rdpInput.c \
-rdpClientCon.c rdpCapture.c rdpTrapezoids.c rdpXv.c rdpSimd.c \
-$(EXTRA_SOURCES)
+rdpClientCon.c rdpCapture.c rdpTrapezoids.c rdpXv.c rdpSimd.c
 
-nasm_verbose = $(nasm_verbose_@AM_V@)
-nasm_verbose_ = $(nasm_verbose_@AM_DEFAULT_V@)
-nasm_verbose_0 = @echo "  NASM     $@";
-
-.asm.lo:
-	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --mode=compile \
-	  $(srcdir)/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@
-
-libxorgxrdp_la_LIBADD =
+libxorgxrdp_la_LIBADD = $(ASMLIB)

--- a/module/amd64/Makefile.am
+++ b/module/amd64/Makefile.am
@@ -1,0 +1,22 @@
+ASMSOURCES = \
+  a8r8g8b8_to_a8b8g8r8_box_amd64_sse2.asm \
+  a8r8g8b8_to_nv12_box_amd64_sse2.asm \
+  cpuid_amd64.asm \
+  i420_to_rgb32_amd64_sse2.asm \
+  uyvy_to_rgb32_amd64_sse2.asm \
+  yuy2_to_rgb32_amd64_sse2.asm \
+  yv12_to_rgb32_amd64_sse2.asm
+
+noinst_LTLIBRARIES = libxorgxrdp-asm.la
+
+libxorgxrdp_asm_la_SOURCES = \
+  funcs_amd64.h \
+  $(ASMSOURCES)
+
+nasm_verbose = $(nasm_verbose_@AM_V@)
+nasm_verbose_ = $(nasm_verbose_@AM_DEFAULT_V@)
+nasm_verbose_0 = @echo "  NASM     $@";
+
+.asm.lo:
+	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --mode=compile \
+	  $(top_srcdir)/module/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@

--- a/module/x86/Makefile.am
+++ b/module/x86/Makefile.am
@@ -1,0 +1,22 @@
+ASMSOURCES = \
+  a8r8g8b8_to_a8b8g8r8_box_x86_sse2.asm \
+  a8r8g8b8_to_nv12_box_x86_sse2.asm \
+  cpuid_x86.asm \
+  i420_to_rgb32_x86_sse2.asm \
+  uyvy_to_rgb32_x86_sse2.asm \
+  yuy2_to_rgb32_x86_sse2.asm \
+  yv12_to_rgb32_x86_sse2.asm
+
+noinst_LTLIBRARIES = libxorgxrdp-asm.la
+
+libxorgxrdp_asm_la_SOURCES = \
+  funcs_x86.h \
+  $(ASMSOURCES)
+
+nasm_verbose = $(nasm_verbose_@AM_V@)
+nasm_verbose_ = $(nasm_verbose_@AM_DEFAULT_V@)
+nasm_verbose_0 = @echo "  NASM     $@";
+
+.asm.lo:
+	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --mode=compile \
+	  $(top_srcdir)/module/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@

--- a/tests/yuv2rgb/.gitignore
+++ b/tests/yuv2rgb/.gitignore
@@ -1,0 +1,1 @@
+yuv2rgb_speed

--- a/tests/yuv2rgb/Makefile.am
+++ b/tests/yuv2rgb/Makefile.am
@@ -2,19 +2,19 @@ AM_CFLAGS =
 
 if WITH_SIMD_AMD64
 AM_CFLAGS += -DUSE_SIMD_AMD64
-ASMOBJ = $(top_builddir)/module/amd64/a8r8g8b8_to_nv12_box_amd64_sse2.lo
+ASMLIB = $(top_builddir)/module/amd64/libxorgxrdp-asm.la
 endif
 
 if WITH_SIMD_X86
 AM_CFLAGS += -DUSE_SIMD_X86
-ASMOBJ = $(top_builddir)/module/x86/a8r8g8b8_to_nv12_box_x86_sse2.lo
+ASMLIB = $(top_builddir)/module/x86/libxorgxrdp-asm.la
 endif
 
 check_PROGRAMS = yuv2rgb_speed
 
 yuv2rgb_speed_SOURCES = yuv2rgb_speed.c
 
-yuv2rgb_speed_LDADD = $(ASMOBJ)
+yuv2rgb_speed_LDADD = $(ASMLIB)
 
 TEST_EXTENSIONS = .sh
 SH_LOG_COMPILER = $(SHELL)


### PR DESCRIPTION
Instead of linking yuv2rgb_speed against a specific object file, link it against a library containing all SIMD accelerated code. That would simplify adding more tests for the assembly code.