### PR TITLE
Faster large screen updates + scrolling detection

### DIFF
--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS = \
   rdpXv.h \
   amd64/funcs_amd64.h \
   x86/funcs_x86.h \
+  wyhash.h \
   $(EXTRA_HEADERS)
 
 libxorgxrdp_la_LTLIBRARIES = libxorgxrdp.la

--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST = common.asm nasm_lt.sh
-EXTRA_FLAGS =
+EXTRA_FLAGS = --std=gnu90 --pedantic
 EXTRA_SOURCES =
 EXTRA_HEADERS =
 SUBDIRS =

--- a/module/Makefile.am
+++ b/module/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST = common.asm nasm_lt.sh
-EXTRA_FLAGS = --std=gnu90 --pedantic
+EXTRA_FLAGS =
 EXTRA_SOURCES =
 EXTRA_HEADERS =
 SUBDIRS =

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -1109,14 +1109,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         }
     }
 
-
-    /* for testing */
-    // *scroll_offset = 76;
-    // scroll_rect->x1 = 64*3;
-    // scroll_rect->x2 = 64*60;
-    // scroll_rect->y1 = 64*6;
-    // scroll_rect->y2 = 64*33;
-
     *out_rects = g_new(BoxRec, RDP_MAX_TILES);
     if (*out_rects == NULL)
     {

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -590,7 +590,8 @@ wyhash_rfx_tile_rows(const uint8_t *src, int src_stride, int x, int y,
 
 /******************************************************************************/
 static uint64_t
-wyhash_rfx_tile_from_rows(const uint64_t *tile_rows, int tile_row_stride, int x, int y)
+wyhash_rfx_tile_from_rows(const uint64_t *tile_rows, int tile_row_stride, 
+                          int x, int y)
 {
     const uint64_t *row_hashes;
     row_hashes = tile_rows + (x / 64) * tile_row_stride + y;
@@ -599,13 +600,15 @@ wyhash_rfx_tile_from_rows(const uint64_t *tile_rows, int tile_row_stride, int x,
 
 /******************************************************************************/
 static void
-wyhash_count_offsets(const uint64_t *row_hashes, uint64_t target_hash, uint16_t *offset_histogram, int num_offsets, int neutral_offset)
+wyhash_count_offsets(const uint64_t *row_hashes, uint64_t target_hash, 
+    uint16_t *offset_histogram, int num_offsets, int neutral_offset)
 {
     int offset;
     /* if a tile as the same as the previous frame with no offset we wouldn't
        need to encode it anyways and also it might be a repeating/blank
        pattern that would cause false positives in our detection */
-    uint64_t neutral_hash = wyhash((const void*)(row_hashes+neutral_offset), 64*sizeof(uint64_t), WYHASH_SEED, _wyp);
+    uint64_t neutral_hash = wyhash((const void*)(row_hashes+neutral_offset), 
+        64*sizeof(uint64_t), WYHASH_SEED, _wyp);
     if(neutral_hash == target_hash)
     {
         return;
@@ -614,7 +617,8 @@ wyhash_count_offsets(const uint64_t *row_hashes, uint64_t target_hash, uint16_t 
     for(offset = 0; offset < num_offsets; offset++)
     {
         if(offset != neutral_offset) {
-            uint64_t offset_tile_hash = wyhash((const void*)(row_hashes+offset), 64*sizeof(uint64_t), WYHASH_SEED, _wyp);
+            uint64_t offset_tile_hash = wyhash((const void*)(row_hashes+offset), 
+                64*sizeof(uint64_t), WYHASH_SEED, _wyp);
             if(offset_tile_hash == target_hash)
             {
                 offset_histogram[offset] += 1;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -592,18 +592,10 @@ wyhash_rfx_tile_rows(const uint8_t *src, int src_stride, int x, int y,
 
 /******************************************************************************/
 static uint64_t
-wyhash_rfx_tile(const uint8_t *src, int src_stride, int x, int y)
-{
-    uint64_t row_hashes[64];
-    wyhash_rfx_tile_rows(src, src_stride, x, y, row_hashes, 64);
-    return wyhash((const void*)row_hashes, 64*sizeof(uint64_t), WYHASH_SEED, _wyp);
-}
-
-/******************************************************************************/
-static uint64_t
 wyhash_rfx_tile_from_rows(const uint64_t *tile_rows, int tile_row_stride, int x, int y)
 {
-    const uint64_t *row_hashes = tile_rows + (x / 64) * tile_row_stride + y;
+    const uint64_t *row_hashes;
+    row_hashes = tile_rows + (x / 64) * tile_row_stride + y;
     return wyhash((const void*)row_hashes, 64*sizeof(uint64_t), WYHASH_SEED, _wyp);
 }
 
@@ -611,6 +603,7 @@ wyhash_rfx_tile_from_rows(const uint64_t *tile_rows, int tile_row_stride, int x,
 static void
 wyhash_count_offsets(const uint64_t *row_hashes, uint64_t target_hash, uint16_t *offset_histogram, int num_offsets, int neutral_offset)
 {
+    int offset;
     /* if a tile as the same as the previous frame with no offset we wouldn't
        need to encode it anyways and also it might be a repeating/blank
        pattern that would cause false positives in our detection */
@@ -620,7 +613,7 @@ wyhash_count_offsets(const uint64_t *row_hashes, uint64_t target_hash, uint16_t 
         return;
     }
 
-    for(int offset = 0; offset < num_offsets; offset++)
+    for(offset = 0; offset < num_offsets; offset++)
     {
         if(offset != neutral_offset) {
             uint64_t offset_tile_hash = wyhash((const void*)(row_hashes+offset), 64*sizeof(uint64_t), WYHASH_SEED, _wyp);
@@ -863,30 +856,32 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
 /******************************************************************************/
 static int
-find_scroll_rect(const uint8_t *map, int map_width, int map_height, int seed_y, BoxPtr foundRect)
+find_scroll_rect(const uint8_t *map, int map_width, int map_height, 
+                 int seed_y, BoxPtr foundRect)
 {
-    // find x extents at seed
-    int x1 = 0;
-    int x2 = 0; // exclusive
-    for(int x = 0; x < map_width; x++)
+    int x1, x2, y1, y2, x, y;
+    /* find x extents at seed */
+    x1 = 0;
+    x2 = 0; /* exclusive */
+    for(x = 0; x < map_width; x++)
     {
         uint8_t v = map[seed_y*map_width+x];
-        if(v == 0 && x1 != x2) break; // already found a span and it ended
+        if(v == 0 && x1 != x2) break; /* already found a span and it ended */
         if(v != 0)
         {
-            if(x1 == x2) x1 = x; // didn't have a span so start one
+            if(x1 == x2) x1 = x; /* didn't have a span so start one */
             x2 = x+1;
         }
     }
     DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrollextentx, x1, x2);
 
-    // extend rectangle up and down
-    int y1 = 0;
-    int y2 = 0; // exclusive
-    for(int y = 0; y < map_height; y++)
+    /* extend rectangle up and down */
+    y1 = 0;
+    y2 = 0; /* exclusive */
+    for(y = 0; y < map_height; y++)
     {
         uint8_t v = 1;
-        for(int x = x1; x < x2; x++)
+        for(x = x1; x < x2; x++)
         {
             if(map[y*map_width+x] == 0)
             {
@@ -895,10 +890,10 @@ find_scroll_rect(const uint8_t *map, int map_width, int map_height, int seed_y, 
             }
         }
 
-        if(v == 0 && y1 != y2) break; // already found a span and it ended
+        if(v == 0 && y1 != y2) break; /* already found a span and it ended */
         if(v != 0)
         {
-            if(y1 == y2) y1 = y; // didn't have a span so start one
+            if(y1 == y2) y1 = y; /* didn't have a span so start one */
             y2 = y+1;
         }
     }
@@ -920,9 +915,11 @@ find_scroll_rect(const uint8_t *map, int map_width, int map_height, int seed_y, 
 static void
 print_scroll_map(const uint8_t *map, int map_width, int map_height)
 {
-    for(int y = 0; y < map_height; y++) {
-        for(int x = 0; x < map_width; x++) {
-            char c = map[y*map_width+x] ? '#' : '.';
+    int y, x;
+    char c;
+    for(y = 0; y < map_height; y++) {
+        for(x = 0; x < map_width; x++) {
+            c = map[y*map_width+x] ? '#' : '.';
             ErrorF("%c", c);
         }
         ErrorF("\n");
@@ -960,6 +957,19 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     uint64_t crc;
     int num_crcs;
     int num_skips;
+    int tile_row_stride, crc_height;
+    int i, best_offset, num_diff_first_rows;
+    int xn, px, yn, py;
+    int num_matched, num_checked;
+    int seed_y, found, tiles_scrolled;
+    uint64_t *row_hashes;
+    uint64_t old_first_row, new_first_row;
+    uint16_t *offset_histogram;
+    uint16_t max_count;
+    uint8_t *scrolled_map;
+    uint64_t old_hash, new_hash;
+    uint64_t target_hash;
+    BoxRec foundRect;
 
     LLOGLN(10, ("rdpCapture2:"));
     extents_rect = *rdpRegionExtents(in_reg);
@@ -970,9 +980,9 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     dst_stride = clientCon->cap_stride_bytes;
 
     crc_stride = (clientCon->dev->width + 63) / 64;
-    // tile rows are column-major
-    int tile_row_stride = ((clientCon->dev->height + 63) / 64) * 64;
-    int crc_height = ((clientCon->dev->height + 63) / 64);
+    /* tile rows are column-major */
+    tile_row_stride = ((clientCon->dev->height + 63) / 64) * 64;
+    crc_height = ((clientCon->dev->height + 63) / 64);
     num_crcs = crc_stride * crc_height;
     if (num_crcs != clientCon->num_rfx_crcs_alloc)
     {
@@ -981,13 +991,12 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         free(clientCon->rfx_crcs);
         free(clientCon->rfx_tile_row_hashes);
         clientCon->rfx_crcs = g_new0(uint64_t, num_crcs);
-        int num_tile_rows = num_crcs * 64;
-        clientCon->rfx_tile_row_hashes = g_new0(uint64_t, num_tile_rows);
+        clientCon->rfx_tile_row_hashes = g_new0(uint64_t, num_crcs * 64);
     }
 
-    // update the tile row hashes
-    // column major order to be kind to prefetchers even though it shouldn't matter much
-    int num_diff_first_rows = 0;
+    /* update the tile row hashes. Column major order to be kind to 
+       prefetchers even though it shouldn't matter much */
+    num_diff_first_rows = 0;
     x = extents_rect.x1 & ~63;
     while (x < extents_rect.x2)
     {
@@ -1001,10 +1010,11 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             rcode = rdpRegionContainsRect(in_reg, &rect);
             if (rcode == rgnIN)
             {
-                uint64_t *row_hashes = clientCon->rfx_tile_row_hashes + (x / 64) * tile_row_stride + y;
-                uint64_t old_first_row = row_hashes[0];
+                row_hashes = clientCon->rfx_tile_row_hashes + 
+                    (x / 64) * tile_row_stride + y;
+                old_first_row = row_hashes[0];
                 wyhash_rfx_tile_rows(src, src_stride, x, y, row_hashes, 64);
-                uint64_t new_first_row = row_hashes[0];
+                new_first_row = row_hashes[0];
                 num_diff_first_rows += (old_first_row != new_first_row);
             }
             y += 64;
@@ -1024,12 +1034,12 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
        extents_rect.x2 - extents_rect.x1 >= SCROLL_DET_MIN_W &&
        num_diff_first_rows >= SCROLL_DET_MIN_FIRST_ROW_CHANGES)
     {
-        // probe for candidate scroll offsets
-        uint16_t *offset_histogram = g_new0(uint16_t, NUM_SCROLL_OFFSETS);
-        int xn = 0;
-        int px = 0;
-        int yn = 0;
-        int py = 0;
+        /* probe for candidate scroll offsets */
+        offset_histogram = g_new0(uint16_t, NUM_SCROLL_OFFSETS);
+        xn = 0;
+        px = 0;
+        yn = 0;
+        py = 0;
         y = extents_rect.y1 & ~63;
         while (y < extents_rect.y2)
         {
@@ -1043,7 +1053,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 rcode = rdpRegionContainsRect(in_reg, &rect);
                 if (rcode == rgnIN)
                 {
-                    /* only use a grid of spaced rectangles for scroll detection */
+                    /* only use a grid of spaced rects for scroll detection */
                     if(x != px) xn += 1;
                     if(y != py) yn += 1;
                     px = x;
@@ -1052,9 +1062,12 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     {
                         /* check scroll offsets */
                         crc_offset = (y / 64) * crc_stride + (x / 64);
-                        uint64_t target_hash = clientCon->rfx_crcs[crc_offset];
-                        uint64_t *row_hashes = clientCon->rfx_tile_row_hashes + (rect.x1 / 64) * tile_row_stride + rect.y1;
-                        wyhash_count_offsets(row_hashes, target_hash, offset_histogram, NUM_SCROLL_OFFSETS, SCROLL_SEARCH_DIST);
+                        target_hash = clientCon->rfx_crcs[crc_offset];
+                        row_hashes = clientCon->rfx_tile_row_hashes + 
+                            (rect.x1 / 64) * tile_row_stride + rect.y1;
+                        wyhash_count_offsets(row_hashes, target_hash, 
+                            offset_histogram, NUM_SCROLL_OFFSETS, 
+                            SCROLL_SEARCH_DIST);
                     }
                 }
                 x += 64;
@@ -1062,10 +1075,10 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             y += 64;
         }
 
-        // find the best candidate scroll offset
-        int best_offset = 0;
-        uint16_t max_count = 0;
-        for(int i = 0; i < NUM_SCROLL_OFFSETS; i++)
+        /* find the best candidate scroll offset */
+        best_offset = 0;
+        max_count = 0;
+        for(i = 0; i < NUM_SCROLL_OFFSETS; i++)
         {
             if(offset_histogram[i] >= max_count)
             {
@@ -1075,15 +1088,15 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         }
         free(offset_histogram);
 
-        // positive means we found the old contents below its old location
+        /* positive means we found the old contents below its old location */
         best_offset -= SCROLL_SEARCH_DIST;
         DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrolldet, best_offset, max_count);
 
         if(max_count >= 7) {
-            int num_matched = 0;
-            int num_checked = 0;
-            uint8_t *scrolled_map = g_new0(uint8_t, num_crcs);
-            // make bitmap of tiles with that offset
+            num_matched = 0;
+            num_checked = 0;
+            scrolled_map = g_new0(uint8_t, num_crcs);
+            /* make bitmap of tiles with that offset */
             x = extents_rect.x1 & ~63;
             while (x < extents_rect.x2)
             {
@@ -1099,9 +1112,11 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     {
                         num_checked += 1;
                         crc_offset = (y / 64) * crc_stride + (x / 64);
-                        uint64_t old_tile_hash = clientCon->rfx_crcs[crc_offset];
-                        uint64_t new_tile_hash = wyhash_rfx_tile_from_rows(clientCon->rfx_tile_row_hashes, tile_row_stride, rect.x1, rect.y1);
-                        if(old_tile_hash == new_tile_hash)
+                        old_hash = clientCon->rfx_crcs[crc_offset];
+                        new_hash = wyhash_rfx_tile_from_rows(
+                            clientCon->rfx_tile_row_hashes, tile_row_stride, 
+                            rect.x1, rect.y1);
+                        if(old_hash == new_hash)
                         {
                             scrolled_map[crc_offset] = 1;
                             num_matched += 1;
@@ -1113,22 +1128,21 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             }
             DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrollmap, num_checked, num_matched);
 
-            // ErrorF("scroll: %i probes for %i (%i,%i)x(%i,%i) \n", max_count, best_offset, extents_rect.x1, extents_rect.y1, extents_rect.x2, extents_rect.y2);
-            // print_scroll_map(scrolled_map, crc_stride, crc_height);
-
-            // find large rectangle from bitmap
-            int seed_y = ((extents_rect.y2 + extents_rect.y1) / 2) / 64;
-            BoxRec foundRect;
-            int found = find_scroll_rect(scrolled_map, crc_stride, crc_height, seed_y, &foundRect);
+            /* find large rectangle from bitmap */
+            seed_y = ((extents_rect.y2 + extents_rect.y1) / 2) / 64;
+            found = find_scroll_rect(scrolled_map, crc_stride, 
+                crc_height, seed_y, &foundRect);
             if(found)
             {
-                int tiles_scrolled = (foundRect.x2-foundRect.x1)*(foundRect.y2-foundRect.y1);
+                tiles_scrolled = (foundRect.x2-foundRect.x1)*
+                    (foundRect.y2-foundRect.y1);
                 if(tiles_scrolled > 10)
                 {
-                    // we copy to the scroll rect from the old frame at the scroll rect plus the y offset
-                    // best_offset maps from old to new so we need to invert it to map new to old
+                    /* we copy to the scroll rect from the old frame at the
+                       scroll rect plus the y offset best_offset maps from old
+                       to new so we need to invert it to map new to old */
                     *scroll_offset = -best_offset;
-                    // transform old tile rect to new scroll rect
+                    /* transform old tile rect to new scroll rect */
                     scroll_rect->x1 = foundRect.x1*64;
                     scroll_rect->x2 = foundRect.x2*64;
                     scroll_rect->y1 = foundRect.y1*64+best_offset;
@@ -1141,14 +1155,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             free(scrolled_map);
         }
     }
-
-
-    /* for testing */
-    // *scroll_offset = 76;
-    // scroll_rect->x1 = 64*3;
-    // scroll_rect->x2 = 64*60;
-    // scroll_rect->y1 = 64*6;
-    // scroll_rect->y2 = 64*33;
 
     *out_rects = g_new(BoxRec, RDP_MAX_TILES);
     if (*out_rects == NULL)
@@ -1171,8 +1177,10 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             rcode = rdpRegionContainsRect(in_reg, &rect);
             LLOGLN(10, ("rdpCapture2: rcode %d", rcode));
 
-            in_scroll_rect = (rect.x1 >= scroll_rect->x1) && (rect.x2 <= scroll_rect->x2) &&
-                (rect.y1 >= scroll_rect->y1) && (rect.y2 <= scroll_rect->y2);
+            in_scroll_rect = (rect.x1 >= scroll_rect->x1) 
+                && (rect.x2 <= scroll_rect->x2) 
+                && (rect.y1 >= scroll_rect->y1) 
+                && (rect.y2 <= scroll_rect->y2);
 
             if (rcode != rgnOUT)
             {
@@ -1185,7 +1193,8 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     rdpRegionIntersect(&tile_reg, in_reg, &tile_reg);
                     rects = REGION_RECTS(&tile_reg);
                     num_rects = REGION_NUM_RECTS(&tile_reg);
-                    crc = wyhash((const void*)rects, num_rects * sizeof(BoxRec), crc, _wyp);
+                    crc = wyhash((const void*)rects, num_rects * sizeof(BoxRec), 
+                        crc, _wyp);
                     rdpCopyBox_a8r8g8b8_to_yuvalp(x, y,
                                                   src, src_stride,
                                                   dst, dst_stride,
@@ -1198,7 +1207,8 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 else /* rgnIN */
                 {
                     LLOGLN(10, ("rdpCapture2: rgnIN"));
-                    crc = wyhash_rfx_tile_from_rows(clientCon->rfx_tile_row_hashes, tile_row_stride, x, y);
+                    crc = wyhash_rfx_tile_from_rows(
+                        clientCon->rfx_tile_row_hashes, tile_row_stride, x, y);
 
                 }
                 crc_offset = (y / 64) * crc_stride + (x / 64);

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -941,7 +941,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int tile_row_stride, crc_height;
     int i, best_offset, num_diff_first_rows;
     int xn, px, yn, py;
-    int num_matched, num_checked;
     int seed_y, found, tiles_scrolled;
     uint64_t *row_hashes;
     uint64_t old_first_row, new_first_row;
@@ -1072,8 +1071,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         best_offset -= SCROLL_SEARCH_DIST;
 
         if(max_count >= 7) {
-            num_matched = 0;
-            num_checked = 0;
             scrolled_map = g_new0(uint8_t, num_crcs);
             /* make bitmap of tiles with that offset */
             x = extents_rect.x1 & ~63;
@@ -1089,7 +1086,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     rcode = rdpRegionContainsRect(in_reg, &rect);
                     if (rcode == rgnIN)
                     {
-                        num_checked += 1;
                         crc_offset = (y / 64) * crc_stride + (x / 64);
                         old_hash = clientCon->rfx_crcs[crc_offset];
                         new_hash = wyhash_rfx_tile_from_rows(
@@ -1098,7 +1094,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                         if(old_hash == new_hash)
                         {
                             scrolled_map[crc_offset] = 1;
-                            num_matched += 1;
                         }
                     }
                     y += 64;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -912,21 +912,6 @@ find_scroll_rect(const uint8_t *map, int map_width, int map_height,
 }
 
 /******************************************************************************/
-static void
-print_scroll_map(const uint8_t *map, int map_width, int map_height)
-{
-    int y, x;
-    char c;
-    for(y = 0; y < map_height; y++) {
-        for(x = 0; x < map_width; x++) {
-            c = map[y*map_width+x] ? '#' : '.';
-            ErrorF("%c", c);
-        }
-        ErrorF("\n");
-    }
-}
-
-/******************************************************************************/
 #define SCROLL_SEARCH_DIST 256
 #define NUM_SCROLL_OFFSETS (SCROLL_SEARCH_DIST*2+1)
 #define SCROLL_DET_MIN_H (NUM_SCROLL_OFFSETS+64)
@@ -1212,8 +1197,6 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
                 }
                 crc_offset = (y / 64) * crc_stride + (x / 64);
-                LLOGLN(10, ("rdpCapture2: crc 0x%8.8lx 0x%8.8lx",
-                       crc, clientCon->rfx_crcs[crc_offset]));
                 if (crc == clientCon->rfx_crcs[crc_offset])
                 {
                     LLOGLN(10, ("rdpCapture2: crc skip at x %d y %d", x, y));

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -1113,6 +1113,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             }
             DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrollmap, num_checked, num_matched);
 
+            // ErrorF("scroll: %i probes for %i (%i,%i)x(%i,%i) \n", max_count, best_offset, extents_rect.x1, extents_rect.y1, extents_rect.x2, extents_rect.y2);
             // print_scroll_map(scrolled_map, crc_stride, crc_height);
 
             // find large rectangle from bitmap
@@ -1121,17 +1122,20 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             int found = find_scroll_rect(scrolled_map, crc_stride, crc_height, seed_y, &foundRect);
             if(found)
             {
-                // we copy to the scroll rect from the old frame at the scroll rect plus the y offset
-                // best_offset maps from old to new so we need to invert it to map new to old
-                *scroll_offset = -best_offset;
-                // transform old tile rect to new scroll rect
-                scroll_rect->x1 = foundRect.x1*64;
-                scroll_rect->x2 = foundRect.x2*64;
-                scroll_rect->y1 = foundRect.y1*64+best_offset;
-                scroll_rect->y2 = foundRect.y2*64+best_offset;
-
                 int tiles_scrolled = (foundRect.x2-foundRect.x1)*(foundRect.y2-foundRect.y1);
-                DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrolled, *scroll_offset, tiles_scrolled);
+                if(tiles_scrolled > 10)
+                {
+                    // we copy to the scroll rect from the old frame at the scroll rect plus the y offset
+                    // best_offset maps from old to new so we need to invert it to map new to old
+                    *scroll_offset = -best_offset;
+                    // transform old tile rect to new scroll rect
+                    scroll_rect->x1 = foundRect.x1*64;
+                    scroll_rect->x2 = foundRect.x2*64;
+                    scroll_rect->y1 = foundRect.y1*64+best_offset;
+                    scroll_rect->y2 = foundRect.y2*64+best_offset;
+
+                    DTRACE_PROBE2(xorgxrdp, rdpCapture2_scrolled, *scroll_offset, tiles_scrolled);
+                }
             }
 
             free(scrolled_map);

--- a/module/rdpCapture.h
+++ b/module/rdpCapture.h
@@ -35,7 +35,8 @@ capture
 
 extern _X_EXPORT Bool
 rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
-           int *num_out_rects, struct image_data *id);
+           int *num_out_rects, BoxPtr scroll_rect, short *scroll_offset,
+           struct image_data *id);
 
 extern _X_EXPORT int
 a8r8g8b8_to_a8b8g8r8_box(const uint8_t *s8, int src_stride,

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -2366,8 +2366,10 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
 {
     RegionPtr cap_dirty;
     BoxRec rect;
+    BoxRec scroll_rect;
     BoxPtr rects;
     int num_rects;
+    short scroll_offset;
 
     cap_dirty = rdpRegionCreate(cap_rect, 0);
     LLOGLN(10, ("rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
@@ -2388,9 +2390,15 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
         num_rects = 0;
         LLOGLN(10, ("rdpCapRect: capture_code %d",
                     clientCon->client_info.capture_code));
-        if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, id))
+        if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, &scroll_rect, &scroll_offset, id))
         {
             LLOGLN(10, ("rdpCapRect: num_rects %d", num_rects));
+            if (scroll_offset != 0)
+            {
+                rdpClientConScreenBlt(clientCon->dev, clientCon,
+                      scroll_rect.x1, scroll_rect.y1, scroll_rect.x2-scroll_rect.x1,
+                      scroll_rect.y2-scroll_rect.y1, scroll_rect.x1, scroll_rect.y1+scroll_offset);
+            }
             rdpClientConSendPaintRectShmEx(clientCon->dev, clientCon, id,
                                            cap_dirty, rects, num_rects);
             free(rects);

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -2390,14 +2390,17 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
         num_rects = 0;
         LLOGLN(10, ("rdpCapRect: capture_code %d",
                     clientCon->client_info.capture_code));
-        if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, &scroll_rect, &scroll_offset, id))
+        if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, 
+            &scroll_rect, &scroll_offset, id))
         {
             LLOGLN(10, ("rdpCapRect: num_rects %d", num_rects));
             if (scroll_offset != 0)
             {
                 rdpClientConScreenBlt(clientCon->dev, clientCon,
-                      scroll_rect.x1, scroll_rect.y1, scroll_rect.x2-scroll_rect.x1,
-                      scroll_rect.y2-scroll_rect.y1, scroll_rect.x1, scroll_rect.y1+scroll_offset);
+                      scroll_rect.x1, scroll_rect.y1, 
+                      scroll_rect.x2-scroll_rect.x1,
+                      scroll_rect.y2-scroll_rect.y1, 
+                      scroll_rect.x1, scroll_rect.y1+scroll_offset);
             }
             rdpClientConSendPaintRectShmEx(clientCon->dev, clientCon, id,
                                            cap_dirty, rects, num_rects);

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -112,6 +112,7 @@ struct _rdpClientCon
 
     int num_rfx_crcs_alloc;
     uint64_t *rfx_crcs;
+    uint64_t *rfx_tile_row_hashes;
 
     /* true = skip drawing */
     int suppress_output;

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -111,7 +111,7 @@ struct _rdpClientCon
     RegionPtr dirtyRegion;
 
     int num_rfx_crcs_alloc;
-    int *rfx_crcs;
+    uint64_t *rfx_crcs;
 
     /* true = skip drawing */
     int suppress_output;

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -34,7 +34,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* all driver need this */
 #include <xf86.h>
 #include <xf86_OSproc.h>
-#include <sys/sdt.h>
 
 #include "rdp.h"
 #include "rdpDraw.h"
@@ -70,7 +69,6 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     int cd;
     BoxRec box;
 
-    DTRACE_PROBE2(xorgxrdp, rdpPutImage, w, h);
     LLOGLN(10, ("rdpPutImage:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPutImageCallCount++;

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -34,6 +34,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* all driver need this */
 #include <xf86.h>
 #include <xf86_OSproc.h>
+#include <sys/sdt.h>
 
 #include "rdp.h"
 #include "rdpDraw.h"
@@ -69,6 +70,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     int cd;
     BoxRec box;
 
+    DTRACE_PROBE2(xorgxrdp, rdpPutImage, w, h);
     LLOGLN(10, ("rdpPutImage:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPutImageCallCount++;

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -373,7 +373,7 @@ rdpRRAddOutput(rdpPtr dev, const char *aname, int x, int y, int width, int heigh
     RROutputPtr output;
     xRRModeInfo modeInfo;
     char name[64];
-    const int vfreq = 50;
+    const int vfreq = 25;
     int i;
 
     sprintf (name, "%dx%d", width, height);
@@ -444,7 +444,7 @@ rdpRRUpdateOutput(RROutputPtr output, RRCrtcPtr crtc,
     RRModePtr mode;
     xRRModeInfo modeInfo;
     char name[64];
-    const int vfreq = 50;
+    const int vfreq = 25;
 
     LLOGLN(0, ("rdpRRUpdateOutput:"));
     sprintf (name, "%dx%d", width, height);

--- a/module/wyhash.h
+++ b/module/wyhash.h
@@ -1,12 +1,11 @@
-//Author: Wang Yi <godspeed_china@yeah.net>
+/* Author: Wang Yi <godspeed_china@yeah.net>
+   chopped down and converted to older C standard for xorgxrdp
+*/
 #ifndef wyhash_final_version
 #define wyhash_final_version
-//defines that change behavior
 #ifndef WYHASH_CONDOM
-#define WYHASH_CONDOM 0 //0,1,2
+#define WYHASH_CONDOM 0
 #endif
-#define WYHASH_32BIT_MUM 0  //faster on 32 bit system
-//includes
 #include <stdint.h>
 #include <string.h>
 #if defined(_MSC_VER) && defined(_M_X64)
@@ -20,18 +19,11 @@
   #define _likely_(x) (x)
   #define _unlikely_(x) (x)
 #endif
-//mum function
-static inline uint64_t _wyrot(uint64_t x) { return (x>>32)|(x<<32); }
-static inline void _wymum(uint64_t *A, uint64_t *B){
-#if(WYHASH_32BIT_MUM)
-  uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(unsigned)*B, lh=(unsigned)*A*(*B>>32), ll=(uint64_t)(unsigned)*A*(unsigned)*B;
-  #if(WYHASH_CONDOM>1)
-  *A^=_wyrot(hl)^hh; *B^=_wyrot(lh)^ll;
-  #else
-  *A=_wyrot(hl)^hh; *B=_wyrot(lh)^ll;
-  #endif
-#elif defined(__SIZEOF_INT128__)
-  __uint128_t r=*A; r*=*B; 
+static __inline__ uint64_t _wyrot(uint64_t x) { return (x>>32)|(x<<32); }
+static __inline__ void _wymum(uint64_t *A, uint64_t *B){
+#if defined(__SIZEOF_INT128__)
+  __uint128_t r;
+  r=*A; r*=*B; 
   #if(WYHASH_CONDOM>1)
   *A^=(uint64_t)r; *B^=(uint64_t)(r>>64);
   #else
@@ -46,8 +38,10 @@ static inline void _wymum(uint64_t *A, uint64_t *B){
   *A=_umul128(*A,*B,B);
   #endif
 #else
-  uint64_t ha=*A>>32, hb=*B>>32, la=(uint32_t)*A, lb=(uint32_t)*B, hi, lo;
-  uint64_t rh=ha*hb, rm0=ha*lb, rm1=hb*la, rl=la*lb, t=rl+(rm0<<32), c=t<rl;
+  uint64_t ha, hb, la, lb, hi, lo;
+  uint64_t rh, rm0, rm1, rl, t, c;
+  ha=*A>>32; hb=*B>>32; la=(uint32_t)*A; lb=(uint32_t)*B;
+  rh=ha*hb; rm0=ha*lb; rm1=hb*la; rl=la*lb; t=rl+(rm0<<32); c=t<rl;
   lo=t+(rm1<<32); c+=lo<t; hi=rh+(rm0>>32)+(rm1>>32)+c;
   #if(WYHASH_CONDOM>1)
   *A^=lo;  *B^=hi;
@@ -56,8 +50,7 @@ static inline void _wymum(uint64_t *A, uint64_t *B){
   #endif
 #endif
 }
-static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
-//read functions
+static __inline__ uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
 #ifndef WYHASH_LITTLE_ENDIAN
   #if defined(_WIN32) || defined(__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
     #define WYHASH_LITTLE_ENDIAN 1
@@ -66,18 +59,17 @@ static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B
   #endif
 #endif
 #if (WYHASH_LITTLE_ENDIAN)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
+static __inline__ uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
+static __inline__ uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+static __inline__ uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
+static __inline__ uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
 #elif defined(_MSC_VER)
-static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+static __inline__ uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static __inline__ uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
 #endif
-static inline uint64_t _wyr3(const uint8_t *p, unsigned k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
-//wyhash function
-static inline uint64_t _wyfinish16(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
+static __inline__ uint64_t _wyr3(const uint8_t *p, unsigned k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
+static __inline__ uint64_t _wyfinish16(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
 #if(WYHASH_CONDOM>0)
   uint64_t a, b;
   if(_likely_(i<=8)){
@@ -93,16 +85,19 @@ static inline uint64_t _wyfinish16(const uint8_t *p, uint64_t len, uint64_t seed
 #endif
 }
 
-static inline uint64_t _wyfinish(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
+static __inline__ uint64_t _wyfinish(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
   if(_likely_(i<=16)) return _wyfinish16(p,len,seed,secret,i);
   return _wyfinish(p+16,len,_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed),secret,i-16);
 }
 
-static inline uint64_t wyhash(const void *key, uint64_t len, uint64_t seed, const uint64_t *secret){
-  const uint8_t *p=(const uint8_t *)key;
-  uint64_t i=len; seed^=*secret;
+static __inline__ uint64_t wyhash(const void *key, uint64_t len, uint64_t seed, const uint64_t *secret){
+  const uint8_t *p;
+  uint64_t i;
+  uint64_t see1;
+  p=(const uint8_t *)key;
+  i=len; seed^=*secret;
   if(_unlikely_(i>64)){
-    uint64_t see1=seed;
+    see1=seed;
     do{
       seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed)^_wymix(_wyr8(p+16)^secret[2],_wyr8(p+24)^seed);
       see1=_wymix(_wyr8(p+32)^secret[3],_wyr8(p+40)^see1)^_wymix(_wyr8(p+48)^secret[4],_wyr8(p+56)^see1);
@@ -112,28 +107,26 @@ static inline uint64_t wyhash(const void *key, uint64_t len, uint64_t seed, cons
   }
   return _wyfinish(p,len,seed,secret,i);
 }
-//utility functions
 const uint64_t _wyp[5] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull, 0x1d8e4e27c47d124full};
-static inline uint64_t wyhash64(uint64_t A, uint64_t B){  A^=_wyp[0]; B^=_wyp[1];  _wymum(&A,&B);  return _wymix(A^_wyp[0],B^_wyp[1]);}
-static inline uint64_t wyrand(uint64_t *seed){  *seed+=_wyp[0]; return _wymix(*seed,*seed^_wyp[1]);}
-static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>12)*_wynorm;}
-static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0;}
-static inline void make_secret(uint64_t seed, uint64_t *secret){
+static __inline__ uint64_t wyhash64(uint64_t A, uint64_t B){  A^=_wyp[0]; B^=_wyp[1];  _wymum(&A,&B);  return _wymix(A^_wyp[0],B^_wyp[1]);}
+static __inline__ uint64_t wyrand(uint64_t *seed){  *seed+=_wyp[0]; return _wymix(*seed,*seed^_wyp[1]);}
+static __inline__ void make_secret(uint64_t seed, uint64_t *secret){
+  size_t i, j;
   uint8_t c[] = {15, 23, 27, 29, 30, 39, 43, 45, 46, 51, 53, 54, 57, 58, 60, 71, 75, 77, 78, 83, 85, 86, 89, 90, 92, 99, 101, 102, 105, 106, 108, 113, 114, 116, 120, 135, 139, 141, 142, 147, 149, 150, 153, 154, 156, 163, 165, 166, 169, 170, 172, 177, 178, 180, 184, 195, 197, 198, 201, 202, 204, 209, 210, 212, 216, 225, 226, 228, 232, 240 };
-  for(size_t i=0;i<5;i++){
+  for(i=0;i<5;i++){
     uint8_t ok;
     do{
       ok=1; secret[i]=0;
-      for(size_t j=0;j<64;j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
+      for(j=0;j<64;j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
       if(secret[i]%2==0){ ok=0; continue; }
-      for(size_t j=0;j<i;j++)
+      for(j=0;j<i;j++)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
         if(__builtin_popcountll(secret[j]^secret[i])!=32){ ok=0; break; }
 #elif defined(_MSC_VER)
         if(_mm_popcnt_u64(secret[j]^secret[i])!=32){ ok=0; break; }
 #endif
        if(!ok)continue;
-       for(uint64_t j=3;j<0x100000000ull;j+=2) if(secret[i]%j==0){ ok=0; break; }
+       for(j=3;j<0x100000000ull;j+=2) if(secret[i]%j==0){ ok=0; break; }
     }while(!ok);
   }
 }

--- a/module/wyhash.h
+++ b/module/wyhash.h
@@ -110,24 +110,4 @@ static __inline__ uint64_t wyhash(const void *key, uint64_t len, uint64_t seed, 
 const uint64_t _wyp[5] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull, 0x1d8e4e27c47d124full};
 static __inline__ uint64_t wyhash64(uint64_t A, uint64_t B){  A^=_wyp[0]; B^=_wyp[1];  _wymum(&A,&B);  return _wymix(A^_wyp[0],B^_wyp[1]);}
 static __inline__ uint64_t wyrand(uint64_t *seed){  *seed+=_wyp[0]; return _wymix(*seed,*seed^_wyp[1]);}
-static __inline__ void make_secret(uint64_t seed, uint64_t *secret){
-  size_t i, j;
-  uint8_t c[] = {15, 23, 27, 29, 30, 39, 43, 45, 46, 51, 53, 54, 57, 58, 60, 71, 75, 77, 78, 83, 85, 86, 89, 90, 92, 99, 101, 102, 105, 106, 108, 113, 114, 116, 120, 135, 139, 141, 142, 147, 149, 150, 153, 154, 156, 163, 165, 166, 169, 170, 172, 177, 178, 180, 184, 195, 197, 198, 201, 202, 204, 209, 210, 212, 216, 225, 226, 228, 232, 240 };
-  for(i=0;i<5;i++){
-    uint8_t ok;
-    do{
-      ok=1; secret[i]=0;
-      for(j=0;j<64;j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
-      if(secret[i]%2==0){ ok=0; continue; }
-      for(j=0;j<i;j++)
-#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-        if(__builtin_popcountll(secret[j]^secret[i])!=32){ ok=0; break; }
-#elif defined(_MSC_VER)
-        if(_mm_popcnt_u64(secret[j]^secret[i])!=32){ ok=0; break; }
-#endif
-       if(!ok)continue;
-       for(j=3;j<0x100000000ull;j+=2) if(secret[i]%j==0){ ok=0; break; }
-    }while(!ok);
-  }
-}
 #endif

--- a/module/wyhash.h
+++ b/module/wyhash.h
@@ -1,0 +1,140 @@
+//Author: Wang Yi <godspeed_china@yeah.net>
+#ifndef wyhash_final_version
+#define wyhash_final_version
+//defines that change behavior
+#ifndef WYHASH_CONDOM
+#define WYHASH_CONDOM 0 //0,1,2
+#endif
+#define WYHASH_32BIT_MUM 0  //faster on 32 bit system
+//includes
+#include <stdint.h>
+#include <string.h>
+#if defined(_MSC_VER) && defined(_M_X64)
+  #include <intrin.h>
+  #pragma intrinsic(_umul128)
+#endif
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+  #define _likely_(x) __builtin_expect(x,1)
+  #define _unlikely_(x) __builtin_expect(x,0)
+#else
+  #define _likely_(x) (x)
+  #define _unlikely_(x) (x)
+#endif
+//mum function
+static inline uint64_t _wyrot(uint64_t x) { return (x>>32)|(x<<32); }
+static inline void _wymum(uint64_t *A, uint64_t *B){
+#if(WYHASH_32BIT_MUM)
+  uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(unsigned)*B, lh=(unsigned)*A*(*B>>32), ll=(uint64_t)(unsigned)*A*(unsigned)*B;
+  #if(WYHASH_CONDOM>1)
+  *A^=_wyrot(hl)^hh; *B^=_wyrot(lh)^ll;
+  #else
+  *A=_wyrot(hl)^hh; *B=_wyrot(lh)^ll;
+  #endif
+#elif defined(__SIZEOF_INT128__)
+  __uint128_t r=*A; r*=*B; 
+  #if(WYHASH_CONDOM>1)
+  *A^=(uint64_t)r; *B^=(uint64_t)(r>>64);
+  #else
+  *A=(uint64_t)r; *B=(uint64_t)(r>>64);
+  #endif
+#elif defined(_MSC_VER) && defined(_M_X64)
+  #if(WYHASH_CONDOM>1)
+  uint64_t  a,  b;
+  a=_umul128(*A,*B,&b);
+  *A^=a;  *B^=b;
+  #else
+  *A=_umul128(*A,*B,B);
+  #endif
+#else
+  uint64_t ha=*A>>32, hb=*B>>32, la=(uint32_t)*A, lb=(uint32_t)*B, hi, lo;
+  uint64_t rh=ha*hb, rm0=ha*lb, rm1=hb*la, rl=la*lb, t=rl+(rm0<<32), c=t<rl;
+  lo=t+(rm1<<32); c+=lo<t; hi=rh+(rm0>>32)+(rm1>>32)+c;
+  #if(WYHASH_CONDOM>1)
+  *A^=lo;  *B^=hi;
+  #else
+  *A=lo;  *B=hi;
+  #endif
+#endif
+}
+static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
+//read functions
+#ifndef WYHASH_LITTLE_ENDIAN
+  #if defined(_WIN32) || defined(__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+    #define WYHASH_LITTLE_ENDIAN 1
+  #elif defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    #define WYHASH_LITTLE_ENDIAN 0
+  #endif
+#endif
+#if (WYHASH_LITTLE_ENDIAN)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
+static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+#elif defined(_MSC_VER)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+#endif
+static inline uint64_t _wyr3(const uint8_t *p, unsigned k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
+//wyhash function
+static inline uint64_t _wyfinish16(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
+#if(WYHASH_CONDOM>0)
+  uint64_t a, b;
+  if(_likely_(i<=8)){
+    if(_likely_(i>=4)){ a=_wyr4(p); b=_wyr4(p+i-4); }
+    else if (_likely_(i)){ a=_wyr3(p,i); b=0; }
+    else a=b=0;
+  } 
+  else{ a=_wyr8(p); b=_wyr8(p+i-8); }
+  return _wymix(secret[1]^len,_wymix(a^secret[1], b^seed));
+#else
+  #define oneshot_shift ((i<8)*((8-i)<<3))
+  return _wymix(secret[1]^len,_wymix((_wyr8(p)<<oneshot_shift)^secret[1],(_wyr8(p+i-8)>>oneshot_shift)^seed));
+#endif
+}
+
+static inline uint64_t _wyfinish(const uint8_t *p, uint64_t len, uint64_t seed, const uint64_t *secret, uint64_t i){
+  if(_likely_(i<=16)) return _wyfinish16(p,len,seed,secret,i);
+  return _wyfinish(p+16,len,_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed),secret,i-16);
+}
+
+static inline uint64_t wyhash(const void *key, uint64_t len, uint64_t seed, const uint64_t *secret){
+  const uint8_t *p=(const uint8_t *)key;
+  uint64_t i=len; seed^=*secret;
+  if(_unlikely_(i>64)){
+    uint64_t see1=seed;
+    do{
+      seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed)^_wymix(_wyr8(p+16)^secret[2],_wyr8(p+24)^seed);
+      see1=_wymix(_wyr8(p+32)^secret[3],_wyr8(p+40)^see1)^_wymix(_wyr8(p+48)^secret[4],_wyr8(p+56)^see1);
+      p+=64; i-=64;
+    }while(i>64);
+    seed^=see1;
+  }
+  return _wyfinish(p,len,seed,secret,i);
+}
+//utility functions
+const uint64_t _wyp[5] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull, 0x1d8e4e27c47d124full};
+static inline uint64_t wyhash64(uint64_t A, uint64_t B){  A^=_wyp[0]; B^=_wyp[1];  _wymum(&A,&B);  return _wymix(A^_wyp[0],B^_wyp[1]);}
+static inline uint64_t wyrand(uint64_t *seed){  *seed+=_wyp[0]; return _wymix(*seed,*seed^_wyp[1]);}
+static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>12)*_wynorm;}
+static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0;}
+static inline void make_secret(uint64_t seed, uint64_t *secret){
+  uint8_t c[] = {15, 23, 27, 29, 30, 39, 43, 45, 46, 51, 53, 54, 57, 58, 60, 71, 75, 77, 78, 83, 85, 86, 89, 90, 92, 99, 101, 102, 105, 106, 108, 113, 114, 116, 120, 135, 139, 141, 142, 147, 149, 150, 153, 154, 156, 163, 165, 166, 169, 170, 172, 177, 178, 180, 184, 195, 197, 198, 201, 202, 204, 209, 210, 212, 216, 225, 226, 228, 232, 240 };
+  for(size_t i=0;i<5;i++){
+    uint8_t ok;
+    do{
+      ok=1; secret[i]=0;
+      for(size_t j=0;j<64;j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
+      if(secret[i]%2==0){ ok=0; continue; }
+      for(size_t j=0;j<i;j++)
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+        if(__builtin_popcountll(secret[j]^secret[i])!=32){ ok=0; break; }
+#elif defined(_MSC_VER)
+        if(_mm_popcnt_u64(secret[j]^secret[i])!=32){ ok=0; break; }
+#endif
+       if(!ok)continue;
+       for(uint64_t j=3;j<0x100000000ull;j+=2) if(secret[i]%j==0){ ok=0; break; }
+    }while(!ok);
+  }
+}
+#endif


### PR DESCRIPTION
This patch switches from slow byte-serial CRC hashing to the much faster
wyhash, with a two-level hashing scheme that allows fast scrolling
detection and acceleration by finding a rectangle of scrolled content
and submitting that as a large screen-to-screen copy rather than updated
tiles.

There's three components that together make the experience with screen updates that contain a ton of pixels, common with modern apps on a 4k screen, much better:

- Switch from CRC32 to wyhash. CRC is a fast hash function in hardware but the byte-serial table is slow in software since every byte requires a serial wait for the L1 cache. wyhash takes much better advantage of larger operations and out of order execution. This accelerates a full 4k update on my computer from 123ms in rdpCapture to 38ms
- Lazily convert to YUV only the tiles that actually changed. Some modern apps like Sublime Text don't take care to submit minimal damage rectangles, and thus huge areas are often unchanged, this avoids the color conversion on those areas which is now the slowest part of capture. This cuts capture down to around 11ms with a small amount of change.
- Detect scrolled regions and make them a screen-to-screen copy: Scrolling is probably the most common cause of large updates during normal desktop use. Other remote desktop solutions like Windows RDP and Citrix detect them and optimize them to screen to screen copies. This PR adds that functionality to xrdp by using a two-level hashing scheme that makes detecting a scrolled rectangle on a 4k screen take under 2ms.

## Known issues

- The scrolling detection makes scrolling much nicer but adds tearing around the edges as the screen copy happens before the new tile updates. I prefer the faster scrolling to the minor tearing but opinions may differ.
- Scroll copies can propogate minor tile compression boundary artifacts into more noticeable slight color fringes along solid backgrounds. They're not very noticeable but it makes some compression artifacts more noticeable than before.

Both of these would require the new Progressive RemoteFX codec to fix, for its ability to mark the beginning and end of a frame involving both tile and screen copy updates, and its tweaked RFX compression to reduce boundary artifacts. This seems like a lot of work and I don't plan on doing it. Might be worth adding a build flag to disable scroll detection if during testing this seems like it might annoy some people.

## TODO list (will add items and tick off as suggestions are made):

There's still some things to do, I'm submitting this now to solicit comments on any other changes that would be preferred before merging this patch.

- [ ] I test using it day to day for a while to see if I notice any major issues, I've only briefly done focused testing so far
- [ ] rename "crc" variables to "hash"
- [ ] squash this down to one commit it's just a bajillion commits right now for my personal git convenience.

