### PR TITLE
Use different frame rates for H.264 and RFX

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -292,6 +292,8 @@ struct _rdpRec
     CARD32 last_event_time_ms;
     CARD32 last_wheel_time_ms;
 
+    CARD32 msFrameInterval;
+
     int conNumber;
 
     struct _rdpCounts counts;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -61,7 +61,6 @@ Client connection to xrdp
 #define USE_MAX_OS_BYTES 1
 #define MAX_OS_BYTES (16 * 1024 * 1024)
 
-#define MIN_MS_BETWEEN_FRAMES 40
 #define MIN_MS_TO_WAIT_FOR_MORE_UPDATES 4
 
 /*
@@ -779,47 +778,57 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
     clientCon->rdp_height = height;
 
     /* Set the capture parameters */
-    if ((clientCon->client_info.capture_code == CC_SUF_RFX) || /* RFX */
-        (clientCon->client_info.capture_code == CC_GFX_PRO))
+    switch(clientCon->client_info.capture_code)
     {
-        LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
-        /* RFX capture needs fixed-size rectangles */
-        clientCon->cap_width = RDPALIGN(width, XRDP_RFX_ALIGN);
-        clientCon->cap_height = RDPALIGN(height, XRDP_RFX_ALIGN);
-        LLOGLN(0, ("  cap_width %d cap_height %d",
-               clientCon->cap_width, clientCon->cap_height));
+        case CC_SUF_RFX: /* RFX */
+        case CC_GFX_PRO:
+            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
+            /* RFX capture needs fixed-size rectangles */
+            clientCon->cap_width = RDPALIGN(width, XRDP_RFX_ALIGN);
+            clientCon->cap_height = RDPALIGN(height, XRDP_RFX_ALIGN);
+            LLOGLN(0, ("  cap_width %d cap_height %d",
+                   clientCon->cap_width, clientCon->cap_height));
 
-        bytes = clientCon->cap_width * clientCon->cap_height *
-                clientCon->rdp_Bpp;
+            bytes = clientCon->cap_width * clientCon->cap_height *
+                    clientCon->rdp_Bpp;
 
-        clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
-        clientCon->cap_stride_bytes = clientCon->cap_width * 4;
-        shmemstatus = SHM_RFX_ACTIVE_PENDING;
+            clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
+            clientCon->cap_stride_bytes = clientCon->cap_width * 4;
+            shmemstatus = SHM_RFX_ACTIVE_PENDING;
+
+            dev->msFrameInterval = clientCon->client_info.rfx_frame_interval;
+            break;
+        case CC_SUF_A2: /* H264 */
+        case CC_GFX_A2:
+            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
+            clientCon->cap_width = width;
+            clientCon->cap_height = height;
+
+            bytes = clientCon->cap_width * clientCon->cap_height * 2;
+
+            clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
+            clientCon->cap_stride_bytes = clientCon->cap_width * 4;
+            shmemstatus = SHM_H264_ACTIVE_PENDING;
+
+            dev->msFrameInterval = clientCon->client_info.h264_frame_interval;
+            break;
+        default:
+            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got normal capture"));
+            clientCon->cap_width = width;
+            clientCon->cap_width = width;
+            clientCon->cap_height = height;
+
+            bytes = width * height * clientCon->rdp_Bpp;
+
+            clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
+            clientCon->cap_stride_bytes = clientCon->cap_width * clientCon->rdp_Bpp;
+            shmemstatus = SHM_ACTIVE_PENDING;
+
+            dev->msFrameInterval = clientCon->client_info.normal_frame_interval;
+            break;
     }
-    else if ((clientCon->client_info.capture_code == CC_SUF_A2) || /* H264 */
-             (clientCon->client_info.capture_code == CC_GFX_A2))
-    {
-        LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
-        clientCon->cap_width = width;
-        clientCon->cap_height = height;
 
-        bytes = clientCon->cap_width * clientCon->cap_height * 2;
-
-        clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
-        clientCon->cap_stride_bytes = clientCon->cap_width * 4;
-        shmemstatus = SHM_H264_ACTIVE_PENDING;
-    }
-    else
-    {
-        clientCon->cap_width = width;
-        clientCon->cap_height = height;
-
-        bytes = width * height * clientCon->rdp_Bpp;
-
-        clientCon->shmem_lineBytes = clientCon->rdp_Bpp * clientCon->cap_width;
-        clientCon->cap_stride_bytes = clientCon->cap_width * clientCon->rdp_Bpp;
-        shmemstatus = SHM_ACTIVE_PENDING;
-    }
+    LLOGLN(0, ("    msFrameInterval %ld", (long)dev->msFrameInterval));
     rdpClientConAllocateSharedMemory(clientCon, bytes);
 
     if (clientCon->client_info.capture_format != 0)
@@ -2542,7 +2551,7 @@ rdpClientConScheduleDeferredUpdate(rdpPtr dev)
     {
         dev->sendUpdateScheduled = TRUE;
         dev->sendUpdateTimer =
-                TimerSet(dev->sendUpdateTimer, 0, MIN_MS_BETWEEN_FRAMES,
+                TimerSet(dev->sendUpdateTimer, 0, dev->msFrameInterval,
                          rdpClientConDeferredUpdateCallback, dev);
     }
 }
@@ -2661,15 +2670,15 @@ rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
         out_uint32_le(s, clientCon->rect_id);
         out_uint32_le(s, id->shmem_bytes);
         out_uint32_le(s, id->shmem_offset);
-		if (capture_code == CC_SUF_RFX) /* rfx */
-		{
+        if (capture_code == CC_SUF_RFX) /* rfx */
+        {
             out_uint16_le(s, id->left);
             out_uint16_le(s, id->top);
             out_uint16_le(s, id->width);
             out_uint16_le(s, id->height);
-		}
-		else
-		{
+        }
+        else
+        {
             out_uint16_le(s, 0);
             out_uint16_le(s, 0);
             out_uint16_le(s, clientCon->cap_width);
@@ -3000,7 +3009,7 @@ rdpScheduleDeferredUpdate(rdpClientCon *clientCon)
        for more changes before sending an update. Always waiting the longer
        delay would introduce unnecessarily much latency. */
     msToWait = MIN_MS_TO_WAIT_FOR_MORE_UPDATES;
-    minNextUpdateTime = clientCon->lastUpdateTime + MIN_MS_BETWEEN_FRAMES;
+    minNextUpdateTime = clientCon->lastUpdateTime + clientCon->dev->msFrameInterval;
     /* the first check is to gracefully handle the infrequent case of
        the time wrapping around */
     if(clientCon->lastUpdateTime < curTime &&

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -120,6 +120,8 @@ struct _rdpClientCon
     int updateScheduled; /* boolean */
     int updateRetries;
 
+    CARD32 msFrameInterval;
+
     RegionPtr dirtyRegion;
 
     int num_rfx_crcs_alloc[16];


### PR DESCRIPTION
An enterprise user requests this. Some users in the company report that current 25Hz frame rates (40ms between frames) are noticeably laggy even when clients and servers are placed in under a 1ms network. Not all people feel laggy but some people are sensitive to screen latency. 

I also feel 25Hz is noticeably laggy when network RTT >30-40ms.

Now we have H.264, a video codec which takes interframe differences.  So, a higher frame rate does not necessarily consume more network bandwidth. In contrast, RFX doesn't take interframe differences. 2x frame rates might be twice the network bandwidth. This is the reason for using different frame rates per codec.

I'm going to make the frame interval value configurable. Where's the best place to put the configuration? xorg.conf?  client_info and pass from xrdp?

@matt335672 Let me know your opinion.
