### PR TITLE
Gfx mainline merge multimon1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
-      - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
+      - run: git clone --depth 1 --branch=gfx_mainline_merge_work https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
       - run: ./bootstrap
       - run: ./configure ${{ matrix.CONF_FLAGS }}
       - run: make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,9 @@ if test "x${with_simd}" != "xno"; then
   fi
 fi
 
+# shm_open may not be in the C library
+AC_SEARCH_LIBS([shm_open], [rt])
+
 AC_ARG_ENABLE(glamor, AS_HELP_STRING([--enable-glamor],
               [Use glamor(requires xorg server 1.19+) (default: no)]),
               [], [enable_glamor=no])

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -60,29 +60,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         b = (c) & 0xff; \
     } while (0)
 
-/* PIXMAN_a8b8g8r8 */
-#define XRDP_a8b8g8r8 \
-((32 << 24) | (3 << 16) | (8 << 12) | (8 << 8) | (8 << 4) | 8)
-/* PIXMAN_a8r8g8b8 */
-#define XRDP_a8r8g8b8 \
-((32 << 24) | (2 << 16) | (8 << 12) | (8 << 8) | (8 << 4) | 8)
-/* PIXMAN_r5g6b5 */
-#define XRDP_r5g6b5 \
-((16 << 24) | (2 << 16) | (0 << 12) | (5 << 8) | (6 << 4) | 5)
-/* PIXMAN_a1r5g5b5 */
-#define XRDP_a1r5g5b5 \
-((16 << 24) | (2 << 16) | (1 << 12) | (5 << 8) | (5 << 4) | 5)
-/* PIXMAN_r3g3b2 */
-#define XRDP_r3g3b2 \
-((8 << 24) | (2 << 16) | (0 << 12) | (3 << 8) | (3 << 4) | 2)
-
-/* XRDP_nv12 */
-#define XRDP_nv12 \
-((12 << 24) | (64 << 16) | (0 << 12) | (0 << 8) | (0 << 4) | 0)
-/* XRDP_nv12 */
-#define XRDP_i420 \
-((12 << 24) | (65 << 16) | (0 << 12) | (0 << 8) | (0 << 4) | 0)
-
 #define PixelToMM(_size, _dpi) (((_size) * 254 + (_dpi) * 5) / ((_dpi) * 10))
 
 #define RDPMIN(_val1, _val2) ((_val1) < (_val2) ? (_val1) : (_val2))
@@ -90,6 +67,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define RDPCLAMP(_val, _lo, _hi) \
     ((_val) < (_lo) ? (_lo) : (_val) > (_hi) ? (_hi) : (_val))
 #define RDPALIGN(_val, _al) ((((uintptr_t)(_val)) + ((_al) - 1)) & ~((_al) - 1))
+
+#define XRDP_RFX_ALIGN 64
+#define XRDP_H264_ALIGN 16
 
 #define XRDP_CD_NODRAW 0
 #define XRDP_CD_NOCLIP 1
@@ -122,6 +102,7 @@ struct image_data
     int bpp;
     int Bpp;
     int lineBytes;
+    int flags;
     uint8_t *pixels;
     uint8_t *shmem_pixels;
     int shmem_fd;

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -97,6 +97,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct image_data
 {
+    int left;
+    int top;
     int width;
     int height;
     int bpp;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -873,7 +873,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     src = id->pixels;
     dst = id->shmem_pixels;
     src_stride = id->lineBytes;
-    dst_stride = id->shmem_lineBytes;
+    dst_stride = ((id->width + 63) & ~63) * 4;
 
     src = src + src_stride * id->top + id->left * 4;
 

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -850,6 +850,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int crc_stride;
     int crc;
     int num_crcs;
+    int mon_index;
 
     LLOGLN(10, ("rdpCapture2:"));
 
@@ -867,19 +868,26 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     out_rect_index = 0;
 
+    rdpRegionTranslate(in_reg, -id->left, -id->top);
+
     src = id->pixels;
     dst = id->shmem_pixels;
     src_stride = id->lineBytes;
-    dst_stride = clientCon->cap_stride_bytes;
+    dst_stride = id->shmem_lineBytes;
 
-    crc_stride = (clientCon->dev->width + 63) / 64.0;
-    num_crcs = crc_stride * ((clientCon->dev->height + 63) / 64.0);
-    if (num_crcs != clientCon->num_rfx_crcs_alloc)
+    src = src + src_stride * id->top + id->left * 4;
+
+    mon_index = (id->flags >> 28) & 0xF;
+    crc_stride = (id->width + 63) / 64;
+    num_crcs = crc_stride * ((id->height + 63) / 64);
+    if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
+        LLOGLN(0, ("rdpCapture2: resize the crc list was %d now %d",
+               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
         /* resize the crc list */
-        clientCon->num_rfx_crcs_alloc = num_crcs;
-        free(clientCon->rfx_crcs);
-        clientCon->rfx_crcs = g_new0(int, num_crcs);
+        clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
+        free(clientCon->rfx_crcs[mon_index]);
+        clientCon->rfx_crcs[mon_index] = g_new0(int, num_crcs);
     }
 
     extents_rect = *rdpRegionExtents(in_reg);
@@ -936,8 +944,8 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 crc_offset = (y / XRDP_RFX_ALIGN) * crc_stride 
                              + (x / XRDP_RFX_ALIGN);
                 LLOGLN(10, ("rdpCapture2: crc 0x%8.8x 0x%8.8x",
-                       crc, clientCon->rfx_crcs[crc_offset]));
-                if (crc == clientCon->rfx_crcs[crc_offset])
+                       crc, clientCon->rfx_crcs[mon_index][crc_offset]));
+                if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
                     LLOGLN(10, ("rdpCapture2: crc skip at x %d y %d", x, y));
                     rdpRegionInit(&tile_reg, &rect, 0);
