### PR TITLE
Address invalid memory access (#104) in rdpClientCon

### DIFF
--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -62,10 +62,9 @@ struct _rdpClientCon
 
     int rectIdAck;
     int rectId;
-    int connected; /* boolean */
+    int connected; /* boolean. Set to False when I/O fails */
     int begin; /* boolean */
     int count;
-    int sckClosed; /* boolean */
     struct rdpup_os_bitmap *osBitmaps;
     int maxOsBitmaps;
     int osBitmapStamp;
@@ -114,6 +113,7 @@ struct _rdpClientCon
     int *rfx_crcs;
 
     struct _rdpClientCon *next;
+    struct _rdpClientCon *prev;
 };
 
 extern _X_EXPORT int


### PR DESCRIPTION
This is the last of a couple of pull requests to address the memory issues found in #104 by @keithrob91.

As mentioned in that request, the `clientCon` is freed whenever `rdpClientConSend()` or `rdpClientConRecv()` detect a connection problem. Not all the code paths are expecting this, and as a result the `clientCon` is potentially accessed after being freed.

One approach would be to go through all the code paths which call `rdpClientConSend()` or `rdpClientConRecv()`  and check they can handle the connection being deleted. I think this is likely to be a bit fiddly and quite brittle to maintain.

The approach I've taken is to remove most of the calls to `rdpClientConDisconnect()` and replace them with clearing a boolean flag `connected` . The actual call to `rdpClientConDisconnect()` now happens in the main select loop.  This makes it a lot easier to check that the connection isn't accessed after being freed.

Here are some other notes:-

- I  noticed that `struct _rdpClientCon` contained a couple of boolean members that were effectively serving no purpose. These were `connected` and `sckClosed`. I've repurposed `connected` to act as the marker above, and I've removed `sckClosed`.
- I've made the client connection list in the dev a double-linked list now rather than a single one. This simplifies the deletion of a connection from the list, as the list does not need to be scanned to find the connection.
- connection addition and deletion logic is now in two routines `rdpAddClientConToDev()` and `rdpRemoveClientConFromDev()`
- Around line 1173 I've replaced a while loop with a for loop over the list which simplifies the next element logic slightly. I couldn't find anything in the coding standards about these kind of for loops, but I know some project leads don't like them.

@keithrob91 - would you be happy to run your static analysis tool again? I don't have access to anything better than cppcheck here.