### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ if test x$solaris = xyes; then
 fi 
 
 if test "x$XRDP_CFLAGS" = "x"; then
-  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.10.80])
+  PKG_CHECK_MODULES([XRDP], [xrdp >= 0.10.1])
   XRDP_CFLAGS=`pkg-config xrdp --cflags`
 fi
 


### PR DESCRIPTION
Latest release is v0.10.1. When this was changed to 0.10.80 the Enhanced Session Mode section in the Arch wiki Hyper-V article broke.