### PR TITLE
replace non-posix tool `which` with `command -v`

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,27 +1,27 @@
 #!/bin/sh
 
-which autoconf
+command -v autoconf
 if ! test $? -eq 0
 then
   echo "error, install autoconf"
   exit 1
 fi
 
-which automake
+command -v automake
 if ! test $? -eq 0
 then
   echo "error, install automake"
   exit 1
 fi
 
-which libtool || which libtoolize
+command -v libtool || command -v libtoolize
 if ! test $? -eq 0
 then
   echo "error, install libtool"
   exit 1
 fi
 
-which pkg-config
+command -v pkg-config
 if ! test $? -eq 0
 then
   echo "error, install pkg-config"

--- a/tests/xorg-test-run.sh
+++ b/tests/xorg-test-run.sh
@@ -43,7 +43,7 @@ XORG_ARGS="$@"
 
 
 # If the X server has setuid bit, make a local copy
-XORG_FULL=`which $XORG`
+XORG_FULL=`command -v $XORG`
 if test -u $XORG_FULL; then
   XORG=`pwd`/Xorg.no-setuid
   echo "$XORG_FULL has setuid bit set, will use $XORG"


### PR DESCRIPTION
`which` is a non-posix tool that might not be present in restricted
build-environments. It can however be fully replaced by the posix
shell-builtin `command -v`.

See also:
https://lwn.net/Articles/874049/