### PR TITLE
[V0.10] Get display number from dixGetDisplayName()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,16 @@ fi
 # shm_open may not be in the C library
 AC_SEARCH_LIBS([shm_open], [rt])
 
+# See if we need to use a getter function for the display name
+CFLAGS_sav="$CFLAGS"
+CFLAGS="$CFLAGS $XORG_SERVER_CFLAGS"
+AC_CHECK_DECL([dixGetDisplayName],
+    [AC_DEFINE([HAS_DIX_GET_DISPLAY_NAME], [1], [support display getter])],
+    [],
+    [[#include <dix.h>]])
+CFLAGS="$CFLAGS_sav"
+
+
 AC_ARG_ENABLE(glamor, AS_HELP_STRING([--enable-glamor],
               [Use glamor(requires xorg server 1.19+) (default: no)]),
               [], [enable_glamor=no])

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1570,12 +1570,21 @@ rdpClientConInit(rdpPtr dev)
         g_chmod_hex(socket_dir, 0x1777);
     }
 
+    // Later versions of the X server removed the global display variable
+    // and replaced it with a getter function
+#ifdef HAS_DIX_GET_DISPLAY_NAME
+    const char *display = dixGetDisplayName(&dev->pScreen);
+    if (display == NULL)
+    {
+        FatalError("rdpClientConInit: Can't get display from DIX layer");
+    }
+#endif
+
     errno = 0;
     i = (int)strtol(display, &endptr, 10);
     if (errno != 0 || display == endptr || *endptr != 0)
     {
-        LLOGLN(0, ("rdpClientConInit: can not run at non-interger display"));
-        return 0;
+        FatalError("rdpClientConInit: can not run at non-integer display");
     }
 
     /* TODO: don't hardcode socket name */


### PR DESCRIPTION
Backport of #364 

Devel versions of the X server do not contain the global string variable 'display' in opaque.h. It has been replaced by the getter function dixGetDisplayName()

(cherry picked from commit de43adc513d2129ced2a27720a247577f32e97f7)