### PR TITLE
Avoid potential infinite loop for rdpUpdate.

### DIFF
--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -116,6 +116,7 @@ struct _rdpClientCon
     OsTimerPtr updateTimer;
     CARD32 lastUpdateTime; /* millisecond timestamp */
     int updateScheduled; /* boolean */
+    int updateRetries;
 
     RegionPtr dirtyRegion;
 


### PR DESCRIPTION
# Summary
When frame acknowledgement is enabled, such as with the prototype of
egfx, the driver is at risk of going into an infinite loop if for some
reason an ack is missed.

While this line could fix it from xrdp: `mm->mod->mod_frame_ack(mm->mod, 0, INT_MAX);`,
the driver needs to be stable by itself.

The rationale here is that this is akin to a network socket timeout.
After a certain wait, it gives up. Same here.

Also, frame acknowledgement is a quality of service feature, and is not
strictly necessary for the functionality of remote desktop. In the worst
case, bandwidth calcuations between client and server are temporarily
incorrect.

200 was selected after some empirical testing, it could be tweaked.

# Testing
```
[184680.280] rdpDeferredUpdateCallback: reschedule rect_id 542 rect_id_ack 541, retries: 197
[184680.284] rdpDeferredUpdateCallback: reschedule rect_id 542 rect_id_ack 541, retries: 198
[184680.289] rdpDeferredUpdateCallback: reschedule rect_id 542 rect_id_ack 541, retries: 199
[184680.293] rdpDeferredUpdateCallback: reschedule rect_id 542 rect_id_ack 541, retries: 200
[184680.298] rdpDeferredUpdateCallback: reschedule rect_id 542 rect_id_ack 541, retries: 201
[184680.298] rdpScheduleDeferredUpdate: clientCon->retries is 201 and has exceeded timeout. Overriding rect_id_ack.
```