### PR TITLE
Improve stability of xorgxrdp when resolution changes during a session ("dynamic resolution")

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -587,6 +587,11 @@ rdpCapture0(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
     LLOGLN(10, ("rdpCapture0:"));
 
+    if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
+        LLOGLN(0, ("rdpCapture0: WARNING -- Shared memory is not configured. Aborting capture!"));
+        return FALSE;
+    }
+
     rv = TRUE;
 
 
@@ -691,6 +696,11 @@ rdpCapture1(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
 
     LLOGLN(10, ("rdpCapture1:"));
+
+    if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
+        LLOGLN(0, ("rdpCapture1: WARNING -- Shared memory is not configured. Aborting capture!"));
+        return FALSE;
+    }
 
     rv = TRUE;
 
@@ -824,6 +834,11 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
     LLOGLN(10, ("rdpCapture2:"));
 
+    if (clientCon->shmemstatus != SHM_RFX_ACTIVE) {
+        LLOGLN(0, ("rdpCapture2: WARNING -- Shared memory is not configured for RFX. Aborting capture!"));
+        return FALSE;
+    }
+
     *out_rects = g_new(BoxRec, RDP_MAX_TILES);
     if (*out_rects == NULL)
     {
@@ -937,6 +952,11 @@ rdpCapture3(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
 
     LLOGLN(10, ("rdpCapture3:"));
+
+    if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
+        LLOGLN(0, ("rdpCapture3: WARNING -- Shared memory is not configured. Aborting capture!"));
+        return FALSE;
+    }
 
     rv = TRUE;
 

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -49,6 +49,14 @@ struct rdpup_os_bitmap
     int stamp;
 };
 
+enum shared_memory_status {
+    SHM_UNINITIALIZED = 0,
+    SHM_RESIZING,
+    SHM_ACTIVE,
+    SHM_RFX_ACTIVE,
+    SHM_H264_ACTIVE
+};
+
 /* one of these for each client */
 struct _rdpClientCon
 {
@@ -103,6 +111,7 @@ struct _rdpClientCon
     RegionPtr shmRegion;
     int rect_id;
     int rect_id_ack;
+    enum shared_memory_status shmemstatus;
 
     OsTimerPtr updateTimer;
     CARD32 lastUpdateTime; /* millisecond timestamp */


### PR DESCRIPTION
During dynamic resize, it's possible for the capture timer to trigger while the screen's memory buffer is not in a proper state for the given codec used. The resize algorithm updates the screen to be compatible for "vanilla" remoting with no codecs, but both RFX and H264 have special configurations to the `shmem` (Shared Memory) buffer that will cause the capture routines to crash if they run before the resizing handshake sequence is complete.

This patches the issue in two ways:
1. While `clientCon->suppress_output` is used by the client to configure suppression remotely in special circumstances, previously `clientCon->client_info.suppress_output` was unused. So repurpose that for internal driver use to prevent capture from occurring while the buffer is in an indeterminate state.

2. Update the `_rdpClientCon` data structure to include an enumeration that gives a high-level status of the `shmem` buffer. I may have missed places in the driver where this needs to be updated as well, but for resizing it works.

I could envision further enhancements to the `_rdpClientCon` data structure that make this easier to access, such as breaking out the "shmem" and all related variables into a child struct that is part of _rdpClientCon, so the root namespace of the structure is not as cluttered (It's starting to get to be a lot).

I've tested this extensively with FreeRDP and the `/rfx` switch (Not `/gfx` just yet as that's still in development), and this should not change the way the driver behaves in any way until the changes to xrdp itself are added that enable resizing. I've also verified this works with the Microsoft Remote Desktop Mac OS and Windows 10 clients. Note that MSTSC doesn't support the feature.