### PR TITLE
Allow AMD integrated graphics for glamor

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -53,7 +53,7 @@ Section "Device"
     Driver "xrdpdev"
     Option "DRMDevice" "/dev/dri/renderD128"
     Option "DRI3" "1"
-    Option "DRMAllowList" "i915 radeon"
+    Option "DRMAllowList" "amdgpu i915 radeon"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
This enables glamor acceleration with AMD Ryzen 7 5700G integrated Radeon Vega graphics.

```
[2270589.746] rdpPreInit:
[2270589.746] rdpPreInit: /dev/dri/renderD128 open ok, fd 9
[2270589.746] rdpPreInit: name [amdgpu]
[2270589.746] rdpPreInit: date [20150101]
[2270589.746] rdpPreInit: desc [AMD GPU]
[2270589.747] rdpPreInit: drm device looks ok, use glamor set
[2270589.747] (**) XRDPDEV(0): Depth 24, (--) framebuffer bpp 32
[2270589.747] (==) XRDPDEV(0): RGB weight 888
[2270589.747] (==) XRDPDEV(0): Using gamma correction (1.0, 1.0, 1.0)
[2270589.747] (==) XRDPDEV(0): Default visual is TrueColor
[2270589.747] (==) XRDPDEV(0): DPI set to (96, 96)
[2270589.747] (II) XRDPDEV(0):  mode "640x480" ok
[2270589.747] (II) XRDPDEV(0):  mode "800x600" ok
[2270589.747] (II) XRDPDEV(0): Virtual size is 800x600 (pitch 800)
[2270589.747] (**) XRDPDEV(0):  Default mode "800x600": 36.0 MHz (scaled from 0.0 MHz), 35.2 kHz, 56.2 Hz
[2270589.747] (II) XRDPDEV(0): Modeline "800x600"x0.0   36.00  800 824 896 1024  600 601 603 625 +hsync +vsync (35.2 kHz d)
[2270589.747] (II) Loading sub module "glamoregl"
[2270589.747] (II) LoadModule: "glamoregl"
[2270589.747] (II) Loading /usr/local/lib/xorg/modules/libglamoregl.so
[2270589.748] (II) Module glamoregl: vendor="X.Org Foundation"
[2270589.748]   compiled for 1.21.1.13, module version = 1.0.1
[2270589.748]   ABI class: X.Org ANSI C Emulation, version 0.4
[2270589.748] rdpPreInit: glamor module load ok
[2270589.870] (II) XRDPDEV(0): glamor X acceleration enabled on AMD Radeon Graphics (radeonsi, renoir, LLVM 15.0.7, DRM 3.49, 14.1-STABLE)
[2270589.870] rdpPreInit: glamor init ok
```