### PR TITLE
Bump version to v0.9.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Build Status](https://github.com/neutrinolabs/xorgxrdp/actions/workflows/build.yml/badge.svg)](https://github.com/neutrinolabs/xorgxrdp/actions)
 
-*Current Version:* 0.9.19
-
 # xorgxrdp
 
 ## Overview

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ(2.65)
 # package version must be x.y.z
-AC_INIT([xorgxrdp], [0.9.19], [xrdp-devel@googlegroups.com])
+AC_INIT([xorgxrdp], [0.9.20], [xrdp-devel@googlegroups.com])
 package_version_major=$(echo ${PACKAGE_VERSION}|cut -d. -f1)
 package_version_minor=$(echo ${PACKAGE_VERSION}|cut -d. -f2)
 package_version_patchlevel=$(echo ${PACKAGE_VERSION}|cut -d. -f3)
@@ -31,7 +31,7 @@ if test "x${enable_glamor}" = "xyes"; then
 fi
 
 if test "x$XRDP_CFLAGS" = "x"; then
-  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.9.16])
+  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.9.25])
   XRDP_CFLAGS=`pkg-config xrdp --cflags`
 fi
 


### PR DESCRIPTION
This version requires xrdp v0.9.25 which supports inertial scrolling.

ref. https://github.com/neutrinolabs/xrdp/pull/2948