### PR TITLE
Get display number from the DIX layer rather than a global

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,16 @@ fi
 # shm_open may not be in the C library
 AC_SEARCH_LIBS([shm_open], [rt])
 
+# See if we need to use a getter function for the display name
+CFLAGS_sav="$CFLAGS"
+CFLAGS="$CFLAGS $XORG_SERVER_CFLAGS"
+AC_CHECK_DECL([dixGetDisplayName],
+    [AC_DEFINE([HAS_DIX_GET_DISPLAY_NAME], [1], [support display getter])],
+    [],
+    [[#include <dix.h>]])
+CFLAGS="$CFLAGS_sav"
+
+
 AC_ARG_ENABLE(glamor, AS_HELP_STRING([--enable-glamor],
               [Use glamor(requires xorg server 1.19+) (default: no)]),
               [], [enable_glamor=no])

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1575,12 +1575,21 @@ rdpClientConInit(rdpPtr dev)
         g_chmod_hex(socket_dir, 0x1777);
     }
 
+    // Later versions of the X server removed the global display variable
+    // and replaced it with a getter function
+#ifdef HAS_DIX_GET_DISPLAY_NAME
+    const char *display = dixGetDisplayName(&dev->pScreen);
+    if (display == NULL)
+    {
+        FatalError("rdpClientConInit: Can't get display from DIX layer");
+    }
+#endif
+
     errno = 0;
     i = (int)strtol(display, &endptr, 10);
     if (errno != 0 || display == endptr || *endptr != 0)
     {
-        LLOGLN(0, ("rdpClientConInit: can not run at non-interger display"));
-        return 0;
+        FatalError("rdpClientConInit: can not run at non-integer display");
     }
 
     /* TODO: don't hardcode socket name */


### PR DESCRIPTION
Fixes #340 
Fixes #362 

~~Draft PR for now. It isn't clear that we need this yet, as the change which has precipitated this has not yet appeared in any mainline distros.~~  Devel versions of the X server do not contain the global string variable 'display' in opaque.h. See #340 for more information.

~~This commit works around that by extracting the required information from the DISPLAY variable.~~
**Edit: 2025-02-12** We've been provided with a new function in the DIX layer to get the display name. This PR uses that function if it is available

@jsorg71 - I'd appreciate your thoughts on this. I can't find a better way to do this at the moment. Would it be better to set a variable in sesman for the whole socket path do you think?

Also, it might be better to use the Xorg version to test for the getter function, as we do this elsewhere. At the moment this isn't possible, as we don't know what the version will be.