### PR TITLE
Ignore screen size changes which don't change anything

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -760,7 +760,7 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
 
     bytes = clientCon->rdp_width * clientCon->rdp_height *
             clientCon->rdp_Bpp;
-    AllocSharedMemory(clientCon, bytes);
+    rdpClientConAllocateSharedMemory(clientCon, bytes);
     clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->rdp_width;
 
     if (clientCon->shmRegion != 0)
@@ -893,7 +893,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
                clientCon->cap_width, clientCon->cap_height));
         bytes = clientCon->cap_width * clientCon->cap_height *
                 clientCon->rdp_Bpp;
-        AllocSharedMemory(clientCon, bytes);
+        rdpClientConAllocateSharedMemory(clientCon, bytes);
         clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
         clientCon->cap_stride_bytes = clientCon->cap_width * 4;
         shmemstatus = SHM_RFX_ACTIVE;
@@ -906,7 +906,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
         LLOGLN(0, ("  cap_width %d cap_height %d",
                clientCon->cap_width, clientCon->cap_height));
         bytes = clientCon->cap_width * clientCon->cap_height * 2;
-        AllocSharedMemory(clientCon, bytes);
+        rdpClientConAllocateSharedMemory(clientCon, bytes);
         clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
         clientCon->cap_stride_bytes = clientCon->cap_width * 4;
         shmemstatus = SHM_H264_ACTIVE;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -685,27 +685,26 @@ rdpClientConProcessMsgVersion(rdpPtr dev, rdpClientCon *clientCon,
  * @param bytes Size of area to attach
  */
 static void
-AllocSharedMemory(rdpClientCon *clientCon, int bytes)
+rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
 {
-    if (clientCon->shmemptr == NULL || clientCon->shmem_bytes != bytes)
+    if (clientCon->shmemptr != NULL && clientCon->shmem_bytes == bytes)
     {
-        if (clientCon->shmemptr != 0)
-        {
-            shmdt(clientCon->shmemptr);
-        }
-        clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
-        clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
-        clientCon->shmem_bytes = bytes;
-        shmctl(clientCon->shmemid, IPC_RMID, NULL);
-        LLOGLN(0, ("AllocSharedMemory: shmemid %d shmemptr %p bytes %d",
-               clientCon->shmemid, clientCon->shmemptr,
-               clientCon->shmem_bytes));
-    }
-    else
-    {
-        LLOGLN(0, ("AllocSharedMemory: reusing shmemid %d",
+        LLOGLN(0, ("rdpClientConAllocateSharedMemory: reusing shmemid %d",
                clientCon->shmemid));
+        return;
     }
+    
+    if (clientCon->shmemptr != 0)
+    {
+        shmdt(clientCon->shmemptr);
+    }
+    clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
+    clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
+    clientCon->shmem_bytes = bytes;
+    shmctl(clientCon->shmemid, IPC_RMID, NULL);
+    LLOGLN(0, ("rdpClientConAllocateSharedMemory: shmemid %d shmemptr %p bytes %d",
+           clientCon->shmemid, clientCon->shmemptr,
+           clientCon->shmem_bytes));
 }
 /******************************************************************************/
 /*

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -675,6 +675,38 @@ rdpClientConProcessMsgVersion(rdpPtr dev, rdpClientCon *clientCon,
     return 0;
 }
 
+/**************************************************************************//**
+ * Allocate shared memory
+ *
+ * This memory is shared with the xup driver in xrdp which avoids a lot
+ * of unnecessary copying
+ *
+ * @param clientCon Client connection
+ * @param bytes Size of area to attach
+ */
+static void
+AllocSharedMemory(rdpClientCon *clientCon, int bytes)
+{
+    if (clientCon->shmemptr == NULL || clientCon->shmem_bytes != bytes)
+    {
+        if (clientCon->shmemptr != 0)
+        {
+            shmdt(clientCon->shmemptr);
+        }
+        clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
+        clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
+        clientCon->shmem_bytes = bytes;
+        shmctl(clientCon->shmemid, IPC_RMID, NULL);
+        LLOGLN(0, ("AllocSharedMemory: shmemid %d shmemptr %p bytes %d",
+               clientCon->shmemid, clientCon->shmemptr,
+               clientCon->shmem_bytes));
+    }
+    else
+    {
+        LLOGLN(0, ("AllocSharedMemory: reusing shmemid %d",
+               clientCon->shmemid));
+    }
+}
 /******************************************************************************/
 /*
     this from miScreenInit
@@ -727,17 +759,9 @@ rdpClientConProcessScreenSizeMsg(rdpPtr dev, rdpClientCon *clientCon,
 
     clientCon->cap_stride_bytes = clientCon->rdp_width * clientCon->rdp_Bpp;
 
-    if (clientCon->shmemptr != 0)
-    {
-        shmdt(clientCon->shmemptr);
-    }
     bytes = clientCon->rdp_width * clientCon->rdp_height *
             clientCon->rdp_Bpp;
-    clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
-    clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
-    shmctl(clientCon->shmemid, IPC_RMID, NULL);
-    LLOGLN(0, ("rdpClientConProcessScreenSizeMsg: shmemid %d shmemptr %p",
-           clientCon->shmemid, clientCon->shmemptr));
+    AllocSharedMemory(clientCon, bytes);
     clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->rdp_width;
 
     if (clientCon->shmRegion != 0)
@@ -868,17 +892,9 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
         clientCon->cap_height = RDPALIGN(clientCon->rdp_height, 64);
         LLOGLN(0, ("  cap_width %d cap_height %d",
                clientCon->cap_width, clientCon->cap_height));
-        if (clientCon->shmemptr != 0)
-        {
-            shmdt(clientCon->shmemptr);
-        }
         bytes = clientCon->cap_width * clientCon->cap_height *
                 clientCon->rdp_Bpp;
-        clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
-        clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
-        shmctl(clientCon->shmemid, IPC_RMID, NULL);
-        LLOGLN(0, ("rdpClientConProcessMsgClientInfo: shmemid %d shmemptr %p "
-               "bytes %d", clientCon->shmemid, clientCon->shmemptr, bytes));
+        AllocSharedMemory(clientCon, bytes);
         clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
         clientCon->cap_stride_bytes = clientCon->cap_width * 4;
         shmemstatus = SHM_RFX_ACTIVE;
@@ -890,16 +906,8 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
         clientCon->cap_height = clientCon->rdp_height;
         LLOGLN(0, ("  cap_width %d cap_height %d",
                clientCon->cap_width, clientCon->cap_height));
-        if (clientCon->shmemptr != 0)
-        {
-            shmdt(clientCon->shmemptr);
-        }
         bytes = clientCon->cap_width * clientCon->cap_height * 2;
-        clientCon->shmemid = shmget(IPC_PRIVATE, bytes, IPC_CREAT | 0777);
-        clientCon->shmemptr = shmat(clientCon->shmemid, 0, 0);
-        shmctl(clientCon->shmemid, IPC_RMID, NULL);
-        LLOGLN(0, ("rdpClientConProcessMsgClientInfo: shmemid %d shmemptr %p "
-               "bytes %d", clientCon->shmemid, clientCon->shmemptr, bytes));
+        AllocSharedMemory(clientCon, bytes);
         clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
         clientCon->cap_stride_bytes = clientCon->cap_width * 4;
         shmemstatus = SHM_H264_ACTIVE;

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -107,6 +107,7 @@ struct _rdpClientCon
 
     uint8_t *shmemptr;
     int shmemid;
+    int shmem_bytes;
     int shmem_lineBytes;
     RegionPtr shmRegion;
     int rect_id;


### PR DESCRIPTION
As a result of investigating neutrinolabs/xrdp#1928, it was discovered that that when `mstsc.exe` has a single monitor session full-screen, and this session is moved to another monitor and made full-screen, `mstsc.exe` sends two seemingly identical DISPLAYCONTROL_MONITOR_LAYOUT_PDUs for the new screen size in quick succession.

This behaviour was observed on `mstsc.exe` version 10.0.19041.1266. This doesn't seem to be necessary, but we need to deal with it.

[[MS-RDPEDISP]](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedisp/d2954508-f487-48bc-8731-39743e0854a9) has nothing to say on this, except that the server should react to valid messages.

In practice, what happens is that the two messages cause xorgxrdp to reallocate the shared memory area twice. Between the first allocation and the second allocation, an update is send to xup with the id of the first shared memory area. If xup does not process this mesage until after the second area has been allocated, xup fails to connect to the shared memory area, and xrdp exits.

See also neutrinolabs/xrdp#2065 which attempts to improve xrdp logging in this area.

This PR deals with the above situation by only reallocating the shared memory area if it differs in size from the previous area. In use cases like that mentioned in neutrinolabs/xrdp#1928, where a single-monitor session is moved from one monitor to a monitor of the same resolution, this reallocation will be unnecessary anyway.

@Nexarian - I'd very much appreciate your comments on this, particularly as to whether this is the right way to deal with this. I'll be happy to answer any questions you might have.