### PR TITLE
keep and use crc calculations for rfx tiles to save bandwidth when an app redraws aggressively

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -51,6 +51,58 @@ capture
 
 #define RDP_MAX_TILES 4096
 
+static const unsigned int g_crc_table[256] =
+{
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
+    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
+    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+    0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+};
+
+#define CRC_START(in_crc) (in_crc) = 0xFFFFFFFF
+#define CRC_PASS(in_pixel, in_crc) \
+    (in_crc) = g_crc_table[((in_crc) ^ (in_pixel)) & 0xff] ^ ((in_crc) >> 8)
+#define CRC_END(in_crc) (in_crc) = ((in_crc) ^ 0xFFFFFFFF)
+
 /******************************************************************************/
 /* copy rects with no error checking */
 static int
@@ -796,6 +848,21 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 }
 
 /******************************************************************************/
+static int
+rdpCaptureCrcMem(const char *in_mem, int in_num_bytes, int in_crc)
+{
+    int index;
+
+    index = 0;
+    while (index < in_num_bytes)
+    {
+        CRC_PASS(in_mem[index], in_crc);
+        index++;
+    }
+    return in_crc;
+}
+
+/******************************************************************************/
 static Bool
 rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             int *num_out_rects, struct image_data *id)
@@ -811,8 +878,12 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     RegionRec tile_reg;
     const uint8_t *src;
     uint8_t *dst;
+    uint8_t *crc_dst;
     int src_stride;
     int dst_stride;
+    int crc_offset;
+    int crc_stride;
+    int crc;
 
     LLOGLN(10, ("rdpCapture2:"));
 
@@ -827,6 +898,8 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     dst = id->shmem_pixels;
     src_stride = id->lineBytes;
     dst_stride = clientCon->cap_stride_bytes;
+
+    crc_stride = (clientCon->dev->width + 63) / 64;
 
     extents_rect = *rdpRegionExtents(in_reg);
     y = extents_rect.y1 & ~63;
@@ -844,6 +917,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
             if (rcode != rgnOUT)
             {
+                CRC_START(crc);
                 if (rcode == rgnPART)
                 {
                     LLOGLN(10, ("rdpCapture2: rgnPART"));
@@ -852,6 +926,9 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     rdpRegionIntersect(&tile_reg, in_reg, &tile_reg);
                     rects = REGION_RECTS(&tile_reg);
                     num_rects = REGION_NUM_RECTS(&tile_reg);
+                    crc = rdpCaptureCrcMem((char *) rects,
+                                           num_rects * sizeof(BoxRec),
+                                           crc);
                     rdpCopyBox_a8r8g8b8_to_yuvalp(x, y,
                                                   src, src_stride,
                                                   dst, dst_stride,
@@ -866,13 +943,27 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                                                   dst, dst_stride,
                                                   &rect, 1);
                 }
-                (*out_rects)[out_rect_index] = rect;
-                out_rect_index++;
-                if (out_rect_index >= RDP_MAX_TILES)
+                crc_dst = dst + (y << 8) * (dst_stride >> 8) + (x << 8);
+                crc = rdpCaptureCrcMem(crc_dst, 64 * 64 * 4, crc);
+                CRC_END(crc);
+                crc_offset = (y / 64) * crc_stride + (x / 64);
+                LLOGLN(10, ("rdpCapture2: crc 0x%8.8x 0x%8.8x",
+                       crc, clientCon->rfx_crcs[crc_offset]));
+                if (crc == clientCon->rfx_crcs[crc_offset])
                 {
-                    free(*out_rects);
-                    *out_rects = NULL;
-                    return FALSE;
+                    LLOGLN(10, ("rdpCapture2: crc skip at x %d y %d", x, y));
+                }
+                else
+                {
+                    clientCon->rfx_crcs[crc_offset] = crc;
+                    (*out_rects)[out_rect_index] = rect;
+                    out_rect_index++;
+                    if (out_rect_index >= RDP_MAX_TILES)
+                    {
+                        free(*out_rects);
+                        *out_rects = NULL;
+                        return FALSE;
+                    }
                 }
             }
             x += 64;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -884,6 +884,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int crc_offset;
     int crc_stride;
     int crc;