@@ -946,7 +954,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 else
                 {
-                    clientCon->rfx_crcs[crc_offset] = crc;
+                    clientCon->rfx_crcs[mon_index][crc_offset] = crc;
                     (*out_rects)[out_rect_index] = rect;
                     out_rect_index++;
                     if (out_rect_index >= RDP_MAX_TILES)
@@ -1126,7 +1134,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     if (clientCon->dev->glamor)
     {
 #if defined(XORGXRDP_GLAMOR)
-        if (mode == 2)
+        if ((mode == 2) || (mode == 4))
         {
             return rdpEglCaptureRfx(clientCon, in_reg, out_rects,
                                     num_out_rects, id);
@@ -1141,9 +1149,11 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         case 1:
             return rdpCapture1(clientCon, in_reg, out_rects, num_out_rects, id);
         case 2:
+        case 4:
             /* used for remotefx capture */
             return rdpCapture2(clientCon, in_reg, out_rects, num_out_rects, id);
         case 3:
+        case 5:
             /* used for even align capture */
             return rdpCapture3(clientCon, in_reg, out_rects, num_out_rects, id);
         default:

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -891,12 +891,19 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         {
             rect.x1 = x;
             rect.y1 = y;
-            rect.x2 = rect.x1 + 64;
-            rect.y2 = rect.y1 + 64;
+            rect.x2 = rect.x1 + XRDP_RFX_ALIGN;
+            rect.y2 = rect.y1 + XRDP_RFX_ALIGN;
             rcode = rdpRegionContainsRect(in_reg, &rect);
             LLOGLN(10, ("rdpCapture2: rcode %d", rcode));
 
-            if (rcode != rgnOUT)
+            if (rcode == rgnOUT)
+            {
+                LLOGLN(0, ("rdpCapture2: rgnOUT"));
+                rdpRegionInit(&tile_reg, &rect, 0);
+                rdpRegionSubtract(in_reg, in_reg, &tile_reg);
+                rdpRegionUninit(&tile_reg);
+            }
+            else
             {
                 crc = crc_start();
                 if (rcode == rgnPART)
@@ -933,6 +940,9 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 if (crc == clientCon->rfx_crcs[crc_offset])
                 {
                     LLOGLN(10, ("rdpCapture2: crc skip at x %d y %d", x, y));
+                    rdpRegionInit(&tile_reg, &rect, 0);
+                    rdpRegionSubtract(in_reg, in_reg, &tile_reg);
+                    rdpRegionUninit(&tile_reg);
                 }
                 else
                 {
@@ -947,9 +957,9 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     }
                 }
             }
-            x += 64;
+            x += XRDP_RFX_ALIGN;
         }
-        y += 64;
+        y += XRDP_RFX_ALIGN;
     }
     *num_out_rects = out_rect_index;
     return TRUE;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -898,7 +898,7 @@ rdpCapture2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
             if (rcode == rgnOUT)
             {
-                LLOGLN(0, ("rdpCapture2: rgnOUT"));
+                LLOGLN(10, ("rdpCapture2: rgnOUT"));
                 rdpRegionInit(&tile_reg, &rect, 0);
                 rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                 rdpRegionUninit(&tile_reg);

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -885,6 +885,133 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
     return 0;
 }
 
+int
+rdpClientConPreCheck(rdpPtr dev, rdpClientCon *clientCon, int in_size);
+
+/******************************************************************************/
+static int
+rdpSendGfxMonitors(rdpPtr dev, rdpClientCon *clientCon)
+{
+    int x;
+    int y;
+    int width;
+    int height;
+    int index;
+    int size;
+    int monitor_count;
+    int reset_bytes;
+    int create_surface_bytes;
+    int map_surface_bytes;
+    int surface_id;
+    int pixel_format;
+    int total_cmd_bytes;
+    struct monitor_info lmi;
+    struct monitor_info *mi;
+    struct monitor_info *vmi;
+    struct stream *s;
+
+    rdpClientConBeginUpdate(dev, clientCon);
+
+    monitor_count = clientCon->client_info.display_sizes.monitorCount;
+    width = clientCon->client_info.display_sizes.session_width;
+    height = clientCon->client_info.display_sizes.session_height;
+    pixel_format = 0x20; /* XR_PIXEL_FORMAT_XRGB_8888 */
+
+    if (monitor_count < 1)
+    {
+        memset(&lmi, 0, sizeof(struct monitor_info));
+        lmi.right = width - 1;
+        lmi.bottom = height - 1;
+        lmi.is_primary = 1;
+        vmi = &lmi;
+        monitor_count = 1;
+    }
+    else
+    {
+        vmi = clientCon->client_info.display_sizes.minfo_wm;
+    }
+
+    LLOGLN(0, ("rdpSendGfxMonitors: monitor_count %d width %d height %d",
+           monitor_count, width, height));
+
+    reset_bytes = 8 + 12 + monitor_count * 20;
+    create_surface_bytes = 8 + 7;
+    map_surface_bytes = 8 + 10;
+
+    size = 2 + 2;                   /* header */
+    size += 4;                      /* message 62 cmd_bytes */
+    size += reset_bytes;            /* reset gfx message */
+    size += monitor_count *         /* create surface message(s) */
+            create_surface_bytes;
+    size += monitor_count *         /* map surface message(s) */
+            map_surface_bytes;
+    size += 4;                      /* message 62 data_bytes */
+
+    LLOGLN(0, ("rdpSendGfxMonitors: reset_bytes %d create_surface_bytes %d "
+           "map_surface_bytes %d size %d",
+           reset_bytes, create_surface_bytes, map_surface_bytes, size));
+
+    rdpClientConPreCheck(dev, clientCon, size);
+    s = clientCon->out_s;
+    out_uint16_le(s, 62);
+    out_uint16_le(s, size);
+    clientCon->count++;
+
+    total_cmd_bytes = reset_bytes +
+                  monitor_count * create_surface_bytes +
+                  monitor_count * map_surface_bytes;
+    out_uint32_le(s, total_cmd_bytes);
+
+    /* XR_RDPGFX_CMDID_RESETGRAPHICS */
+    out_uint16_le(s, 0x000E);
+    out_uint16_le(s, 0);                    /* flags */
+    out_uint32_le(s, reset_bytes);          /* cmd_bytes */
+    out_uint32_le(s, width);
+    out_uint32_le(s, height);
+    out_uint32_le(s, monitor_count);
+    for (index = 0; index < monitor_count; index++)
+    {
+        mi = vmi + index;
+        out_uint32_le(s, mi->left);
+        out_uint32_le(s, mi->top);
+        out_uint32_le(s, mi->right);
+        out_uint32_le(s, mi->bottom);
+        out_uint32_le(s, mi->is_primary);
+    }
+
+    for (index = 0; index < monitor_count; index++)
+    {
+        surface_id = index;
+        mi = vmi + index;
+        x = mi->left;
+        y = mi->top;
+        width = (mi->right - mi->left) + 1;
+        height = (mi->bottom - mi->top) + 1;
+
+        /* XR_RDPGFX_CMDID_CREATESURFACE */
+        out_uint16_le(s, 0x0009);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, create_surface_bytes); /* cmd_bytes */
+        out_uint16_le(s, surface_id);
+        out_uint16_le(s, width);
+        out_uint16_le(s, height);
+        out_uint8(s, pixel_format);
+
+        /* XR_RDPGFX_CMDID_MAPSURFACETOOUTPUT */
+        out_uint16_le(s, 0x000F);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, map_surface_bytes);    /* cmd_bytes */
+        out_uint16_le(s, surface_id);
+        out_uint32_le(s, x);
+        out_uint32_le(s, y);
+    }
+
+    out_uint32_le(s, 0);                        /* data_bytes */
+
+    rdpClientConEndUpdate(dev, clientCon);
+    return 0;
+}
+
 /******************************************************************************/
 static int
 rdpSendMemoryAllocationComplete(rdpPtr dev, rdpClientCon *clientCon)
