### PR TITLE
Code improvements

### DIFF
--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -127,8 +127,8 @@ rdpAllocRec(ScrnInfoPtr pScrn)
     {
         return TRUE;
     }
-    /* xnfcalloc exits if alloc failed */
-    pScrn->driverPrivate = xnfcalloc(sizeof(rdpRec), 1);
+    /* XNFcallocarray exits if alloc failed */
+    pScrn->driverPrivate = XNFcallocarray(sizeof(rdpRec), 1);
     return TRUE;
 }
 
@@ -149,8 +149,8 @@ rdpFreeRec(ScrnInfoPtr pScrn)
 static Bool
 rdpPreInit(ScrnInfoPtr pScrn, int flags)
 {
-    rgb zeros1;
-    Gamma zeros2;
+    rgb zeros1 = {0};
+    Gamma zeros2 = {0};
     int got_res_match;
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 16, 0, 0, 0)
     char **modename;
@@ -263,14 +263,12 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         return FALSE;
     }
     xf86PrintDepthBpp(pScrn);
-    g_memset(&zeros1, 0, sizeof(zeros1));
     if (!xf86SetWeight(pScrn, zeros1, zeros1))
     {
         LLOGLN(0, ("rdpPreInit: xf86SetWeight failed"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
-    g_memset(&zeros2, 0, sizeof(zeros2));
     if (!xf86SetGamma(pScrn, zeros2))
     {
         LLOGLN(0, ("rdpPreInit: xf86SetGamma failed"));
@@ -368,12 +366,12 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
 static miPointerSpriteFuncRec g_rdpSpritePointerFuncs =
 {
     /* these are in rdpCursor.c */
-    rdpSpriteRealizeCursor,
-    rdpSpriteUnrealizeCursor,
-    rdpSpriteSetCursor,
-    rdpSpriteMoveCursor,
-    rdpSpriteDeviceCursorInitialize,
-    rdpSpriteDeviceCursorCleanup
+    .RealizeCursor = rdpSpriteRealizeCursor,
+    .UnrealizeCursor = rdpSpriteUnrealizeCursor,
+    .SetCursor = rdpSpriteSetCursor,
+    .MoveCursor = rdpSpriteMoveCursor,
+    .DeviceCursorInitialize = rdpSpriteDeviceCursorInitialize,
+    .DeviceCursorCleanup = rdpSpriteDeviceCursorCleanup
 };
 
 /******************************************************************************/
@@ -1053,14 +1051,12 @@ rdpIdentify(int flags)
 /*****************************************************************************/
 _X_EXPORT DriverRec g_DriverRec =
 {
-    XRDP_VERSION,
-    g_xrdp_driver_name,
-    rdpIdentify,
-    rdpProbe,
-    rdpAvailableOptions,
-    0,
-    0,
-    rdpDriverFunc
+    .driverVersion = XRDP_VERSION,
+    .driverName = g_xrdp_driver_name,
+    .Identify = rdpIdentify,
+    .Probe = rdpProbe,
+    .AvailableOptions = rdpAvailableOptions,
+    .driverFunc = rdpDriverFunc
 };
 
 /*****************************************************************************/
@@ -1094,7 +1090,7 @@ xrdpdevTearDown(pointer Module)
 /* <drivername>ModuleData */
 _X_EXPORT XF86ModuleData xrdpdevModuleData =
 {
-    &g_VersRec,
-    xrdpdevSetup,
-    xrdpdevTearDown
+    .vers = &g_VersRec,
+    .setup = xrdpdevSetup,
+    .teardown = xrdpdevTearDown
 };

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -485,13 +485,10 @@ rdpkeybUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 /******************************************************************************/
 static InputDriverRec rdpkeyb =
 {
-    PACKAGE_VERSION_MAJOR,  /* version   */
-    g_xrdp_keyb_name,       /* name      */
-    NULL,                   /* identify  */
-    rdpkeybPreInit,         /* preinit   */
-    rdpkeybUnInit,          /* uninit    */
-    NULL,                   /* module    */
-    0                       /* ref count */
+    .driverVersion = PACKAGE_VERSION_MAJOR,
+    .driverName = g_xrdp_keyb_name,
+    .PreInit = rdpkeybPreInit,
+    .UnInit = rdpkeybUnInit
 };
 
 /******************************************************************************/
@@ -634,24 +631,23 @@ rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info)
 /******************************************************************************/
 static XF86ModuleVersionInfo rdpkeybVersionRec =
 {
-    XRDP_KEYB_NAME,
-    MODULEVENDORSTRING,
-    MODINFOSTRING1,
-    MODINFOSTRING2,
-    XORG_VERSION_CURRENT,
-    PACKAGE_VERSION_MAJOR,
-    PACKAGE_VERSION_MINOR,
-    PACKAGE_VERSION_PATCHLEVEL,
-    ABI_CLASS_XINPUT,
-    ABI_XINPUT_VERSION,
-    MOD_CLASS_XINPUT,
-    { 0, 0, 0, 0 }
+    .modname = XRDP_KEYB_NAME,
+    .vendor = MODULEVENDORSTRING,
+    ._modinfo1_ = MODINFOSTRING1,
+    ._modinfo2_ = MODINFOSTRING2,
+    .xf86version = XORG_VERSION_CURRENT,
+    .majorversion = PACKAGE_VERSION_MAJOR,
+    .minorversion = PACKAGE_VERSION_MINOR,
+    .patchlevel = PACKAGE_VERSION_PATCHLEVEL,
+    .abiclass = ABI_CLASS_XINPUT,
+    .abiversion = ABI_XINPUT_VERSION,
+    .moduleclass = MOD_CLASS_XINPUT
 };
 
 /******************************************************************************/
 _X_EXPORT XF86ModuleData xrdpkeybModuleData =
 {
-    &rdpkeybVersionRec,
-    rdpkeybPlug,
-    rdpkeybUnplug
+    .vers = &rdpkeybVersionRec,
+    .setup = rdpkeybPlug,
+    .teardown = rdpkeybUnplug
 };

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -421,13 +421,10 @@ rdpmouseUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 /******************************************************************************/
 static InputDriverRec rdpmouse =
 {
-    PACKAGE_VERSION_MAJOR,    /* version   */
-    g_xrdp_mouse_name,        /* name      */
-    NULL,                     /* identify  */
-    rdpmousePreInit,          /* preinit   */
-    rdpmouseUnInit,           /* uninit    */
-    NULL,                     /* module    */
-    0                         /* ref count */
+    .driverVersion = PACKAGE_VERSION_MAJOR,
+    .driverName = g_xrdp_mouse_name,
+    .PreInit = rdpmousePreInit,
+    .UnInit = rdpmouseUnInit
 };
 
 /******************************************************************************/
@@ -449,24 +446,23 @@ rdpmouseUnplug(pointer p)
 /******************************************************************************/
 static XF86ModuleVersionInfo rdpmouseVersionRec =
 {
-    XRDP_MOUSE_NAME,
-    MODULEVENDORSTRING,
-    MODINFOSTRING1,
-    MODINFOSTRING2,
-    XORG_VERSION_CURRENT,
-    PACKAGE_VERSION_MAJOR,
-    PACKAGE_VERSION_MINOR,
-    PACKAGE_VERSION_PATCHLEVEL,
-    ABI_CLASS_XINPUT,
-    ABI_XINPUT_VERSION,
-    MOD_CLASS_XINPUT,
-    { 0, 0, 0, 0 }
+    .modname = XRDP_MOUSE_NAME,
+    .vendor = MODULEVENDORSTRING,
+    ._modinfo1_ = MODINFOSTRING1,
+    ._modinfo2_ = MODINFOSTRING2,
+    .xf86version = XORG_VERSION_CURRENT,
+    .majorversion = PACKAGE_VERSION_MAJOR,
+    .minorversion = PACKAGE_VERSION_MINOR,
+    .patchlevel = PACKAGE_VERSION_PATCHLEVEL,
+    .abiclass = ABI_CLASS_XINPUT,
+    .abiversion = ABI_XINPUT_VERSION,
+    .moduleclass = MOD_CLASS_XINPUT
 };
 
 /******************************************************************************/
 _X_EXPORT XF86ModuleData xrdpmouseModuleData =
 {
-    &rdpmouseVersionRec,
-    rdpmousePlug,
-    rdpmouseUnplug
+    .vers = &rdpmouseVersionRec,
+    .setup = rdpmousePlug,
+    .teardown = rdpmouseUnplug
 };


### PR DESCRIPTION
Fixes #365 (Xorg alignment review)

Suggested by the xorg team for future compatibility.

~~Draft for now, as I haven't run up and tested. I also need to check compatibility with older X servers for the removal of `xnfcalloc()`~~

Compiles OK against latest version of Xorg (gitlab commit 2e0c19b6d93663c6874d133f8a88267eee8cc16e)  when #362 issues are taken into account:-
1) Missing `display`
2) Missing `miPointerInitialize()`

Because of the last of these I can't test against latest ATM.