### PR TITLE
Use XRDP_SOCKET_PATH environment variable for socket path

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1173,18 +1173,20 @@ rdpClientConInit(rdpPtr dev)
 {
     int i;
     char *ptext;
+    const char *socket_dir;
 
-    if (!g_directory_exist("/tmp/.xrdp"))
+    socket_dir = g_socket_dir();
+    if (!g_directory_exist(socket_dir))
     {
-        if (!g_create_dir("/tmp/.xrdp"))
+        if (!g_create_dir(socket_dir))
         {
-            if (!g_directory_exist("/tmp/.xrdp"))
+            if (!g_directory_exist(socket_dir))
             {
-                LLOGLN(0, ("rdpup_init: g_create_dir failed"));
+                LLOGLN(0, ("rdpup_init: g_create_dir(%s) failed", socket_dir));
                 return 0;
             }
         }
-        g_chmod_hex("/tmp/.xrdp", 0x1777);
+        g_chmod_hex(socket_dir, 0x1777);
     }
     i = atoi(display);
     if (i < 1)
@@ -1192,7 +1194,7 @@ rdpClientConInit(rdpPtr dev)
         LLOGLN(0, ("rdpClientConInit: can not run at display < 1"));
         return 0;
     }
-    g_sprintf(dev->uds_data, "/tmp/.xrdp/xrdp_display_%s", display);
+    g_sprintf(dev->uds_data, "%s/xrdp_display_%s", socket_dir, display);
     if (dev->listen_sck == 0)
     {
         unlink(dev->uds_data);

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -379,6 +379,22 @@ g_chmod_hex(const char *filename, int flags)
 }
 
 /*****************************************************************************/
+/* returns directory where UNIX sockets are located */
+const char *
+g_socket_dir(void)
+{
+    const char *socket_dir;
+
+    socket_dir = getenv("XRDP_SOCKET_PATH");
+    if (socket_dir == NULL || socket_dir[0] == '\0')
+    {
+        socket_dir = "/tmp/.xrdp";
+    }
+
+    return socket_dir;
+}
+
+/*****************************************************************************/
 /* produce a hex dump */
 void
 g_hexdump(void *p, long len)

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -85,6 +85,8 @@ extern _X_EXPORT int
 g_directory_exist(const char *dirname);
 extern _X_EXPORT int
 g_chmod_hex(const char *filename, int flags);
+extern _X_EXPORT const char *
+g_socket_dir(void);
 extern _X_EXPORT void
 g_hexdump(void *p, long len);
 


### PR DESCRIPTION
Needed to support configurable socket directory as implemented in https://github.com/neutrinolabs/xrdp/pull/695