@@ -899,9 +1026,11 @@ rdpSendMemoryAllocationComplete(rdpPtr dev, rdpClientCon *clientCon)
     switch (clientCon->client_info.capture_code)
     {
         case 2:
+        case 4:
             alignment = XRDP_RFX_ALIGN;
             break;
         case 3:
+        case 5:
             alignment = XRDP_H264_ALIGN;
             break;
         default:
@@ -969,7 +1098,8 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     i1 = clientCon->client_info.offscreen_cache_entries;
     LLOGLN(0, ("  offscreen entries %d", i1));
 
-    if (clientCon->client_info.capture_code == 2) /* RFX */
+    if ((clientCon->client_info.capture_code == 2) || /* RFX */
+        (clientCon->client_info.capture_code == 4))
     {
         LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
         clientCon->cap_width = RDPALIGN(clientCon->rdp_width, XRDP_RFX_ALIGN);
@@ -983,7 +1113,8 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
         clientCon->cap_stride_bytes = clientCon->cap_width * 4;
         shmemstatus = SHM_RFX_ACTIVE_PENDING;
     }
-    else if (clientCon->client_info.capture_code == 3) /* H264 */
+    else if ((clientCon->client_info.capture_code == 3) || /* H264 */
+             (clientCon->client_info.capture_code == 5))
     {
         LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
         clientCon->cap_width = clientCon->rdp_width;
@@ -1142,6 +1273,12 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     rdpSendMemoryAllocationComplete(dev, clientCon);
     rdpClientConAddDirtyScreen(dev, clientCon, 0, 0, clientCon->rdp_width,
                                clientCon->rdp_height);
+
+    if ((clientCon->client_info.capture_code == 4) ||
+        (clientCon->client_info.capture_code == 5))
+    {
+        rdpSendGfxMonitors(dev, clientCon);
+    }
 
     return 0;
 }
@@ -2471,25 +2608,78 @@ rdpClientConCheckDirtyScreen(rdpPtr dev, rdpClientCon *clientCon)
 
 /******************************************************************************/
 static int
+out_rects_dr(struct stream *s,
+             BoxPtr rects_d, int num_rects_d,
+             BoxPtr rects_c, int num_rects_c)
+{
+    int index;
+    BoxRec box;
+    short x;
+    short y;
+    short cx;
+    short cy;
+
+    out_uint16_le(s, num_rects_d);
+    for (index = 0; index < num_rects_d; index++)
+    {
+        box = rects_d[index];
+        x = box.x1;
+        y = box.y1;
+        cx = box.x2 - box.x1;
+        cy = box.y2 - box.y1;
+        out_uint16_le(s, x);
+        out_uint16_le(s, y);
+        out_uint16_le(s, cx);
+        out_uint16_le(s, cy);
+        LLOGLN(10, ("out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
+               index, x, y, cx, cy));
+    }
+    out_uint16_le(s, num_rects_c);
+    for (index = 0; index < num_rects_c; index++)
+    {
+        box = rects_c[index];
+        x = box.x1;
+        y = box.y1;
+        cx = box.x2 - box.x1;
+        cy = box.y2 - box.y1;
+        out_uint16_le(s, x);
+        out_uint16_le(s, y);
+        out_uint16_le(s, cx);
+        out_uint16_le(s, cy);
+        LLOGLN(10, ("out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
+               index, x, y, cx, cy));
+    }
+    return 0;
+}
+
+/******************************************************************************/
+static int
 rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
                                struct image_data *id,
                                RegionPtr dirtyReg,
                                BoxPtr copyRects, int numCopyRects)
 {
-    int index;
     int size;
     int num_rects_d;
     int num_rects_c;
-    short x;
-    short y;
-    short cx;
-    short cy;
     struct stream *s;
-    BoxRec box;
+    int capture_code;
+    int start_frame_bytes;
+    int wiretosurface1_bytes;
+    int wiretosurface2_bytes;
+    int end_frame_bytes;
+    int surface_id;
 
     LLOGLN(10, ("rdpClientConSendPaintRectShmFd:"));
+    LLOGLN(10, ("rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
+           "cap_width %d cap_height %d",
+           clientCon->cap_left, clientCon->cap_top,
+           clientCon->cap_width, clientCon->cap_height));
+    LLOGLN(10, ("rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
+           "id->left %d id->top %d id->width %d id->height %d",
+           id->flags, id->left, id->top, id->width, id->height));
 
-    rdpClientConBeginUpdate(dev, clientCon);
+    capture_code = clientCon->client_info.capture_code;
 
     num_rects_d = REGION_NUM_RECTS(dirtyReg);
     num_rects_c = numCopyRects;
@@ -2498,55 +2688,185 @@ rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
         LLOGLN(10, ("rdpClientConSendPaintRectShmFd: nothing to send"));
         return 0;
     }
