### PR TITLE
Add "DefaultServerLayout" option

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -7,6 +7,9 @@ Section "ServerLayout"
 EndSection
 
 Section "ServerFlags"
+    # This line prevents "ServerLayout" sections in xorg.conf.d files
+    # overriding the "X11 Server" layout (xrdp #1784)
+    Option "DefaultServerLayout" "X11 Server"
     Option "DontVTSwitch" "on"
     Option "AutoAddDevices" "off"
 EndSection


### PR DESCRIPTION
Fixes neutrinolabs/xrdp#1784

Another way to do this is to add a `-layout` switch to `/etc/xrdp/sesman.ini`. I'm less keen on this because of the coupling it introduces between the two projects (i.e. xrdp now needs to know the name of the xorgxrdp server layout). Any thoughts on this?