### PR TITLE
mouse: workaround for too fast vertical scroll

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -288,6 +288,7 @@ struct _rdpRec
     int do_dirty_ons; /* boolean */
     int disconnect_scheduled; /* boolean */
     int do_kill_disconnected; /* boolean */
+    int do_touchpad_scroll_hack; /* boolean */
 
     OsTimerPtr disconnectTimer;
     int disconnect_timeout_s;
@@ -296,6 +297,7 @@ struct _rdpRec
     OsTimerPtr idleDisconnectTimer;
     int idle_disconnect_timeout_s;
     CARD32 last_event_time_ms;
+    CARD32 last_wheel_time_ms;
 
     int conNumber;
 

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1473,6 +1473,26 @@ rdpClientConInit(rdpPtr dev)
     LLOGLN(0, ("rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
                dev->do_kill_disconnected, dev->disconnect_timeout_s));
 
+    /* neutrinolabs/xorgxrdp#150 */
+    ptext = getenv("XRDP_XORG_TOUCHPAD_SCROLL_HACK");
+    if (ptext != 0)
+    {
+        i = atoi(ptext);
+	if (i != 0 ||
+            0 == strcasecmp(ptext, "true") ||
+            0 == strcasecmp(ptext, "yes") ||
+            0 == strcasecmp(ptext, "on"))
+	{
+            dev->do_touchpad_scroll_hack = 1;
+	}
+	else
+	{
+            dev->do_touchpad_scroll_hack = 0;
+	}
+    }
+
+    LLOGLN(0, ("rdpClientConInit: do_touchpad_scroll_hack [%d]",
+               dev->do_touchpad_scroll_hack));
 
     return 0;
 }

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -115,6 +115,30 @@ rdpInputMouseEvent(rdpPtr dev, int msg,
 {
     dev->last_event_time_ms = GetTimeInMillis();
 
+    /*
+     * Workaround for too fast vertical scroll on touchpad.
+     * Provided by @seflerZ on neutrinolabs/xorgxrdp#150
+     */
+    if (dev->do_touchpad_scroll_hack)
+    {
+        if (msg == WM_BUTTON4UP ||
+            msg == WM_BUTTON4DOWN ||
+            msg == WM_BUTTON5UP ||
+            msg == WM_BUTTON5DOWN)
+        {
+
+          if (dev->last_event_time_ms - dev->last_wheel_time_ms < 10)
+          {
+              return 0;
+          }
+        }
+
+        if (msg == WM_BUTTON4UP || msg == WM_BUTTON5UP)
+        {
+            dev->last_wheel_time_ms = dev->last_event_time_ms;
+        }
+    }
+
     if (g_input_proc[1].proc != 0)
     {
         return g_input_proc[1].proc(dev, msg, param1, param2, param3, param4);


### PR DESCRIPTION
Provided by @seflerZ at neutrinolabs/xorgxrdp#150.

I tested the patch, 10ms interval looks enough.

----

To enable this hack, edit sesman.ini like this:

```
[SessionVariables]
(some existing lines)
XRDP_XORG_TOUCHPAD_SCROLL_HACK=yes
```