-    size = 2 + 2 + 2 + num_rects_d * 8 + 2 + num_rects_c * 8;
-    size += 4 + 4 + 4 + 4 + 2 + 2 + 2 + 2;
-    rdpClientConPreCheck(dev, clientCon, size);
 
-    s = clientCon->out_s;
-    out_uint16_le(s, 64);
-    out_uint16_le(s, size);
-    clientCon->count++;
+    rdpClientConBeginUpdate(dev, clientCon);
 
-    out_uint16_le(s, num_rects_d);
-    for (index = 0; index < num_rects_d; index++)
+    if (capture_code < 4)
     {
-        box = REGION_RECTS(dirtyReg)[index];
-        x = box.x1;
-        y = box.y1;
-        cx = box.x2 - box.x1;
-        cy = box.y2 - box.y1;
-        out_uint16_le(s, x);
-        out_uint16_le(s, y);
-        out_uint16_le(s, cx);
-        out_uint16_le(s, cy);
-    }
+        /* non gfx */
+        size = 2 + 2 + 2 + num_rects_d * 8 + 2 + num_rects_c * 8;
+        size += 4 + 4 + 4 + 4 + 2 + 2 + 2 + 2 + 2 + 2;
+        rdpClientConPreCheck(dev, clientCon, size);
 
