### PR TITLE
bump version to v0.2.16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ if test "x${enable_glamor}" = "xyes"; then
 fi
 
 if test "x$XRDP_CFLAGS" = "x"; then
-  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.9.14])
+  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.9.16])
   XRDP_CFLAGS=`pkg-config xrdp --cflags`
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ(2.65)
 # package version must be x.y.z
-AC_INIT([xorgxrdp], [0.2.15], [xrdp-devel@googlegroups.com])
+AC_INIT([xorgxrdp], [0.2.16], [xrdp-devel@googlegroups.com])
 package_version_major=$(echo ${PACKAGE_VERSION}|cut -d. -f1)
 package_version_minor=$(echo ${PACKAGE_VERSION}|cut -d. -f2)
 package_version_patchlevel=$(echo ${PACKAGE_VERSION}|cut -d. -f3)


### PR DESCRIPTION
@matt335672 I've changed dependency to require xrdp v0.9.16. Do you think is this valid?