### PR TITLE
rdpCursor: check pDev exists, fixes possible crash

### DIFF
--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -318,6 +318,11 @@ rdpSpriteSetCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
     rdpClientCon *clientCon;
 
     LLOGLN(10, ("rdpSpriteSetCursor:"));
+    if (pDev == 0)
+    {
+        return;
+    }
+
     if (pCurs == 0)
     {
         return;


### PR DESCRIPTION
Iv'e got this issue sometimes after long period of non-activity.
I think it is a possible fix.
```
(EE) 
(EE) Backtrace:
xrdp-chansrv [2777463963]: scard_deinit:
chansrv:smartcard_pcsc [2777463963]: scard_pcsc_deinit:
(EE) 0: Xorg (xorg_backtrace+0x56) [0x7fdeb8a13d46]
(EE) 1: Xorg (0x7fdeb885d000+0x1baf29) [0x7fdeb8a17f29]
(EE) 2: /lib/x86_64-linux-gnu/libc.so.6 (0x7fdeb654f000+0x350e0) [0x7fdeb65840e0]
(EE) 3: /usr/lib/xorg/modules/libxorgxrdp.so (0x7fdeb2668000+0x7b7a) [0x7fdeb266fb7a]
(EE) 4: /usr/lib/xorg/modules/libxorgxrdp.so (rdpSpriteSetCursor+0x57) [0x7fdeb266ff77]
(EE) 5: Xorg (miPointerUpdateSprite+0x26b) [0x7fdeb89fefdb]
(EE) 6: Xorg (0x7fdeb885d000+0x1a222e) [0x7fdeb89ff22e]
(EE) 7: Xorg (0x7fdeb885d000+0xea1d9) [0x7fdeb89471d9]
(EE) 8: Xorg (0x7fdeb885d000+0x135b3f) [0x7fdeb8992b3f]
(EE) 9: Xorg (0x7fdeb885d000+0x601a8) [0x7fdeb88bd1a8]
(EE) 10: Xorg (0x7fdeb885d000+0x63c1a) [0x7fdeb88c0c1a]
(EE) 11: Xorg (0x7fdeb885d000+0x14514b) [0x7fdeb89a214b]
(EE) 12: Xorg (0x7fdeb885d000+0x1457bb) [0x7fdeb89a27bb]
(EE) 13: Xorg (0x7fdeb885d000+0x167e92) [0x7fdeb89c4e92]
(EE) 14: Xorg (0x7fdeb885d000+0x19806a) [0x7fdeb89f506a]
(EE) 15: Xorg (mieqProcessInputEvents+0x127) [0x7fdeb89f5247]
(EE) 16: Xorg (ProcessInputEvents+0x19) [0x7fdeb88f2b69]
(EE) 17: Xorg (0x7fdeb885d000+0x57202) [0x7fdeb88b4202]
(EE) 18: Xorg (0x7fdeb885d000+0x5b596) [0x7fdeb88b8596]
(EE) 19: /lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main+0xf5) [0x7fdeb6570b45]
(EE) 20: Xorg (0x7fdeb885d000+0x4590e) [0x7fdeb88a290e]
(EE) 
(EE) Segmentation fault at address 0x25ff4
(EE) 
Fatal server error:
(EE) Caught signal 11 (Segmentation fault). Server aborting
(EE) 
(EE) 
Please consult the The X.Org Foundation support 
	 at http://wiki.x.org
 for help. 
(EE) Please also check the log file at ".xorgxrdp.10.log" for additional information.
(EE) 
rdpmouseControl: what 4
rdpkeybControl: what 4
rdpLeaveVT:
(EE) Server terminated with error (1). Closing log file.
xrdp-sessvc: WM is dead (waitpid said 51638, errno is 0) exiting...
```