-    out_uint16_le(s, num_rects_c);
-    for (index = 0; index < num_rects_c; index++)
+        s = clientCon->out_s;
+        out_uint16_le(s, 64);
+        out_uint16_le(s, size);
+        clientCon->count++;
+
+        out_rects_dr(s, REGION_RECTS(dirtyReg), num_rects_d,
+                     copyRects, num_rects_c);
+
+        out_uint32_le(s, id->flags);
+        ++clientCon->rect_id;
+        out_uint32_le(s, clientCon->rect_id);
+        out_uint32_le(s, id->shmem_bytes);
+        out_uint32_le(s, id->shmem_offset);
+        out_uint16_le(s, id->left);
+        out_uint16_le(s, id->top);
+        out_uint16_le(s, id->width);
+        out_uint16_le(s, id->height);
+        out_uint16_le(s, clientCon->cap_width);
+        out_uint16_le(s, clientCon->cap_height);
+        rdpClientConSendPending(clientCon->dev, clientCon);
+        g_sck_send_fd_set(clientCon->sck, "int", 4, &(id->shmem_fd), 1);
+    }
+    else if (capture_code == 4) /* gfx pro rfx */
     {
-        box = copyRects[index];
-        x = box.x1;
-        y = box.y1;
-        cx = box.x2 - box.x1;
-        cy = box.y2 - box.y1;
-        out_uint16_le(s, x);
-        out_uint16_le(s, y);
-        out_uint16_le(s, cx);
-        out_uint16_le(s, cy);
+        start_frame_bytes = 8 + 8;
+        wiretosurface2_bytes = 8 + 13 +
+                               2 + num_rects_d * 8 +
+                               2 + num_rects_c * 8 +
+                               12;
+        end_frame_bytes = 8 + 4;
+
+        size = 2 + 2;                   /* header */
+        size += 4;                      /* message 62 cmd_bytes */
+        size += start_frame_bytes;      /* start frame message */
+        size += wiretosurface2_bytes;   /* frame message */
+        size += end_frame_bytes;        /* end frame message */
+        size += 4;                      /* message 62 data_bytes */
+
+        rdpClientConPreCheck(dev, clientCon, size);
+        s = clientCon->out_s;
+        out_uint16_le(s, 62);
+        out_uint16_le(s, size);
+        clientCon->count++;
+
+        out_uint32_le(s, start_frame_bytes +
+                        wiretosurface2_bytes +
+                        end_frame_bytes); /* total of cmd_bytes */
+
+        ++clientCon->rect_id;
+
+        /* XR_RDPGFX_CMDID_STARTFRAME */
+        out_uint16_le(s, 0x000B);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, start_frame_bytes);    /* cmd_bytes */
+        out_uint32_le(s, clientCon->rect_id);   /* frame_id */
+        out_uint32_le(s, 0);                    /* time_stamp */
+
+        surface_id = (id->flags >> 28) & 0xF;
+        /* XR_RDPGFX_CMDID_WIRETOSURFACE_2 */
+        out_uint16_le(s, 0x0002);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, wiretosurface2_bytes); /* cmd_bytes */
+        out_uint16_le(s, surface_id);           /* surface_id */
+        out_uint16_le(s, 0x0009);               /* codec_id */
+        out_uint32_le(s, 0);                    /* codec_context_id */
+        out_uint8(s, 0x20);                     /* pixel_format */
+
+        out_uint32_le(s, id->flags);            /* flags */
+
+        out_rects_dr(s, REGION_RECTS(dirtyReg), num_rects_d,
+                     copyRects, num_rects_c);
+
+        out_uint16_le(s, id->left);
+        out_uint16_le(s, id->top);
+        out_uint16_le(s, id->width);
+        out_uint16_le(s, id->height);
+        out_uint16_le(s, clientCon->cap_width);
+        out_uint16_le(s, clientCon->cap_height);
+
+        /* XR_RDPGFX_CMDID_ENDFRAME */
+        out_uint16_le(s, 0x000C);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, end_frame_bytes);      /* cmd_bytes */
+        out_uint32_le(s, clientCon->rect_id);   /* frame_id */
+
+        if ((id->shmem_bytes > 0) && ((id->flags & 1) == 0))
+        {
+            out_uint32_le(s, id->shmem_bytes);  /* shmem_bytes */
+            rdpClientConSendPending(clientCon->dev, clientCon);
+            g_sck_send_fd_set(clientCon->sck, "int", 4, &(id->shmem_fd), 1);
+        }
+        else
+        {
+            out_uint32_le(s, 0);                /* shmem_bytes */
+        }
     }
