### PR TITLE
Add 'msm' to the glamor whitelist

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -53,7 +53,7 @@ Section "Device"
     Driver "xrdpdev"
     Option "DRMDevice" "/dev/dri/renderD128"
     Option "DRI3" "1"
-    Option "DRMAllowList" "amdgpu i915 radeon"
+    Option "DRMAllowList" "amdgpu i915 msm radeon"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
See #341 for a discussion on this.

AFAICT msm is used by some ARM laptops