### PR TITLE
Use stdint.h, constify more pointers, fix clang warning

### DIFF
--- a/module/amd64/funcs_amd64.h
+++ b/module/amd64/funcs_amd64.h
@@ -27,13 +27,13 @@ amd64 asm functions
 int
 cpuid_amd64(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 int
-yv12_to_rgb32_amd64_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+yv12_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-i420_to_rgb32_amd64_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+i420_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-yuy2_to_rgb32_amd64_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+yuy2_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-uyvy_to_rgb32_amd64_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+uyvy_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
 a8r8g8b8_to_a8b8g8r8_box_amd64_sse2(const char *s8, int src_stride,
                                     char *d8, int dst_stride,

--- a/module/amd64/funcs_amd64.h
+++ b/module/amd64/funcs_amd64.h
@@ -27,21 +27,21 @@ amd64 asm functions
 int
 cpuid_amd64(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 int
-yv12_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+yv12_to_rgb32_amd64_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-i420_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+i420_to_rgb32_amd64_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-yuy2_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+yuy2_to_rgb32_amd64_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-uyvy_to_rgb32_amd64_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+uyvy_to_rgb32_amd64_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-a8r8g8b8_to_a8b8g8r8_box_amd64_sse2(const char *s8, int src_stride,
-                                    char *d8, int dst_stride,
+a8r8g8b8_to_a8b8g8r8_box_amd64_sse2(const uint8_t *s8, int src_stride,
+                                    uint8_t *d8, int dst_stride,
                                     int width, int height);
 int
-a8r8g8b8_to_nv12_box_amd64_sse2(const char *s8, int src_stride,
-                                char *d8_y, int dst_stride_y,
-                                char *d8_uv, int dst_stride_uv,
+a8r8g8b8_to_nv12_box_amd64_sse2(const uint8_t *s8, int src_stride,
+                                uint8_t *d8_y, int dst_stride_y,
+                                uint8_t *d8_uv, int dst_stride_uv,
                                 int width, int height);
 
 #endif

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -208,7 +208,7 @@ struct _rdpCounts
     CARD32 callCount[64 - 23];
 };
 
-typedef int (*yuv_to_rgb32_proc)(unsigned char *yuvs, int width, int height, int *rgbs);
+typedef int (*yuv_to_rgb32_proc)(const unsigned char *yuvs, int width, int height, int *rgbs);
 
 typedef int (*copy_box_proc)(const char *s8, int src_stride,
                              char *d8, int dst_stride,

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -88,7 +88,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define RDPMIN(_val1, _val2) ((_val1) < (_val2) ? (_val1) : (_val2))
 #define RDPMAX(_val1, _val2) ((_val1) < (_val2) ? (_val2) : (_val1))
 #define RDPCLAMP(_val, _lo, _hi) \
-    (_val) < (_lo) ? (_lo) : (_val) > (_hi) ? (_hi) : (_val)
+    ((_val) < (_lo) ? (_lo) : (_val) > (_hi) ? (_hi) : (_val))
 #define RDPALIGN(_val, _al) ((((long)(_val)) + ((_al) - 1)) & ~((_al) - 1))
 
 #define XRDP_CD_NODRAW 0

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -122,8 +122,8 @@ struct image_data
     int bpp;
     int Bpp;
     int lineBytes;
-    char *pixels;
-    char *shmem_pixels;
+    uint8_t *pixels;
+    uint8_t *shmem_pixels;
     int shmem_id;
     int shmem_offset;
     int shmem_lineBytes;
@@ -208,15 +208,15 @@ struct _rdpCounts
     CARD32 callCount[64 - 23];
 };
 
-typedef int (*yuv_to_rgb32_proc)(const unsigned char *yuvs, int width, int height, int *rgbs);
+typedef int (*yuv_to_rgb32_proc)(const uint8_t *yuvs, int width, int height, int *rgbs);
 
-typedef int (*copy_box_proc)(const char *s8, int src_stride,
-                             char *d8, int dst_stride,
+typedef int (*copy_box_proc)(const uint8_t *s8, int src_stride,
+                             uint8_t *d8, int dst_stride,
                              int width, int height);
 /* copy_box_proc but 2 dest */
-typedef int (*copy_box_dst2_proc)(const char *s8, int src_stride,
-                                  char *d8_y, int dst_stride_y,
-                                  char *d8_uv, int dst_stride_uv,
+typedef int (*copy_box_dst2_proc)(const uint8_t *s8, int src_stride,
+                                  uint8_t *d8_y, int dst_stride_y,
+                                  uint8_t *d8_uv, int dst_stride_uv,
                                   int width, int height);
 
 /* move this to common header */
@@ -231,8 +231,8 @@ struct _rdpRec
     int bitsPerPixel;
     int Bpp;
     int Bpp_mask;
-    char *pfbMemory_alloc;
-    char *pfbMemory;
+    uint8_t *pfbMemory_alloc;
+    uint8_t *pfbMemory;
     ScreenPtr pScreen;
     rdpDevPrivateKey privateKeyRecGC;
     rdpDevPrivateKey privateKeyRecPixmap;
@@ -294,7 +294,7 @@ struct _rdpRec
     yuv_to_rgb32_proc yv12_to_rgb32;
     yuv_to_rgb32_proc yuy2_to_rgb32;
     yuv_to_rgb32_proc uyvy_to_rgb32;
-    char *xv_data;
+    uint8_t *xv_data;
     int xv_data_bytes;
     int xv_timer_scheduled;
     OsTimerPtr xv_timer;

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -89,7 +89,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define RDPMAX(_val1, _val2) ((_val1) < (_val2) ? (_val2) : (_val1))
 #define RDPCLAMP(_val, _lo, _hi) \
     ((_val) < (_lo) ? (_lo) : (_val) > (_hi) ? (_hi) : (_val))
-#define RDPALIGN(_val, _al) ((((long)(_val)) + ((_al) - 1)) & ~((_al) - 1))
+#define RDPALIGN(_val, _al) ((((uintptr_t)(_val)) + ((_al) - 1)) & ~((_al) - 1))
 
 #define XRDP_CD_NODRAW 0
 #define XRDP_CD_NOCLIP 1

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -55,12 +55,12 @@ capture
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_a8r8g8b8(rdpClientCon *clientCon,
-                                const char *src, int src_stride, int srcx, int srcy,
-                                char *dst, int dst_stride, int dstx, int dsty,
+                                const uint8_t *src, int src_stride, int srcx, int srcy,
+                                uint8_t *dst, int dst_stride, int dstx, int dsty,
                                 BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
+    const uint8_t *s8;
+    uint8_t *d8;
     int index;
     int jndex;
     int bytes;
@@ -90,7 +90,7 @@ rdpCopyBox_a8r8g8b8_to_a8r8g8b8(rdpClientCon *clientCon,
 /******************************************************************************/
 static int
 rdpFillBox_yuvalp(int ax, int ay,
-                  char *dst, int dst_stride)
+                  uint8_t *dst, int dst_stride)
 {
     dst = dst + (ay << 8) * (dst_stride >> 8) + (ax << 8);
     g_memset(dst, 0, 64 * 64 * 4);
@@ -112,16 +112,16 @@ rdpFillBox_yuvalp(int ax, int ay,
    32756 -27429  -5327 */
 static int
 rdpCopyBox_a8r8g8b8_to_yuvalp(int ax, int ay,
-                              const char *src, int src_stride,
-                              char *dst, int dst_stride,
+                              const uint8_t *src, int src_stride,
+                              uint8_t *dst, int dst_stride,
                               BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
-    char *yptr;
-    char *uptr;
-    char *vptr;
-    char *aptr;
+    const uint8_t *s8;
+    uint8_t *d8;
+    uint8_t *yptr;
+    uint8_t *uptr;
+    uint8_t *vptr;
+    uint8_t *aptr;
     int *s32;
     int index;
     int jndex;
@@ -186,8 +186,8 @@ rdpCopyBox_a8r8g8b8_to_yuvalp(int ax, int ay,
 
 /******************************************************************************/
 int
-a8r8g8b8_to_a8b8g8r8_box(const char *s8, int src_stride,
-                         char *d8, int dst_stride,
+a8r8g8b8_to_a8b8g8r8_box(const uint8_t *s8, int src_stride,
+                         uint8_t *d8, int dst_stride,
                          int width, int height)
 {
     int index;
@@ -219,12 +219,12 @@ a8r8g8b8_to_a8b8g8r8_box(const char *s8, int src_stride,
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_a8b8g8r8(rdpClientCon *clientCon,
-                                const char *src, int src_stride, int srcx, int srcy,
-                                char *dst, int dst_stride, int dstx, int dsty,
+                                const uint8_t *src, int src_stride, int srcx, int srcy,
+                                uint8_t *dst, int dst_stride, int dstx, int dsty,
                                 BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
+    const uint8_t *s8;
+    uint8_t *d8;
     int index;
     int width;
     int height;
@@ -248,8 +248,8 @@ rdpCopyBox_a8r8g8b8_to_a8b8g8r8(rdpClientCon *clientCon,
 
 /******************************************************************************/
 int
-a8r8g8b8_to_r5g6b5_box(const char *s8, int src_stride,
-                       char *d8, int dst_stride,
+a8r8g8b8_to_r5g6b5_box(const uint8_t *s8, int src_stride,
+                       uint8_t *d8, int dst_stride,
                        int width, int height)
 {
     int index;
@@ -281,12 +281,12 @@ a8r8g8b8_to_r5g6b5_box(const char *s8, int src_stride,
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_r5g6b5(rdpClientCon *clientCon,
-                              const char *src, int src_stride, int srcx, int srcy,
-                              char *dst, int dst_stride, int dstx, int dsty,
+                              const uint8_t *src, int src_stride, int srcx, int srcy,
+                              uint8_t *dst, int dst_stride, int dstx, int dsty,
                               BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
+    const uint8_t *s8;
+    uint8_t *d8;
     int index;
     int width;
     int height;
@@ -310,8 +310,8 @@ rdpCopyBox_a8r8g8b8_to_r5g6b5(rdpClientCon *clientCon,
 
 /******************************************************************************/
 int
-a8r8g8b8_to_a1r5g5b5_box(const char *s8, int src_stride,
-                         char *d8, int dst_stride,
+a8r8g8b8_to_a1r5g5b5_box(const uint8_t *s8, int src_stride,
+                         uint8_t *d8, int dst_stride,
                          int width, int height)
 {
     int index;
@@ -343,12 +343,12 @@ a8r8g8b8_to_a1r5g5b5_box(const char *s8, int src_stride,
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_a1r5g5b5(rdpClientCon *clientCon,
-                                const char *src, int src_stride, int srcx, int srcy,
-                                char *dst, int dst_stride, int dstx, int dsty,
+                                const uint8_t *src, int src_stride, int srcx, int srcy,
+                                uint8_t *dst, int dst_stride, int dstx, int dsty,
                                 BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
+    const uint8_t *s8;
+    uint8_t *d8;
     int index;
     int width;
     int height;
@@ -372,8 +372,8 @@ rdpCopyBox_a8r8g8b8_to_a1r5g5b5(rdpClientCon *clientCon,
 
 /******************************************************************************/
 int
-a8r8g8b8_to_r3g3b2_box(const char *s8, int src_stride,
-                       char *d8, int dst_stride,
+a8r8g8b8_to_r3g3b2_box(const uint8_t *s8, int src_stride,
+                       uint8_t *d8, int dst_stride,
                        int width, int height)
 {
     int index;
@@ -382,12 +382,12 @@ a8r8g8b8_to_r3g3b2_box(const char *s8, int src_stride,
     int green;
     int blue;
     unsigned int *s32;
-    unsigned char *ld8;
+    uint8_t *ld8;
 
     for (index = 0; index < height; index++)
     {
         s32 = (unsigned int *) s8;
-        ld8 = (unsigned char *) d8;
+        ld8 = (uint8_t *) d8;
         for (jndex = 0; jndex < width; jndex++)
         {
             SPLITCOLOR32(red, green, blue, *s32);
@@ -405,12 +405,12 @@ a8r8g8b8_to_r3g3b2_box(const char *s8, int src_stride,
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_r3g3b2(rdpClientCon *clientCon,
-                              const char *src, int src_stride, int srcx, int srcy,
-                              char *dst, int dst_stride, int dstx, int dsty,
+                              const uint8_t *src, int src_stride, int srcx, int srcy,
+                              uint8_t *dst, int dst_stride, int dstx, int dsty,
                               BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8;
+    const uint8_t *s8;
+    uint8_t *d8;
     int index;
     int width;
     int height;
@@ -434,9 +434,9 @@ rdpCopyBox_a8r8g8b8_to_r3g3b2(rdpClientCon *clientCon,
 
 /******************************************************************************/
 int
-a8r8g8b8_to_nv12_box(const char *s8, int src_stride,
-                     char *d8_y, int dst_stride_y,
-                     char *d8_uv, int dst_stride_uv,
+a8r8g8b8_to_nv12_box(const uint8_t *s8, int src_stride,
+                     uint8_t *d8_y, int dst_stride_y,
+                     uint8_t *d8_uv, int dst_stride_uv,
                      int width, int height)
 {
     int index;
@@ -452,9 +452,9 @@ a8r8g8b8_to_nv12_box(const char *s8, int src_stride,
     int pixel;
     const int *s32a;
     const int *s32b;
-    char *d8ya;
-    char *d8yb;
-    char *d8uv;
+    uint8_t *d8ya;
+    uint8_t *d8yb;
+    uint8_t *d8uv;
 
     for (jndex = 0; jndex < height; jndex += 2)
     {
@@ -533,15 +533,15 @@ a8r8g8b8_to_nv12_box(const char *s8, int src_stride,
 /* copy rects with no error checking */
 static int
 rdpCopyBox_a8r8g8b8_to_nv12(rdpClientCon *clientCon,
-                            const char *src, int src_stride, int srcx, int srcy,
-                            char *dst_y, int dst_stride_y,
-                            char *dst_uv, int dst_stride_uv,
+                            const uint8_t *src, int src_stride, int srcx, int srcy,
+                            uint8_t *dst_y, int dst_stride_y,
+                            uint8_t *dst_uv, int dst_stride_uv,
                             int dstx, int dsty,
                             BoxPtr rects, int num_rects)
 {
-    const char *s8;
-    char *d8_y;
-    char *d8_uv;
+    const uint8_t *s8;
+    uint8_t *d8_y;
+    uint8_t *d8_uv;
     int index;
     int width;
     int height;
@@ -576,8 +576,8 @@ rdpCapture0(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int num_rects;
     int i;
     Bool rv;
-    const char *src;
-    char *dst;
+    const uint8_t *src;
+    uint8_t *dst;
     int src_stride;
     int dst_stride;
     int dst_format;
@@ -661,8 +661,8 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     BoxPtr psrc_rects;
     BoxRec rect;
     BoxRec srect;
-    const char *src_rect;
-    char *dst_rect;
+    const uint8_t *src_rect;
+    uint8_t *dst_rect;
     int num_rects;
     int src_bytespp;
     int dst_bytespp;
@@ -681,8 +681,8 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     Bool rv;
     const unsigned int *s32;
     unsigned int *d32;
-    const char *src;
-    char *dst;
+    const uint8_t *src;
+    uint8_t *dst;
     int src_stride;
     int dst_stride;
     int dst_format;
@@ -809,8 +809,8 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     BoxRec extents_rect;
     BoxPtr rects;
     RegionRec tile_reg;
-    const char *src;
-    char *dst;
+    const uint8_t *src;
+    uint8_t *dst;
     int src_stride;
     int dst_stride;
 
@@ -893,10 +893,10 @@ rdpCapture3(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     BoxRec rect;
     int num_rects;
     int index;
-    char *dst_uv;
+    uint8_t *dst_uv;
     Bool rv;
-    const char *src;
-    char *dst;
+    const uint8_t *src;
+    uint8_t *dst;
     int src_stride;
     int dst_stride;
     int dst_format;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -122,14 +122,14 @@ rdpCopyBox_a8r8g8b8_to_yuvalp(int ax, int ay,
     uint8_t *uptr;
     uint8_t *vptr;
     uint8_t *aptr;
-    int *s32;
+    const uint32_t *s32;
     int index;
     int jndex;
     int kndex;
     int width;
     int height;
-    int pixel;
-    int a;
+    uint32_t pixel;
+    uint8_t a;
     int r;
     int g;
     int b;
@@ -150,7 +150,7 @@ rdpCopyBox_a8r8g8b8_to_yuvalp(int ax, int ay,
         height = box->y2 - box->y1;
         for (jndex = 0; jndex < height; jndex++)
         {
-            s32 = (int *) s8;
+            s32 = (const uint32_t *) s8;
             yptr = d8;
             uptr = yptr + 64 * 64;
             vptr = uptr + 64 * 64;
@@ -195,13 +195,13 @@ a8r8g8b8_to_a8b8g8r8_box(const uint8_t *s8, int src_stride,
     int red;
     int green;
     int blue;
-    unsigned int *s32;
-    unsigned int *d32;
+    const uint32_t *s32;
+    uint32_t *d32;
 
     for (index = 0; index < height; index++)
     {
-        s32 = (unsigned int *) s8;
-        d32 = (unsigned int *) d8;
+        s32 = (const uint32_t *) s8;
+        d32 = (uint32_t *) d8;
         for (jndex = 0; jndex < width; jndex++)
         {
             SPLITCOLOR32(red, green, blue, *s32);
@@ -257,13 +257,13 @@ a8r8g8b8_to_r5g6b5_box(const uint8_t *s8, int src_stride,
     int red;
     int green;
     int blue;
-    unsigned int *s32;
-    unsigned short *d16;
+    const uint32_t *s32;
+    uint16_t *d16;
 
     for (index = 0; index < height; index++)
     {
-        s32 = (unsigned int *) s8;
-        d16 = (unsigned short *) d8;
+        s32 = (const uint32_t *) s8;
+        d16 = (uint16_t *) d8;
         for (jndex = 0; jndex < width; jndex++)
         {
             SPLITCOLOR32(red, green, blue, *s32);
@@ -319,13 +319,13 @@ a8r8g8b8_to_a1r5g5b5_box(const uint8_t *s8, int src_stride,
     int red;
     int green;
     int blue;
-    const unsigned int *s32;
-    unsigned short *d16;
+    const uint32_t *s32;
+    uint16_t *d16;
 
     for (index = 0; index < height; index++)
     {
-        s32 = (const unsigned int *) s8;
-        d16 = (unsigned short *) d8;
+        s32 = (const uint32_t *) s8;
+        d16 = (uint16_t *) d8;
         for (jndex = 0; jndex < width; jndex++)
         {
             SPLITCOLOR32(red, green, blue, *s32);
@@ -381,12 +381,12 @@ a8r8g8b8_to_r3g3b2_box(const uint8_t *s8, int src_stride,
     int red;
     int green;
     int blue;
-    unsigned int *s32;
+    const uint32_t *s32;
     uint8_t *ld8;
 
     for (index = 0; index < height; index++)
     {
-        s32 = (unsigned int *) s8;
+        s32 = (const uint32_t *) s8;
         ld8 = (uint8_t *) d8;
         for (jndex = 0; jndex < width; jndex++)
         {
@@ -450,16 +450,16 @@ a8r8g8b8_to_nv12_box(const uint8_t *s8, int src_stride,
     int U_sum;
     int V_sum;
     int pixel;
-    const int *s32a;
-    const int *s32b;
+    const uint32_t *s32a;
+    const uint32_t *s32b;
     uint8_t *d8ya;
     uint8_t *d8yb;
     uint8_t *d8uv;
 
     for (jndex = 0; jndex < height; jndex += 2)
     {
-        s32a = (const int *) (s8 + src_stride * jndex);
-        s32b = (const int *) (s8 + src_stride * (jndex + 1));
+        s32a = (const uint32_t *) (s8 + src_stride * jndex);
+        s32b = (const uint32_t *) (s8 + src_stride * (jndex + 1));
         d8ya = d8_y + dst_stride_y * jndex;
         d8yb = d8_y + dst_stride_y * (jndex + 1);
         d8uv = d8_uv + dst_stride_uv * (jndex / 2);
@@ -679,8 +679,8 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int ex;
     int ey;
     Bool rv;
-    const unsigned int *s32;
-    unsigned int *d32;
+    const uint32_t *s32;
+    uint32_t *d32;
     const uint8_t *src;
     uint8_t *dst;
     int src_stride;
@@ -774,8 +774,8 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             /* copy one line at a time */
             for (jndex = 0; jndex < height; jndex++)
             {
-                s32 = (const unsigned int *) src_rect;
-                d32 = (unsigned int *) dst_rect;
+                s32 = (const uint32_t *) src_rect;
+                d32 = (uint32_t *) dst_rect;
                 for (kndex = 0; kndex < width; kndex++)
                 {
                     SPLITCOLOR32(red, green, blue, *s32);

--- a/module/rdpCapture.h
+++ b/module/rdpCapture.h
@@ -38,13 +38,13 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
            int *num_out_rects, struct image_data *id);
 
 extern _X_EXPORT int
-a8r8g8b8_to_a8b8g8r8_box(const char *s8, int src_stride,
-                         char *d8, int dst_stride,
+a8r8g8b8_to_a8b8g8r8_box(const uint8_t *s8, int src_stride,
+                         uint8_t *d8, int dst_stride,
                          int width, int height);
 extern _X_EXPORT int
-a8r8g8b8_to_nv12_box(const char *s8, int src_stride,
-                     char *d8_y, int dst_stride_y,
-                     char *d8_uv, int dst_stride_uv,
+a8r8g8b8_to_nv12_box(const uint8_t *s8, int src_stride,
+                     uint8_t *d8_y, int dst_stride_y,
+                     uint8_t *d8_uv, int dst_stride_uv,
                      int width, int height);
 
 #endif

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1669,7 +1669,7 @@ rdpClientConDrawLine(rdpPtr dev, rdpClientCon *clientCon,
 /******************************************************************************/
 int
 rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
-                      short x, short y, char *cur_data, char *cur_mask)
+                      short x, short y, uint8_t *cur_data, uint8_t *cur_mask)
 {
     int size;
 
@@ -1697,8 +1697,8 @@ rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
 /******************************************************************************/
 int
 rdpClientConSetCursorEx(rdpPtr dev, rdpClientCon *clientCon,
-                        short x, short y, char *cur_data,
-                        char *cur_mask, int bpp)
+                        short x, short y, uint8_t *cur_data,
+                        uint8_t *cur_mask, int bpp)
 {
     int size;
     int Bpp;
@@ -2417,7 +2417,7 @@ rdpClientConGetPixmapImageRect(rdpPtr dev, rdpClientCon *clientCon,
     id->bpp = clientCon->rdp_bpp;
     id->Bpp = clientCon->rdp_Bpp;
     id->lineBytes = pPixmap->devKind;
-    id->pixels = (char *)(pPixmap->devPrivate.ptr);
+    id->pixels = (uint8_t *)(pPixmap->devPrivate.ptr);
     id->shmem_pixels = 0;
     id->shmem_id = 0;
     id->shmem_offset = 0;
@@ -2433,8 +2433,8 @@ rdpClientConSendArea(rdpPtr dev, rdpClientCon *clientCon,
     BoxRec box;
     int ly;
     int size;
-    const char *src;
-    char *dst;
+    const uint8_t *src;
+    uint8_t *dst;
     struct stream *s;
 
     LLOGLN(10, ("rdpClientConSendArea: id %p x %d y %d w %d h %d", id, x, y, w, h));

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -340,7 +340,7 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
 /*****************************************************************************/
 /* returns error */
 static int
-rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, char *data, int len)
+rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
 {
     int sent;
 
@@ -1470,13 +1470,13 @@ rdpClientConConvertPixel(rdpPtr dev, rdpClientCon *clientCon, int in_pixel)
 /******************************************************************************/
 int
 rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
-                          void *src, void *dst, int num_pixels)
+                          const void *src, void *dst, int num_pixels)
 {
     unsigned int pixel;
     unsigned int red;
     unsigned int green;
     unsigned int blue;
-    unsigned int *src32;
+    const unsigned int *src32;
     unsigned int *dst32;
     unsigned short *dst16;
     unsigned char *dst8;
@@ -1490,7 +1490,7 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
 
     if (dev->depth == 24)
     {
-        src32 = (unsigned int *)src;
+        src32 = (const unsigned int *) src;
 
         if (clientCon->rdp_bpp == 24)
         {
@@ -1553,14 +1553,14 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
 
 /******************************************************************************/
 int
-rdpClientConAlphaPixels(void* src, void* dst, int num_pixels)
+rdpClientConAlphaPixels(const void *src, void *dst, int num_pixels)
 {
-    unsigned int* src32;
-    unsigned char* dst8;
+    const unsigned int *src32;
+    unsigned char *dst8;
     int index;
 
-    src32 = (unsigned int*)src;
-    dst8 = (unsigned char*)dst;
+    src32 = (const unsigned int *) src;
+    dst8 = (unsigned char *) dst;
     for (index = 0; index < num_pixels; index++)
     {
         *dst8 = (*src32) >> 24;
@@ -2433,7 +2433,7 @@ rdpClientConSendArea(rdpPtr dev, rdpClientCon *clientCon,
     BoxRec box;
     int ly;
     int size;
-    char *src;
+    const char *src;
     char *dst;
     struct stream *s;
 

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1472,14 +1472,14 @@ int
 rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
                           const void *src, void *dst, int num_pixels)
 {
-    unsigned int pixel;
-    unsigned int red;
-    unsigned int green;
-    unsigned int blue;
-    const unsigned int *src32;
-    unsigned int *dst32;
-    unsigned short *dst16;
-    unsigned char *dst8;
+    uint32_t pixel;
+    uint32_t red;
+    uint32_t green;
+    uint32_t blue;
+    const uint32_t *src32;
+    uint32_t *dst32;
+    uint16_t *dst16;
+    uint8_t *dst8;
     int index;
 
     if (dev->depth == clientCon->rdp_bpp)
@@ -1490,11 +1490,11 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
 
     if (dev->depth == 24)
     {
-        src32 = (const unsigned int *) src;
+        src32 = (const uint32_t *) src;
 
         if (clientCon->rdp_bpp == 24)
         {
-            dst32 = (unsigned int *)dst;
+            dst32 = (uint32_t *) dst;
 
             for (index = 0; index < num_pixels; index++)
             {
@@ -1506,7 +1506,7 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
         }
         else if (clientCon->rdp_bpp == 16)
         {
-            dst16 = (unsigned short *)dst;
+            dst16 = (uint16_t *) dst;
 
             for (index = 0; index < num_pixels; index++)
             {
@@ -1520,7 +1520,7 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
         }
         else if (clientCon->rdp_bpp == 15)
         {
-            dst16 = (unsigned short *)dst;
+            dst16 = (uint16_t *) dst;
 
             for (index = 0; index < num_pixels; index++)
             {
@@ -1534,7 +1534,7 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
         }
         else if (clientCon->rdp_bpp == 8)
         {
-            dst8 = (unsigned char *)dst;
+            dst8 = (uint8_t *) dst;
 
             for (index = 0; index < num_pixels; index++)
             {
@@ -1555,12 +1555,12 @@ rdpClientConConvertPixels(rdpPtr dev, rdpClientCon *clientCon,
 int
 rdpClientConAlphaPixels(const void *src, void *dst, int num_pixels)
 {
-    const unsigned int *src32;
-    unsigned char *dst8;
+    const uint32_t *src32;
+    uint8_t *dst8;
     int index;
 
-    src32 = (const unsigned int *) src;
-    dst8 = (unsigned char *) dst;
+    src32 = (const uint32_t *) src;
+    dst8 = (uint8_t *) dst;
     for (index = 0; index < num_pixels; index++)
     {
         *dst8 = (*src32) >> 24;

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -98,7 +98,7 @@ struct _rdpClientCon
 
     struct xrdp_client_info client_info;
 
-    char *shmemptr;
+    uint8_t *shmemptr;
     int shmemid;
     int shmem_lineBytes;
     RegionPtr shmRegion;
@@ -160,10 +160,10 @@ extern _X_EXPORT int
 rdpClientConAddAllBox(rdpPtr dev, BoxPtr box, DrawablePtr pDrawable);
 extern _X_EXPORT int
 rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
-                      short x, short y, char *cur_data, char *cur_mask);
+                      short x, short y, uint8_t *cur_data, uint8_t *cur_mask);
 extern _X_EXPORT int
 rdpClientConSetCursorEx(rdpPtr dev, rdpClientCon *clientCon,
-                        short x, short y, char *cur_data,
-                        char *cur_mask, int bpp);
+                        short x, short y, uint8_t *cur_data,
+                        uint8_t *cur_mask, int bpp);
 
 #endif

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -57,7 +57,7 @@ cursor
 
 #if (X_BYTE_ORDER == X_LITTLE_ENDIAN)
 /* Copied from Xvnc/lib/font/util/utilbitmap.c */
-static unsigned char g_reverse_byte[0x100] =
+static uint8_t g_reverse_byte[0x100] =
 {
     0x00, 0x80, 0x40, 0xc0, 0x20, 0xa0, 0x60, 0xe0,
     0x10, 0x90, 0x50, 0xd0, 0x30, 0xb0, 0x70, 0xf0,
@@ -122,7 +122,7 @@ get_pixel_safe(const uint8_t *data, int x, int y, int width, int height, int bpp
     int start;
     int shift;
     int c;
-    const unsigned int *src32;
+    const uint32_t *src32;
 
     if (x < 0)
     {
@@ -149,7 +149,7 @@ get_pixel_safe(const uint8_t *data, int x, int y, int width, int height, int bpp
         width = (width + 7) / 8;
         start = (y * width) + x / 8;
         shift = x % 8;
-        c = (unsigned char)(data[start]);
+        c = (uint8_t) (data[start]);
 #if (X_BYTE_ORDER == X_LITTLE_ENDIAN)
         return (g_reverse_byte[c] & (0x80 >> shift)) != 0;
 #else
@@ -158,7 +158,7 @@ get_pixel_safe(const uint8_t *data, int x, int y, int width, int height, int bpp
     }
     else if (bpp == 32)
     {
-        src32 = (const unsigned int *) data;
+        src32 = (const uint32_t *) data;
         return src32[y * width + x];
     }
 
@@ -172,7 +172,7 @@ set_pixel_safe(uint8_t *data, int x, int y, int width, int height, int bpp,
 {
     int start;
     int shift;
-    unsigned int *dst32;
+    uint32_t *dst32;
 
     if (x < 0)
     {
@@ -217,7 +217,7 @@ set_pixel_safe(uint8_t *data, int x, int y, int width, int height, int bpp,
     }
     else if (bpp == 32)
     {
-        dst32 = (unsigned int*)data;
+        dst32 = (uint32_t *) data;
         dst32[y * width + x] = pixel;
     }
 }

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -117,7 +117,7 @@ rdpSpriteUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 
 /******************************************************************************/
 static int
-get_pixel_safe(const char *data, int x, int y, int width, int height, int bpp)
+get_pixel_safe(const uint8_t *data, int x, int y, int width, int height, int bpp)
 {
     int start;
     int shift;
@@ -167,7 +167,7 @@ get_pixel_safe(const char *data, int x, int y, int width, int height, int bpp)
 
 /******************************************************************************/
 static void
-set_pixel_safe(char *data, int x, int y, int width, int height, int bpp,
+set_pixel_safe(uint8_t *data, int x, int y, int width, int height, int bpp,
                int pixel)
 {
     int start;
@@ -228,10 +228,10 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
                       DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
                       int x, int y)
 {
-    char cur_data[32 * (32 * 4)];
-    char cur_mask[32 * (32 / 8)];
-    char *mask;
-    char *data;
+    uint8_t cur_data[32 * (32 * 4)];
+    uint8_t cur_mask[32 * (32 / 8)];
+    uint8_t *mask;
+    uint8_t *data;
     int i;
     int j;
     int w;
@@ -255,7 +255,7 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         paddedRowBytes = PixmapBytePad(w, 32);
         xhot = pCurs->bits->xhot;
         yhot = pCurs->bits->yhot;
-        data = (char *)(pCurs->bits->argb);
+        data = (uint8_t *)(pCurs->bits->argb);
         memset(cur_data, 0, sizeof(cur_data));
         memset(cur_mask, 0, sizeof(cur_mask));
 
@@ -274,8 +274,8 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         paddedRowBytes = PixmapBytePad(w, 1);
         xhot = pCurs->bits->xhot;
         yhot = pCurs->bits->yhot;
-        data = (char *)(pCurs->bits->source);
-        mask = (char *)(pCurs->bits->mask);
+        data = (uint8_t *)(pCurs->bits->source);
+        mask = (uint8_t *)(pCurs->bits->mask);
         fgcolor = (((pCurs->foreRed >> 8) & 0xff) << 16) |
                   (((pCurs->foreGreen >> 8) & 0xff) << 8) |
                   ((pCurs->foreBlue >> 8) & 0xff);

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -117,12 +117,12 @@ rdpSpriteUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 
 /******************************************************************************/
 static int
-get_pixel_safe(char *data, int x, int y, int width, int height, int bpp)
+get_pixel_safe(const char *data, int x, int y, int width, int height, int bpp)
 {
     int start;
     int shift;
     int c;
-    unsigned int *src32;
+    const unsigned int *src32;
 
     if (x < 0)
     {
@@ -158,7 +158,7 @@ get_pixel_safe(char *data, int x, int y, int width, int height, int bpp)
     }
     else if (bpp == 32)
     {
-        src32 = (unsigned int*)data;
+        src32 = (const unsigned int *) data;
         return src32[y * width + x];
     }
 

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -136,7 +136,7 @@ g_sleep(int msecs)
 
 /*****************************************************************************/
 int
-g_sck_send(int sck, void *ptr, int len, int flags)
+g_sck_send(int sck, const void *ptr, int len, int flags)
 {
     return send(sck, ptr, len, flags);
 }
@@ -397,15 +397,15 @@ g_socket_dir(void)
 /*****************************************************************************/
 /* produce a hex dump */
 void
-g_hexdump(void *p, long len)
+g_hexdump(const void *p, long len)
 {
-    unsigned char *line;
+    const unsigned char *line;
     int i;
     int thisline;
     int offset;
 
     offset = 0;
-    line = (unsigned char *) p;
+    line = (const unsigned char *) p;
 
     while (offset < (int) len)
     {

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -52,7 +52,7 @@ g_sck_last_error_would_block(int sck);
 extern _X_EXPORT void
 g_sleep(int msecs);
 extern _X_EXPORT int
-g_sck_send(int sck, void *ptr, int len, int flags);
+g_sck_send(int sck, const void *ptr, int len, int flags);
 extern _X_EXPORT void
 g_sprintf(char *dest, const char *format, ...);
 extern _X_EXPORT int
@@ -88,7 +88,7 @@ g_chmod_hex(const char *filename, int flags);
 extern _X_EXPORT const char *
 g_socket_dir(void);
 extern _X_EXPORT void
-g_hexdump(void *p, long len);
+g_hexdump(const void *p, long len);
 
 
 /* glib-style memory allocation macros */

--- a/module/rdpPri.c
+++ b/module/rdpPri.c
@@ -56,8 +56,8 @@ to deal with privates changing in xorg versions
 #define XRDP_PRI 3
 #endif
 
-#define PTR2INT(_ptr) ((int)    ((long) ((void*) (_ptr))))
-#define INT2PTR(_int) ((void *) ((long) ((int)   (_int))))
+#define PTR2INT(_ptr) ((int)    ((uintptr_t) ((void*) (_ptr))))
+#define INT2PTR(_int) ((void *) ((uintptr_t) ((int)   (_int))))
 
 #if XRDP_PRI == 3
 static DevPrivateKeyRec g_privateKeyRecGC;

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -121,8 +121,8 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     pScreen->mmHeight = mmHeight;
     screenPixmap = pScreen->GetScreenPixmap(pScreen);
     free(dev->pfbMemory_alloc);
-    dev->pfbMemory_alloc = g_new0(char, dev->sizeInBytes + 16);
-    dev->pfbMemory = (char *) RDPALIGN(dev->pfbMemory_alloc, 16);
+    dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
+    dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
     if (screenPixmap != 0)
     {
         pScreen->ModifyPixmapHeader(screenPixmap, width, height,

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -165,7 +165,7 @@ xrdpVidQueryBestSize(ScrnInfoPtr pScrn, Bool motion,
 
 /*****************************************************************************/
 int
-YV12_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
+YV12_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 {
     int size_total;
     int y;
@@ -206,7 +206,7 @@ YV12_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-I420_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
+I420_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 {
     int size_total;
     int y;
@@ -247,7 +247,7 @@ I420_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-YUY2_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
+YUY2_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 {
     int y1;
     int y2;
@@ -301,7 +301,7 @@ YUY2_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-UYVY_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs)
+UYVY_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 {
     int y1;
     int y2;

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -165,7 +165,7 @@ xrdpVidQueryBestSize(ScrnInfoPtr pScrn, Bool motion,
 
 /*****************************************************************************/
 int
-YV12_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
+YV12_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs)
 {
     int size_total;
     int y;
@@ -206,7 +206,7 @@ YV12_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-I420_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
+I420_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs)
 {
     int size_total;
     int y;
@@ -247,7 +247,7 @@ I420_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-YUY2_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
+YUY2_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs)
 {
     int y1;
     int y2;
@@ -301,7 +301,7 @@ YUY2_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
 
 /*****************************************************************************/
 int
-UYVY_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs)
+UYVY_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs)
 {
     int y1;
     int y2;
@@ -499,7 +499,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     if (index > dev->xv_data_bytes)
     {
         free(dev->xv_data);
-        dev->xv_data = g_new(char, index);
+        dev->xv_data = g_new(uint8_t, index);
         if (dev->xv_data == NULL)
         {
             LLOGLN(0, ("xrdpVidPutImage: memory alloc error"));

--- a/module/rdpXv.h
+++ b/module/rdpXv.h
@@ -31,12 +31,12 @@ XVideo
 extern _X_EXPORT Bool
 rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn);
 extern _X_EXPORT int
-YV12_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
+YV12_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-I420_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
+I420_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-YUY2_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
+YUY2_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-UYVY_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
+UYVY_to_RGB32(const uint8_t *yuvs, int width, int height, int *rgbs);
 
 #endif

--- a/module/rdpXv.h
+++ b/module/rdpXv.h
@@ -31,12 +31,12 @@ XVideo
 extern _X_EXPORT Bool
 rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn);
 extern _X_EXPORT int
-YV12_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs);
+YV12_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-I420_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs);
+I420_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-YUY2_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs);
+YUY2_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
 extern _X_EXPORT int
-UYVY_to_RGB32(unsigned char *yuvs, int width, int height, int *rgbs);
+UYVY_to_RGB32(const unsigned char *yuvs, int width, int height, int *rgbs);
 
 #endif

--- a/module/x86/funcs_x86.h
+++ b/module/x86/funcs_x86.h
@@ -27,13 +27,13 @@ x86 asm functions
 int
 cpuid_x86(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 int
-yv12_to_rgb32_x86_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+yv12_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-i420_to_rgb32_x86_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+i420_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-yuy2_to_rgb32_x86_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+yuy2_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
-uyvy_to_rgb32_x86_sse2(unsigned char *yuvs, int width, int height, int *rgbs);
+uyvy_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
 int
 a8r8g8b8_to_a8b8g8r8_box_x86_sse2(const char *s8, int src_stride,
                                   char *d8, int dst_stride,

--- a/module/x86/funcs_x86.h
+++ b/module/x86/funcs_x86.h
@@ -27,21 +27,21 @@ x86 asm functions
 int
 cpuid_x86(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 int
-yv12_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+yv12_to_rgb32_x86_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-i420_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+i420_to_rgb32_x86_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-yuy2_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+yuy2_to_rgb32_x86_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-uyvy_to_rgb32_x86_sse2(const unsigned char *yuvs, int width, int height, int *rgbs);
+uyvy_to_rgb32_x86_sse2(const uint8_t *yuvs, int width, int height, int *rgbs);
 int
-a8r8g8b8_to_a8b8g8r8_box_x86_sse2(const char *s8, int src_stride,
-                                  char *d8, int dst_stride,
+a8r8g8b8_to_a8b8g8r8_box_x86_sse2(const uint8_t *s8, int src_stride,
+                                  uint8_t *d8, int dst_stride,
                                   int width, int height);
 int
-a8r8g8b8_to_nv12_box_x86_sse2(const char *s8, int src_stride,
-                              char *d8_y, int dst_stride_y,
-                              char *d8_uv, int dst_stride_uv,
+a8r8g8b8_to_nv12_box_x86_sse2(const uint8_t *s8, int src_stride,
+                              uint8_t *d8_y, int dst_stride_y,
+                              uint8_t *d8_uv, int dst_stride_uv,
                               int width, int height);
 
 #endif

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -448,8 +448,8 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
     LLOGLN(0, ("rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes));
-    dev->pfbMemory_alloc = g_new0(char, dev->sizeInBytes + 16);
-    dev->pfbMemory = (char *) RDPALIGN(dev->pfbMemory_alloc, 16);
+    dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
+    dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
     LLOGLN(0, ("rdpScreenInit: pfbMemory %p", dev->pfbMemory));
     if (!fbScreenInit(pScreen, dev->pfbMemory,
                       pScrn->virtualX, pScrn->virtualY,


### PR DESCRIPTION
clang 3.9.1 produces a warning about casting 255 to char. Fixing that warning lead me to making extensive changes throughout the code.

Xorg uses stdint.h, so it should be OK for xorgxrdp. Take advantage of the types that use the exact bit size. It documents the intent of the code much better.

Add `const` to many more pointers.

Fix an issue in RDPCLAMP macro that made it impossible to cast to another type.