+    else if (capture_code == 5) /* gfx h264 */
+    {
+        start_frame_bytes = 8 + 8;
+        wiretosurface1_bytes = 8 + 9 +
+                               2 + num_rects_d * 8 +
+                               2 + num_rects_c * 8 +
+                               12;
+        end_frame_bytes = 8 + 4;
 
-    out_uint32_le(s, id->flags);
-    clientCon->rect_id++;
-    out_uint32_le(s, clientCon->rect_id);
-    out_uint32_le(s, id->shmem_bytes);
-    out_uint32_le(s, id->shmem_offset);
-    out_uint16_le(s, clientCon->cap_left);
-    out_uint16_le(s, clientCon->cap_top);
-    out_uint16_le(s, clientCon->cap_width);
-    out_uint16_le(s, clientCon->cap_height);
+        size = 2 + 2;                   /* header */
+        size += 4;                      /* message 62 cmd_bytes */
+        size += start_frame_bytes;      /* start frame message */
+        size += wiretosurface1_bytes;   /* frame message */
+        size += end_frame_bytes;        /* end frame message */
+        size += 4;                      /* message 62 data_bytes */
 
-    rdpClientConSendPending(clientCon->dev, clientCon);
-    g_sck_send_fd_set(clientCon->sck, "int", 4, &(id->shmem_fd), 1);
+        rdpClientConPreCheck(dev, clientCon, size);
+        s = clientCon->out_s;
+        out_uint16_le(s, 62);
+        out_uint16_le(s, size);
+        clientCon->count++;
+
+        out_uint32_le(s, start_frame_bytes +
+                        wiretosurface1_bytes +
+                        end_frame_bytes); /* total of cmd_bytes */
+
+        ++clientCon->rect_id;
+
+        /* XR_RDPGFX_CMDID_STARTFRAME */
+        out_uint16_le(s, 0x000B);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, start_frame_bytes);    /* cmd_bytes */
+        out_uint32_le(s, clientCon->rect_id);   /* frame_id */
+        out_uint32_le(s, 0);                    /* time_stamp */
+
+        surface_id = (id->flags >> 28) & 0xF;
+        /* XR_RDPGFX_CMDID_WIRETOSURFACE_1 */
+        out_uint16_le(s, 0x0001);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, wiretosurface1_bytes); /* cmd_bytes */
+        out_uint16_le(s, surface_id);           /* surface_id */
+        out_uint16_le(s, 0x000B);               /* codec_id */
+        out_uint8(s, 0x20);                     /* pixel_format */
+
+        out_uint32_le(s, id->flags);            /* flags */
+
+        out_rects_dr(s, REGION_RECTS(dirtyReg), num_rects_d,
+                     copyRects, num_rects_c);
+
+        out_uint16_le(s, id->left);
+        out_uint16_le(s, id->top);
+        out_uint16_le(s, id->width);
+        out_uint16_le(s, id->height);
+        out_uint16_le(s, clientCon->cap_width);
+        out_uint16_le(s, clientCon->cap_height);
+
+        /* XR_RDPGFX_CMDID_ENDFRAME */
+        out_uint16_le(s, 0x000C);
+        out_uint16_le(s, 0);                    /* flags */
+        out_uint32_le(s, end_frame_bytes);      /* cmd_bytes */
+        out_uint32_le(s, clientCon->rect_id);   /* frame_id */
+
+        if ((id->shmem_bytes > 0) && ((id->flags & 1) == 0))
+        {
+            out_uint32_le(s, id->shmem_bytes);  /* shmem_bytes */
+            rdpClientConSendPending(clientCon->dev, clientCon);
+            g_sck_send_fd_set(clientCon->sck, "int", 4, &(id->shmem_fd), 1);
+        }
+        else
+        {
+            out_uint32_le(s, 0);                /* shmem_bytes */
+        }
+    }
 
     rdpClientConEndUpdate(dev, clientCon);
 
@@ -2564,7 +2884,7 @@ static int
 rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
 {
     RegionPtr cap_dirty;
-    BoxRec rect;
+    RegionPtr cap_dirty_save;
     BoxPtr rects;
     int num_rects;
 
@@ -2572,17 +2892,12 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
     LLOGLN(10, ("rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
                cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2));
     rdpRegionIntersect(cap_dirty, cap_dirty, clientCon->dirtyRegion);
+    /* make a copy of cap_dirty because it may get altered */
+    cap_dirty_save = rdpRegionCreate(NullBox, 0);
+    rdpRegionCopy(cap_dirty_save, cap_dirty);
     num_rects = REGION_NUM_RECTS(cap_dirty);
     if (num_rects > 0)
     {
-        if (num_rects > MAX_CAPTURE_RECTS)
-        {
-            /* the dirty region is too complex, just get a rect that
-               covers the whole region */
-            rect = *rdpRegionExtents(cap_dirty);
-            rdpRegionDestroy(cap_dirty);
-            cap_dirty = rdpRegionCreate(&rect, 0);
-        }
         rects = 0;
         num_rects = 0;
         LLOGLN(10, ("rdpCapRect: capture_code %d",
@@ -2605,8 +2920,9 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
         }
     }
     rdpRegionSubtract(clientCon->dirtyRegion, clientCon->dirtyRegion,
-                      cap_dirty);
+                      cap_dirty_save);
     rdpRegionDestroy(cap_dirty);
+    rdpRegionDestroy(cap_dirty_save);
     return 0;
 }
 
