### PR TITLE
Tests - check for undefined symbols in modules

### DIFF
--- a/tests/xorg-test-run.sh
+++ b/tests/xorg-test-run.sh
@@ -65,6 +65,12 @@ moduledir="$top_builddir/xrdpkeyb/.libs,$moduledir"
 moduledir="$top_builddir/xrdpmouse/.libs,$moduledir"
 
 # Run Xorg with compiled modules as a background task
+#
+# [Linux]   Set LD_BIND_NOW (see dlopen(3)) to disable lazy symbol
+#           resolution so we check the modules for undefined symbols.
+# [FreeBSD] Setting LD_BIND_NOW does not affect the operation of
+#           dlopen()
+LD_BIND_NOW=1 \
 $XORG \
   -modulepath $moduledir \
   -config $top_srcdir/xrdpdev/xorg.conf \


### PR DESCRIPTION
This small change is prompted by Jay's comments regarding Devuan 4 and `shm_open` not being in libc on this platform.

By default, Xorg module symbols are resolved 'lazily'. They are not resolved when the module is loaded, but when they are encountered at runtime. If an undefined symbol is encountered, this can result in the X server log just stopping with no clues. This can be hard to reproduce as the tests do not cover all code paths.

With this change an unresolveable symbol is reported in the `make check` X server log. For example, if I make this change:-

```patch
--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -570,6 +570,9 @@ g_alloc_shm_map_fd(void **addr, int *fd, size_t size)
     char name[128];
     static unsigned int autoinc;
 
+    extern void undef_test_sym(void);
+    undef_test_sym();
+
     snprintf(name, 128, "/%8.8X%8.8X", getpid(), autoinc++);
     lfd = shm_open(name, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (lfd == -1)
```

the existing `make check` completes without errors as `undef_test_sym` is only encountered when xrdp connects to the driver.

With the PR `make check` fails. `tests/test-xorg.log` contains these lines:-

```
[  9357.499] (II) LoadModule: "xorgxrdp"
[  9357.499] (II) Loading /home/mjb/xorgxrdp/module/.libs/libxorgxrdp.so
[  9357.499] (EE) Failed to load /home/mjb/xorgxrdp/module/.libs/libxorgxrdp.so: /home/mjb/xorgxrdp/module/.libs/libxorgxrdp.so: undefined symbol: undef_test_sym
[  9357.499] (EE) Failed to load module "xorgxrdp" (loader failed, 0)
```