+    int num_crcs;
 
     LLOGLN(10, ("rdpCapture2:"));
 
@@ -900,6 +901,14 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     dst_stride = clientCon->cap_stride_bytes;
 
     crc_stride = (clientCon->dev->width + 63) / 64;
+    num_crcs = crc_stride * ((clientCon->dev->height + 63) / 64);
+    if (num_crcs != clientCon->num_rfx_crcs_alloc)
+    {
+        /* resize the crc list */
+        clientCon->num_rfx_crcs_alloc = num_crcs;
+        free(clientCon->rfx_crcs);
+        clientCon->rfx_crcs = g_new0(int, num_crcs);
+    }
 
     extents_rect = *rdpRegionExtents(in_reg);
     y = extents_rect.y1 & ~63;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -849,7 +849,7 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
 /******************************************************************************/
 static int
-rdpCaptureCrcMem(const char *in_mem, int in_num_bytes, int in_crc)
+rdpCaptureCrcMem(const uint8_t *in_mem, int in_num_bytes, int in_crc)
 {
     int index;
 
@@ -935,7 +935,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     rdpRegionIntersect(&tile_reg, in_reg, &tile_reg);
                     rects = REGION_RECTS(&tile_reg);
                     num_rects = REGION_NUM_RECTS(&tile_reg);
-                    crc = rdpCaptureCrcMem((char *) rects,
+                    crc = rdpCaptureCrcMem((uint8_t *) rects,
                                            num_rects * sizeof(BoxRec),
                                            crc);
                     rdpCopyBox_a8r8g8b8_to_yuvalp(x, y,

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -607,7 +607,6 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
     int mmwidth;
     int mmheight;
     int bytes;
-    int num_crcs;
     Bool ok;
 
     LLOGLN(0, ("rdpClientConProcessScreenSizeMsg: set width %d height %d "
@@ -617,10 +616,6 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
     clientCon->rdp_bpp = bpp;
     clientCon->cap_width = width;
     clientCon->cap_height = height;
-
-    num_crcs = ((dev->width + 63) / 64) * ((dev->height + 63) / 64);
-    free(clientCon->rfx_crcs);
-    clientCon->rfx_crcs = g_new0(int, num_crcs);
 
     if (bpp < 15)
     {

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -2110,7 +2110,7 @@ rdpClientConSendPaintRectShmEx(rdpPtr dev, rdpClientCon *clientCon,
     num_rects_c = numCopyRects;
     if ((num_rects_c < 1) || (num_rects_d < 1))
     {
-        LLOGLN(0, ("rdpClientConSendPaintRectShmEx: nothing to send"));
+        LLOGLN(10, ("rdpClientConSendPaintRectShmEx: nothing to send"));
         return 0;
     }
     size = 2 + 2 + 2 + num_rects_d * 8 + 2 + num_rects_c * 8;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -607,6 +607,7 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
     int mmwidth;
     int mmheight;
     int bytes;
+    int num_crcs;
     Bool ok;
 
     LLOGLN(0, ("rdpClientConProcessScreenSizeMsg: set width %d height %d "
@@ -616,6 +617,10 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
     clientCon->rdp_bpp = bpp;
     clientCon->cap_width = width;
     clientCon->cap_height = height;
+
+    num_crcs = ((dev->width + 63) / 64) * ((dev->height + 63) / 64);
+    free(clientCon->rfx_crcs);
+    clientCon->rfx_crcs = g_new0(int, num_crcs);
 
     if (bpp < 15)
     {

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -110,6 +110,8 @@ struct _rdpClientCon
 
     RegionPtr dirtyRegion;
 
+    int *rfx_crcs;
+
     struct _rdpClientCon *next;
 };
 

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -110,6 +110,7 @@ struct _rdpClientCon
 
     RegionPtr dirtyRegion;
 
+    int num_rfx_crcs_alloc;
     int *rfx_crcs;
 
     struct _rdpClientCon *next;


### PR DESCRIPTION
Resolve conflicts after #90.