@@ -2725,6 +3041,12 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             cap_rect.y1 = clientCon->dev->minfo[index].top;
             cap_rect.x2 = clientCon->dev->minfo[index].right + 1;
             cap_rect.y2 = clientCon->dev->minfo[index].bottom + 1;
+            rdpClientConGetScreenImageRect(clientCon->dev, clientCon, &id);
+            id.left = cap_rect.x1;
+            id.top = cap_rect.y1;
+            id.width = cap_rect.x2 - cap_rect.x1;
+            id.height = cap_rect.y2 - cap_rect.y1;
+            id.flags = (index & 0xF) << 28;
             rdpCapRect(clientCon, &cap_rect, &id);
             monitor_index++;
         }
@@ -2825,11 +3147,14 @@ void
 rdpClientConGetScreenImageRect(rdpPtr dev, rdpClientCon *clientCon,
                                struct image_data *id)
 {
+    id->left = 0;
+    id->top = 0;
     id->width = dev->width;
     id->height = dev->height;
     id->bpp = clientCon->rdp_bpp;
     id->Bpp = clientCon->rdp_Bpp;
     id->lineBytes = dev->paddedWidthInBytes;
+    id->flags = 0;
     id->pixels = dev->pfbMemory;
     id->shmem_pixels = clientCon->shmemptr;
     id->shmem_fd = clientCon->shmemfd;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -2589,6 +2589,11 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, struct image_data *id)
         if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, id))
         {
             LLOGLN(10, ("rdpCapRect: num_rects %d", num_rects));
+            if (clientCon->rect_id_ack == INT_MAX)
+            {
+                id->flags = (enum xrdp_encoder_flags)
+                            ((int)id->flags | KEY_FRAME_REQUESTED);
+            }
             rdpClientConSendPaintRectShmFd(clientCon->dev, clientCon, id,
                                            cap_dirty, rects, num_rects);
             free(rects);

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -52,6 +52,9 @@ struct rdpup_os_bitmap
 enum shared_memory_status {
     SHM_UNINITIALIZED = 0,
     SHM_RESIZING,
+    SHM_ACTIVE_PENDING,
+    SHM_RFX_ACTIVE_PENDING,
+    SHM_H264_ACTIVE_PENDING,
     SHM_ACTIVE,
     SHM_RFX_ACTIVE,
     SHM_H264_ACTIVE

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -122,8 +122,8 @@ struct _rdpClientCon
 
     RegionPtr dirtyRegion;
 
-    int num_rfx_crcs_alloc;
-    int *rfx_crcs;
+    int num_rfx_crcs_alloc[16];
+    int *rfx_crcs[16];
 
     /* true = skip drawing */
     int suppress_output;

--- a/module/rdpDraw.h
+++ b/module/rdpDraw.h
@@ -49,7 +49,8 @@ misc draw calls
     ) || \
     ( \
         ((_drw)->type == DRAWABLE_PIXMAP) && \
-        (((PixmapPtr)(_drw))->devPrivate.ptr == (_dev)->pfbMemory) \
+            (_drw)->pScreen->GetScreenPixmap((_drw)->pScreen) == \
+            (PixmapPtr)(_drw) \
     ) \
 )
 

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -545,6 +545,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     int out_rect_index;
     int status;
     BoxRec rect;
+    RegionRec tile_reg;
     uint8_t *dst;
     uint8_t *tile_dst;
     int crc_offset;
@@ -590,7 +591,14 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
             LLOGLN(10, ("rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
                    rect.x1, rect.y1, rect.x2, rect.y2));
             rcode = rdpRegionContainsRect(in_reg, &rect);
-            if (rcode != rgnOUT)
+            if (rcode == rgnOUT)
+            {
+                LLOGLN(10, ("rdpEglOut: rgnOUT"));
+                rdpRegionInit(&tile_reg, &rect, 0);
+                rdpRegionSubtract(in_reg, in_reg, &tile_reg);
+                rdpRegionUninit(&tile_reg);
+            }
+            else
             {
                 lx = x - tile_extents_rect->x1;
                 ly = y - tile_extents_rect->y1;
@@ -614,6 +622,9 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 if (crc == clientCon->rfx_crcs[crc_offset])
                 {
                     LLOGLN(10, ("rdpEglOut: crc skip at x %d y %d", x, y));
+                    rdpRegionInit(&tile_reg, &rect, 0);
+                    rdpRegionSubtract(in_reg, in_reg, &tile_reg);
+                    rdpRegionUninit(&tile_reg);
                 }
                 else
                 {

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -553,7 +553,9 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     int crc;
     int num_crcs;
     int tile_extents_stride;
+    int mon_index;
 
+    mon_index = (id->flags >> 28) & 0xF;
     glBindFramebuffer(GL_FRAMEBUFFER, egl->fb[0]);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                            GL_TEXTURE_2D, tex, 0);
@@ -563,18 +565,18 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
         LLOGLN(0, ("rdpEglOut: glCheckFramebufferStatus error"));
     }
     dst = id->shmem_pixels;
