### PR TITLE
[v0.10] Remove unnecessary autoconf AC_C_CONST macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,6 @@ AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_PROG_CC_C99
-AC_C_CONST
 AC_PROG_LIBTOOL
 
 case $host_os in


### PR DESCRIPTION
See neutrinolabs/xrdp#3205

I've checked that this compiles on the github runner `ubuntu-24.04` as well as `ubuntu-latest`.

(cherry picked from commit bcd6683779fb2bb72a1b4869747fd17308481dc8)