### PR TITLE
Check client_info version from xrdp

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -839,6 +839,14 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     memcpy(&(clientCon->client_info), s->p - 4, bytes);
     clientCon->client_info.size = bytes;
 
+    if (clientCon->client_info.version != CLIENT_INFO_CURRENT_VERSION)
+    {
+        LLOGLN(0, ("expected xrdp client_info version %d, got %d",
+                   CLIENT_INFO_CURRENT_VERSION,
+                   clientCon->client_info.version));
+        FatalError("Incompatible xrdp version detected  - please recompile");
+    }
+
     LLOGLN(0, ("  got client info bytes %d", bytes));
     LLOGLN(0, ("  jpeg support %d", clientCon->client_info.jpeg));
     i1 = clientCon->client_info.offscreen_support_level;


### PR DESCRIPTION
Companion PR to neutrinolabs/xrdp#1813

This won't pass CI at the moment for obvious reasons!

Here's the tail of an example xorgxrdp log for a version mismatch:-

```
. . .
[   289.083] expected xrdp client_info version 20210225, got 20210226
[   289.083] (EE)
Fatal server error:
[   289.083] (EE) Incompatible xrdp version detected  - please recompile(EE)
[   289.083] (EE)
Please consult the The X.Org Foundation support
         at http://wiki.x.org
 for help.
[   289.083] (EE) Please also check the log file at ".xorgxrdp.11.log" for additional information.
[   289.083] (EE)
[   289.083] rdpmouseControl: what 4
[   289.083] rdpkeybControl: what 4
[   289.083] rdpLeaveVT:
[   289.084] (EE) Server terminated with error (1). Closing log file.
```

I've gone for a fatal error as I think this will save time in debugging. Thoughts?