### PR TITLE
Fix build break in GitHub workflow

### DIFF
--- a/scripts/install_xorgxrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xorgxrdp_build_dependencies_with_apt.sh
@@ -40,7 +40,8 @@ in
         ;;
 esac
 
-exec apt-get -yq \
+apt-get update
+apt-get -yq \
     --no-install-suggests \
     --no-install-recommends \
     $APT_EXTRA_ARGS \


### PR DESCRIPTION
Need to add `apt-get update` to refresh the aptitude cache before
installing dependencies.

The same fix was introduced in XRDP here:

https://github.com/neutrinolabs/xrdp/blob/dd968a98b097f8331a1ffbd4991130056b913833/scripts/install_xrdp_build_dependencies_with_apt.sh#L128