### PR TITLE
change XvExtension use

### DIFF
--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -468,7 +468,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* try to init simd functions */
     rdpSimdInit(pScreen, pScrn);
 
-#if defined(XvExtension) && XvExtension
+#if defined(XvExtension)
     /* XVideo */
     if (!rdpXvInit(pScreen, pScrn))
     {


### PR DESCRIPTION
Autotools configures xorg-server.h
define XvExtension 1
Meson configures xorg-server.h
define XvExtension
So we just want to test for if XvExtension is defined.
If XVideo is not configured, XvExtension is not defined. You never see
define XvExtension 0
so this should work for all Xorg versions.