### PR TITLE
Idle timer optimized version

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -282,11 +282,11 @@ struct _rdpRec
 
     OsTimerPtr disconnectTimer;
     int disconnect_timeout_s;
-    int disconnect_time_ms;
+    CARD32 disconnect_time_ms;
 
     OsTimerPtr idleDisconnectTimer;
     int idle_disconnect_timeout_s;
-    time_t last_event_time;
+    CARD32 last_event_time_ms;
 
     int conNumber;
 

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -98,7 +98,7 @@ rdpInputKeyboardEvent(rdpPtr dev, int msg,
                       long param1, long param2,
                       long param3, long param4)
 {
-    dev->last_event_time = time(0);
+    dev->last_event_time_ms = GetTimeInMillis();
 
     if (g_input_proc[0].proc != 0)
     {
@@ -113,7 +113,7 @@ rdpInputMouseEvent(rdpPtr dev, int msg,
                    long param1, long param2,
                    long param3, long param4)
 {
-    dev->last_event_time = time(0);
+    dev->last_event_time_ms = GetTimeInMillis();
 
     if (g_input_proc[1].proc != 0)
     {


### PR DESCRIPTION
this version does not use fixed 1s timers. it calculates the remaining idle time and sets the timer to calculated value. this way only the minimum of timer eexcutions are needed.