### PR TITLE
Don't define package/module version in multiple files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,14 @@
 # Process this file with autoconf to produce a configure script
 
 AC_PREREQ(2.65)
-# don't forget to also change version in module/rdp.h
+# package version must be x.y.z
 AC_INIT([xorgxrdp], [0.2.5], [xrdp-devel@googlegroups.com])
+package_version_major=$(echo ${PACKAGE_VERSION}|cut -d. -f1)
+package_version_minor=$(echo ${PACKAGE_VERSION}|cut -d. -f2)
+package_version_patchlevel=$(echo ${PACKAGE_VERSION}|cut -d. -f3)
+AC_SUBST([package_version_major], [${package_version_major}])
+AC_SUBST([package_version_minor], [${package_version_minor}])
+AC_SUBST([package_version_patchlevel], [${package_version_patchlevel}])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -18,6 +18,9 @@ endif
 AM_CFLAGS = \
   $(XORG_SERVER_CFLAGS) \
   $(XRDP_CFLAGS) \
+  -DPACKAGE_VERSION_MAJOR=@package_version_major@ \
+  -DPACKAGE_VERSION_MINOR=@package_version_minor@ \
+  -DPACKAGE_VERSION_PATCHLEVEL=@package_version_patchlevel@ \
   -I$(top_srcdir)/module \
   $(EXTRA_FLAGS)
 

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -41,10 +41,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XRDP_KEYB_NAME "XRDPKEYB"
 #define XRDP_VERSION 1000
 
-#define PACKAGE_VERSION_MAJOR 0
-#define PACKAGE_VERSION_MINOR 2
-#define PACKAGE_VERSION_PATCHLEVEL 5
-
 #define COLOR8(r, g, b) \
     ((((r) >> 5) << 0)  | (((g) >> 5) << 3) | (((b) >> 6) << 6))
 #define COLOR15(r, g, b) \

--- a/xrdpdev/Makefile.am
+++ b/xrdpdev/Makefile.am
@@ -3,6 +3,9 @@ EXTRA_DIST =
 AM_CFLAGS = \
   $(XORG_SERVER_CFLAGS) \
   $(XRDP_CFLAGS) \
+  -DPACKAGE_VERSION_MAJOR=@package_version_major@ \
+  -DPACKAGE_VERSION_MINOR=@package_version_minor@ \
+  -DPACKAGE_VERSION_PATCHLEVEL=@package_version_patchlevel@ \
   -I$(top_srcdir)/module
 
 xrdpdev_drv_la_LTLIBRARIES = xrdpdev_drv.la

--- a/xrdpkeyb/Makefile.am
+++ b/xrdpkeyb/Makefile.am
@@ -3,6 +3,9 @@ EXTRA_DIST =
 AM_CFLAGS = \
   $(XORG_SERVER_CFLAGS) \
   $(XRDP_CFLAGS) \
+  -DPACKAGE_VERSION_MAJOR=@package_version_major@ \
+  -DPACKAGE_VERSION_MINOR=@package_version_minor@ \
+  -DPACKAGE_VERSION_PATCHLEVEL=@package_version_patchlevel@ \
   -I$(top_srcdir)/module
 
 xrdpkeyb_drv_la_LTLIBRARIES = xrdpkeyb_drv.la

--- a/xrdpmouse/Makefile.am
+++ b/xrdpmouse/Makefile.am
@@ -3,6 +3,9 @@ EXTRA_DIST =
 AM_CFLAGS = \
   $(XORG_SERVER_CFLAGS) \
   $(XRDP_CFLAGS) \
+  -DPACKAGE_VERSION_MAJOR=@package_version_major@ \
+  -DPACKAGE_VERSION_MINOR=@package_version_minor@ \
+  -DPACKAGE_VERSION_PATCHLEVEL=@package_version_patchlevel@ \
   -I$(top_srcdir)/module
 
 xrdpmouse_drv_la_LTLIBRARIES = xrdpmouse_drv.la


### PR DESCRIPTION
Now configure.ac is the only place to define version. Pass the version
via Makefile and compiler command line args -Dfoo=bar.