-    dst_stride = clientCon->cap_stride_bytes;
+    dst_stride = id->shmem_lineBytes;
     /* check crc list size */
-    crc_stride = (clientCon->dev->width + 63) / 64;
-    num_crcs = crc_stride * ((clientCon->dev->height + 63) / 64);
-    if (num_crcs != clientCon->num_rfx_crcs_alloc)
+    crc_stride = (id->width + 63) / 64;
+    num_crcs = crc_stride * ((id->height + 63) / 64);
+    if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
         LLOGLN(0, ("rdpEglOut: resize the crc list was %d now %d",
-               clientCon->num_rfx_crcs_alloc, num_crcs));
+               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
         /* resize the crc list */
-        clientCon->num_rfx_crcs_alloc = num_crcs;
-        free(clientCon->rfx_crcs);
-        clientCon->rfx_crcs = g_new0(int, num_crcs);
+        clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
+        free(clientCon->rfx_crcs[mon_index]);
+        clientCon->rfx_crcs[mon_index] = g_new0(int, num_crcs);
     }
     tile_extents_stride = (tile_extents_rect->x2 - tile_extents_rect->x1) / 64;
     out_rect_index = 0;
@@ -619,7 +621,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
 #endif
                 crc = crcs[(ly / 64) * tile_extents_stride + (lx / 64)];
                 crc_offset = (y / 64) * crc_stride + (x / 64);
-                if (crc == clientCon->rfx_crcs[crc_offset])
+                if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
                     LLOGLN(10, ("rdpEglOut: crc skip at x %d y %d", x, y));
                     rdpRegionInit(&tile_reg, &rect, 0);
@@ -630,7 +632,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 {
                     glReadPixels(lx, ly, 64, 64, GL_BGRA,
                                  GL_UNSIGNED_INT_8_8_8_8_REV, tile_dst);
-                    clientCon->rfx_crcs[crc_offset] = crc;
+                    clientCon->rfx_crcs[mon_index][crc_offset] = crc;
                     out_rects[out_rect_index] = rect;
                     if (out_rect_index < RDP_MAX_TILES)
                     {
@@ -644,9 +646,9 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 }
 
             }
-            x += 64;
+            x += XRDP_RFX_ALIGN;
         }
-        y += 64;
+        y += XRDP_RFX_ALIGN;
     }
     *num_out_rects = out_rect_index;
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -710,6 +712,9 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     {
         return FALSE;
     }
+
+    rdpRegionTranslate(in_reg, -id->left, -id->top);
+
     extents_rect = *rdpRegionExtents(in_reg);
     tile_extents_rect.x1 = extents_rect.x1 & ~63;
     tile_extents_rect.y1 = extents_rect.y1 & ~63;
@@ -752,8 +757,8 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                     yuv_tex = glamor_get_pixmap_texture(yuv_pixmap);
                     rfxGC->ops->CopyArea(&(screen_pixmap->drawable),
                                          &(pixmap->drawable), rfxGC,
-                                         tile_extents_rect.x1,
-                                         tile_extents_rect.y1,
+                                         tile_extents_rect.x1 + id->left,
+                                         tile_extents_rect.y1 + id->top,
                                          width, height, 0, 0);
                     rdpEglRfxRgbToYuv(egl, tex, yuv_tex, width, height);
                     rdpEglRfxClear(rfxGC, yuv_pixmap, &tile_extents_rect,

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -565,7 +565,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
         LLOGLN(0, ("rdpEglOut: glCheckFramebufferStatus error"));
     }
     dst = id->shmem_pixels;
-    dst_stride = id->shmem_lineBytes;
+    dst_stride = ((id->width + 63) & ~63) * 4;
     /* check crc list size */
     crc_stride = (id->width + 63) / 64;
     num_crcs = crc_stride * ((id->height + 63) / 64);

--- a/tests/xorg-test-run.sh
+++ b/tests/xorg-test-run.sh
@@ -65,6 +65,12 @@ moduledir="$top_builddir/xrdpkeyb/.libs,$moduledir"
 moduledir="$top_builddir/xrdpmouse/.libs,$moduledir"
 
 # Run Xorg with compiled modules as a background task
+#
+# [Linux]   Set LD_BIND_NOW (see dlopen(3)) to disable lazy symbol
+#           resolution so we check the modules for undefined symbols.
+# [FreeBSD] Setting LD_BIND_NOW does not affect the operation of
+#           dlopen()
+LD_BIND_NOW=1 \
 $XORG \
   -modulepath $moduledir \
   -config $top_srcdir/xrdpdev/xorg.conf \


### PR DESCRIPTION
This adds the mutimon changes that include the xup message 62 for GFX message passthrough from the backend(Xorg)
Alos, the shared memory area is use a bit differently. Not you do not need a huge shared memory to cover the entire desktop. It only need to cover the monitor. This allows larger desktop with / height with RemoteFX sessions and GFX sessions.

