### PR TITLE
Create a RandR output before the first client connects

### DIFF
--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -491,6 +491,7 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
     }
 
     RRScreenSetSizeRange(pScreen, 256, 256, 16 * 1024, 16 * 1024);
+    rdpRRSetRdpOutputs(dev);
     RRTellChanged(pScreen);
 
     return 0;


### PR DESCRIPTION
Prompted by neutrinolabs/xrdp#2580

This allows clients expecting RandR outputs to work correctly if no client is connected at startup (i.e. if `xrdp-sesrun` is used)