### PR TITLE
Disable some auto-add hardware features

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -12,6 +12,7 @@ Section "ServerFlags"
     Option "DefaultServerLayout" "X11 Server"
     Option "DontVTSwitch" "on"
     Option "AutoAddDevices" "off"
+    Option "AutoAddGPU" "off"
 EndSection
 
 Section "Module"
@@ -57,6 +58,8 @@ EndSection
 Section "Screen"
     Identifier "Screen (xrdpdev)"
     Device "Video Card (xrdpdev)"
+    # Comment out this line for xorg < 1.18.0
+    GPUDevice ""
     Monitor "Monitor"
     DefaultDepth 24
     SubSection "Display"


### PR DESCRIPTION
Addresses neutrinolabs/xrdp#2379 and neutrinolabs/xrdp#2253.

On some systems, GPUs are auto-loaded. These can be incompatible with the xorgxrdp module.

These keywords are not used by us yet, so I've done a quick analysis of contemporary systems. The reason is that these can cause errors on systems which don't expect them.

The `AutoAddGPU` keyword was introduced for xorg 1.13.0. This is no longer used by any contemporary systems.

The GPUDevice keyword was introduced for xorg 1.18.0. This is still used by Ubuntu 16.04 which is technically still supported if you have an ESM contract with Canonical.

Our other long-term enterprise system, RHEL 7, uses Xorg 1.20.

I'm marking this draft for now, as I want to test on Ubuntu 16 and CentOS 7.

@akarl10 - do you have any comments on this PR? I'm pretty sure it's what we've discussed recently.