### PR TITLE
Give group write perms to socket.

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1242,6 +1242,7 @@ rdpClientConInit(rdpPtr dev)
             return 1;
         }
         g_sck_listen(dev->listen_sck);
+        g_chmod_hex(dev->uds_data, 0x0660);
         rdpClientConAddEnabledDevice(dev->pScreen, dev->listen_sck);
     }
 


### PR DESCRIPTION
I've been looking at the issues with running xrdp as a non-root user, and comparing #16, https://github.com/neutrinolabs/xrdp/pull/464 and the debian packaging patches (https://anonscm.debian.org/cgit/pkg-remote/xrdp.git/tree/debian/patches/fix_perms.diff).

I'm contemplating running xrdp as a non-root user on other distros (e.g. redhat) who don't take the step of patching the package, and was hoping this might be fixable upstream?

I appreciate that the project is reluctant to change the permissions/bits on the whole socketdir directory, but was wondering if just this simple change to the socket itself would be acceptable?

Since the code that creates the socketdir does nothing if the socket already exists, it's easy to make the directory with appropriate permissions before starting the daemon. However there's no way to modify the socket perms without patching, or something a bit more hacky (inotify script, ld_preload library) etc.

I'm fairly sure this change is 'safe' as it should have no effect unless the directory changes have also been made.

Thanks for considering this request!
