### PR TITLE
Prevent GNOME 3 gnome-settings-daemon crash on RHEL/CentOS 7.4

### DIFF
--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -178,19 +178,6 @@ rdpRRCrtcGetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
     LLOGLN(0, ("rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
            crtc->gammaBlue, crtc->gammaGreen));
-    crtc->gammaSize = 1;
-    if (crtc->gammaRed == NULL)
-    {
-        crtc->gammaRed = g_new0(CARD16, 16);
-    }
-    if (crtc->gammaBlue == NULL)
-    {
-        crtc->gammaBlue = g_new0(CARD16, 16);
-    }
-    if (crtc->gammaGreen == NULL)
-    {
-        crtc->gammaGreen = g_new0(CARD16, 16);
-    }
     return TRUE;
 }
 
@@ -332,6 +319,7 @@ rdpRRAddOutput(rdpPtr dev, const char *aname, int x, int y, int width, int heigh
     xRRModeInfo modeInfo;
     char name[64];
     const int vfreq = 50;
+    int i;
 
     sprintf (name, "%dx%d", width, height);
     memset (&modeInfo, 0, sizeof(modeInfo));
@@ -355,6 +343,16 @@ rdpRRAddOutput(rdpPtr dev, const char *aname, int x, int y, int width, int heigh
         RRModeDestroy(mode);
         return 0;
     }
+    /* Create and initialise (unused) gamma ramps */
+    RRCrtcGammaSetSize (crtc, 256);
+    for (i = 0 ; i < crtc->gammaSize; ++i)
+    {
+        unsigned short val = (0xffff * i) / (crtc->gammaSize - 1);
+        crtc->gammaRed[i] = val;
+        crtc->gammaGreen[i] = val;
+        crtc->gammaBlue[i] = val;
+    }
+
     output = RROutputCreate(dev->pScreen, aname, strlen(aname), NULL);
     if (output == 0)
     {


### PR DESCRIPTION
When using xorgxrdp, a call to XRRGetCtrcGamma() returned a result with a single entry.

This is confusing to some software. For example, gnome-settings-daemon on RHEL/CentOS 7.4 can coredump which takes out the whole session. See:-

https://bugs.centos.org/view.php?id=14054

The coredump is caused by a division of (size-1) where 'size' is the number of entries in the gamma ramp.

This change replaces the single entry gamma ramp with a 256 entry gamma ramp, which seems to be more standard. This is what is implemented in tigervnc-server (see https://github.com/TigerVNC/tigervnc/blob/master/unix/xserver/hw/vnc/xvnc.c ) and also by nouveau on a GTX 470.