### PR TITLE
Reduce input lag by 36ms by separating frame rate limiting from update batching

### DIFF
--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -105,6 +105,7 @@ struct _rdpClientCon
     int rect_id_ack;
 
     OsTimerPtr updateTimer;
+    CARD32 lastUpdateTime; /* millisecond timestamp */
     int updateScheduled; /* boolean */
 
     RegionPtr dirtyRegion;


### PR DESCRIPTION
So I've been doing some [latency testing](https://thume.ca/2020/05/20/making-a-latency-tester/) and tracing of xrdp and I found that after it receives a paint the computer sits idle for 40ms before sending the paint to the client. In xterm depending on the monitor and other factors I can see keyboard-to-screen latencies of 120ms with xrdp, so in those cases the 40ms sleep accounts for 1/3rd of the end-to-end latency.

I tracked it down to a timer that serves dual duty as a hard-coded frame rate limiter (25fps) and a way to wait for any more updates from the app before sending off a packet. 40ms is way longer than is needed to wait for more screen paints, so I split it into two separate delays: an inter-frame delay and a "waiting for more updates" delay. I kept a 4ms delay to wait for more updates, which is still probably much more than necessary, but it corresponds to 1/10th the previous delay and is reasonably small, still providing a 36ms unconditional latency improvement.