### PR TITLE
Enable touchpad inertial scrolling(fix touchpad scrolls too fast)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ NEWS
 README
 stamp-h1
 test-driver
+.vscode/*

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -288,7 +288,6 @@ struct _rdpRec
     int do_dirty_ons; /* boolean */
     int disconnect_scheduled; /* boolean */
     int do_kill_disconnected; /* boolean */
-    int do_touchpad_scroll_hack; /* boolean */
 
     OsTimerPtr disconnectTimer;
     int disconnect_timeout_s;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1473,26 +1473,6 @@ rdpClientConInit(rdpPtr dev)
     LLOGLN(0, ("rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
                dev->do_kill_disconnected, dev->disconnect_timeout_s));
 
-    /* neutrinolabs/xorgxrdp#150 */
-    ptext = getenv("XRDP_XORG_TOUCHPAD_SCROLL_HACK");
-    if (ptext != 0)
-    {
-        i = atoi(ptext);
-	if (i != 0 ||
-            0 == strcasecmp(ptext, "true") ||
-            0 == strcasecmp(ptext, "yes") ||
-            0 == strcasecmp(ptext, "on"))
-	{
-            dev->do_touchpad_scroll_hack = 1;
-	}
-	else
-	{
-            dev->do_touchpad_scroll_hack = 0;
-	}
-    }
-
-    LLOGLN(0, ("rdpClientConInit: do_touchpad_scroll_hack [%d]",
-               dev->do_touchpad_scroll_hack));
 
     return 0;
 }

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -115,30 +115,6 @@ rdpInputMouseEvent(rdpPtr dev, int msg,
 {
     dev->last_event_time_ms = GetTimeInMillis();
 
-    /*
-     * Workaround for too fast vertical scroll on touchpad.
-     * Provided by @seflerZ on neutrinolabs/xorgxrdp#150
-     */
-    if (dev->do_touchpad_scroll_hack)
-    {
-        if (msg == WM_BUTTON4UP ||
-            msg == WM_BUTTON4DOWN ||
-            msg == WM_BUTTON5UP ||
-            msg == WM_BUTTON5DOWN)
-        {
-
-          if (dev->last_event_time_ms - dev->last_wheel_time_ms < 10)
-          {
-              return 0;
-          }
-        }
-
-        if (msg == WM_BUTTON4UP || msg == WM_BUTTON5UP)
-        {
-            dev->last_wheel_time_ms = dev->last_event_time_ms;
-        }
-    }
-
     if (g_input_proc[1].proc != 0)
     {
         return g_input_proc[1].proc(dev, msg, param1, param2, param3, param4);

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -154,6 +154,9 @@ PtrAddEvent(rdpPointer *pointer)
 }
 
 /******************************************************************************/
+// Maybe make it configurable later
+#define SCALE_FACTOR 10
+
 static void
 PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
 {
@@ -161,11 +164,13 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     int mask_pos;
     int scaled_delta;
 
-    LLOGLN(0, ("PtrAddScrollEvent: vertical %d y %d", vertical, delta));
+    LLOGLN(10, ("PtrAddScrollEvent: vertical %d y %d", vertical, delta));
 
     scroll_events_mask = valuator_mask_new(NAXES);
     mask_pos = vertical ? 2 : 3;
-    scaled_delta = delta / 10 == 0 ? delta > 0 ? 1 : -1 : delta / 10;
+    scaled_delta = delta / SCALE_FACTOR == 0 ? delta > 0 ? 1 : -1 : delta / SCALE_FACTOR;
+
+    // XWindow's and RDP's scrolling directions are exactly oppersite 
     scaled_delta = -scaled_delta;
 
     valuator_mask_zero(scroll_events_mask);

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -171,7 +171,10 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     scaled_delta = delta / SCALE_FACTOR == 0 ? delta > 0 ? 1 : -1 : delta / SCALE_FACTOR;
 
     // XWindow's and RDP's scrolling directions are exactly oppersite 
-    scaled_delta = -scaled_delta;
+    // on vertical(Some document references?).
+    if (vertical) {
+        scaled_delta = -scaled_delta;
+    }
 
     valuator_mask_zero(scroll_events_mask);
     valuator_mask_set_double(scroll_events_mask, mask_pos, scaled_delta);

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -124,7 +124,7 @@ PtrAddEvent(rdpPointer *pointer)
     LLOGLN(10, ("PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y));
 
     if ((pointer->old_cursor_x != pointer->cursor_x) ||
-        (pointer->old_cursor_y != pointer->cursor_y))
+            (pointer->old_cursor_y != pointer->cursor_y))
     {
         rdpEnqueueMotion(pointer->device, pointer->cursor_x, pointer->cursor_y);
         pointer->old_cursor_x = pointer->cursor_x;
@@ -170,9 +170,10 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     mask_pos = vertical ? 2 : 3;
     scaled_delta = delta / SCALE_FACTOR == 0 ? delta > 0 ? 1 : -1 : delta / SCALE_FACTOR;
 
-    // XWindow's and RDP's scrolling directions are exactly oppersite 
-    // on vertical(Some document references?).
-    if (vertical) {
+    // XWindow's and RDP's scrolling directions are exactly opposite
+    // on vertical(Need document references).
+    if (vertical)
+    {
         scaled_delta = -scaled_delta;
     }
 
@@ -195,7 +196,7 @@ rdpInputMouse(rdpPtr dev, int msg,
     rdpPointer *pointer;
 
     LLOGLN(10, ("rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
-           msg, param1, param2, param3, param4));
+                msg, param1, param2, param3, param4));
     pointer = &(dev->pointer);
     switch (msg)
     {
@@ -334,9 +335,9 @@ rdpmouseControl(DeviceIntPtr device, int what)
 
             // Initialize scroll valuators
             xf86InitValuatorAxisStruct(device, 2, axes_labels[2]
-                                        , 0, -1, 0, 0, 0, Relative);
+                                       , 0, -1, 0, 0, 0, Relative);
             xf86InitValuatorAxisStruct(device, 3, axes_labels[3]
-                                        , 0, -1, 0, 0, 0, Relative);
+                                       , 0, -1, 0, 0, 0, Relative);
 
             SetScrollValuator(device, 2, SCROLL_TYPE_VERTICAL, 10, 0);
             SetScrollValuator(device, 3, SCROLL_TYPE_HORIZONTAL, 10, 0);
@@ -377,7 +378,7 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
     InputInfoPtr info;
 
     LLOGLN(0, ("rdpmousePreInit: drv %p dev %p, flags 0x%x",
-           drv, dev, flags));
+               drv, dev, flags));
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
     info->device_control = rdpmouseControl;
@@ -400,7 +401,7 @@ static int
 rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LLOGLN(0, ("rdpmousePreInit: drv %p info %p, flags 0x%x",
-           drv, info, flags));
+               drv, info, flags));
     info->device_control = rdpmouseControl;
     info->type_name = g_Mouse_str;
     return 0;
@@ -413,7 +414,7 @@ static void
 rdpmouseUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LLOGLN(0, ("rdpmouseUnInit: drv %p info %p, flags 0x%x",
-           drv, info, flags));
+               drv, info, flags));
     rdpUnregisterInputCallback(rdpInputMouse);
 }
 


### PR DESCRIPTION
Close #150 @metalefty 
The xrdpMouse module doesn't handle touchpad inertial scrolling properly. At first I was intented to write a touchpad driver, now I found it uncessary. Because the RDP protocol doesn't have a touchpad channel, it should be good to add some touchpad function in the xrdpMouse driver.

Now the scrolling works great both on vertical and horizontal scrollings. Inertial scrolling also supported.
![touchpad-scroll_Trim](https://user-images.githubusercontent.com/2093588/189598314-a9e4f21f-5572-436b-b47c-f2f84d5c41f4.gif)

_Note: Some applications such as Firefox which uses WebKitGTK, have their own inertial handling process, so it won't work on every applications._
