### PR TITLE
Add xorg sources to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
             name_extra: Basic build and dist check
 
           - CC: gcc
+            CONF_FLAGS:
+            XORG_SRC: 1
+            name_extra: Basic build against Xorg sources
+
+          - CC: gcc
             CONF_FLAGS: --without-simd
             name_extra: Without simd
 
@@ -66,11 +71,19 @@ jobs:
       CC: ${{ matrix.CC }}
       CFLAGS: ${{matrix.CFLAGS }}
       XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
+      # PKG_CONFIG_PATH only works if the directory is there. We use it to
+      # build against the Xorg server directly (XORG_SRC=1)
+      PKG_CONFIG_PATH: ${{ github.workspace }}/xorg-build/lib/pkgconfig
 
     steps:
       - uses: actions/checkout@v4
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
+      - if: ${{ matrix.XORG_SRC }}
+        name: Replace xserver-xorg-dev with latest master
+        run: |
+          sudo apt-get remove -y xserver-xorg-dev
+          scripts/build_latest_xorg_apt.sh ${{ github.workspace }}/xorg-build
       - run: ./bootstrap
       - run: ./configure ${{ matrix.CONF_FLAGS }}
       - run: make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,6 @@ jobs:
             name_extra: Basic build and dist check
 
           - CC: gcc
-            CONF_FLAGS:
-            XORG_SRC: 1
-            name_extra: Basic build against Xorg sources
-
-          - CC: gcc
             CONF_FLAGS: --without-simd
             name_extra: Without simd
 
@@ -71,19 +66,10 @@ jobs:
       CC: ${{ matrix.CC }}
       CFLAGS: ${{matrix.CFLAGS }}
       XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
-      # PKG_CONFIG_PATH only works if the directory is there. We use it to
-      # build against the Xorg server directly (XORG_SRC=1)
-      PKG_CONFIG_PATH: ${{ github.workspace }}/xorg-build/lib/pkgconfig
-
     steps:
       - uses: actions/checkout@v4
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
-      - if: ${{ matrix.XORG_SRC }}
-        name: Replace xserver-xorg-dev with latest master
-        run: |
-          sudo apt-get remove -y xserver-xorg-dev
-          scripts/build_latest_xorg_apt.sh ${{ github.workspace }}/xorg-build
       - run: ./bootstrap
       - run: ./configure ${{ matrix.CONF_FLAGS }}
       - run: make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"
@@ -94,3 +80,40 @@ jobs:
       - if: ${{ always() }}
         name: Display test logs (make check only)
         run: scripts/display_test_logs
+
+  build_with_latest_xorg:
+    name: Build with latest xorg
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CONF_FLAGS: --enable-glamor
+      XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
+      # Use a PKG_CONFIG_PATH to pick up the pkg-config file for Xorg
+      PKG_CONFIG_PATH: ${{ github.workspace }}/xorg-build/lib/pkgconfig
+      # This is used for the tests
+      XORG: ${{ github.workspace }}/xorg-build/bin/Xorg
+
+    steps:
+      # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu24')
+      - name: Get operating system name and version.
+        id: os
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
+        shell: sh
+      - uses: actions/checkout@v4
+      - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
+      - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
+      - name: Cache xorg-build
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-xorg-build
+        with:
+          path: ${{ github.workspace }}/xorg-build
+          key: ${{ steps.os.outputs.image }}-${{ env.cache-name }}
+      - name: Remove OS xserver-xorg-dev package
+        run: sudo apt-get remove -y xserver-xorg-dev
+      - name: Build latest xorg-build
+        run: scripts/build_latest_xorg_apt.sh ${{ github.workspace }}/xorg-build
+      - run: ./bootstrap
+      - run: ./configure $CONF_FLAGS
+      - run: make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"
+      - run: make check

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ AX_GCC_FUNC_ATTRIBUTE([format])
 
 PKG_CHECK_MODULES([XORG_SERVER], [xorg-server >= 0], [],
   [AC_MSG_ERROR([please install xserver-xorg-dev, xorg-x11-server-sdk or xorg-x11-server-devel])])
+echo "Xorg version is :"$(pkg-config --modversion xorg-server)
 if test "x${enable_glamor}" = "xyes"; then
   PKG_CHECK_MODULES([XORG_SERVER_GLAMOR], [xorg-server >= 1.19.0])
   PKG_CHECK_MODULES([LIBDRM], [libdrm >= 0], [], [AC_MSG_ERROR([please install libdrm-dev or libdrm-devel])])

--- a/scripts/build_latest_xorg_apt.sh
+++ b/scripts/build_latest_xorg_apt.sh
@@ -72,6 +72,10 @@ PYTHON_VENV="$SOURCE_DIR/python"            ; # Used for meson/ninja
 # The build directory (set later)
 BUILD_DIR=
 
+# Dependencies within the BUILD_DIR. When we know the BUILD_DIR, it
+# is added as a prefix to these
+BUILD_TARGET=lib/pkgconfig/xorg-server.pc    ; # What we are trying to make
+
 # ------------------------------------------------------------------------------
 # C R E A T E   B U I L D   M O D F I L E
 #
@@ -182,6 +186,13 @@ if ! cd "$1" || ! [ -w . ]; then
     exit 1
 fi
 BUILD_DIR=$(pwd)
+BUILD_TARGET="$BUILD_DIR/$BUILD_TARGET"
+
+# Have we run this script before?
+if [ -e "$BUILD_TARGET" ]; then
+    echo "- Target $BUILD_TARGET exists. The script will not be run again" >&2
+    exit 0
+fi
 
 # Debian has an extra pkgconfig directory to consider in
 # lib/$(uname -p)-linux-gnu/, which meson from pip doesn't pick up on.

--- a/scripts/build_latest_xorg_apt.sh
+++ b/scripts/build_latest_xorg_apt.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+################################################################################
+# B U I L D   W I T H   L A T E S T   X O R G   A P T . S H
+#
+# Builds the latest version of the xserver from gitlab.freedesktop.org
+#
+# (c) Matt Burt  2025
+#
+# Usage ./build_with_latest_xorg_apt.sh [-r] <build_dir>
+#
+# Add [-r] to use an autoresume file. This can be useful when tracking down
+# problems with the build script. It can also make things very confusing!
+#
+# sudo is used to install build dependencies, plus a few package
+# dependencies.
+#
+# Most dependencies are pulled down and installed as the build user.
+################################################################################
+
+# ------------------------------------------------------------------------------
+# G L O B A L S
+# ------------------------------------------------------------------------------
+# Build tools
+APT_PKG_LIST="git pip pkg-config cmake automake autoconf libtool"
+APT_PKG_LIST="$APT_PKG_LIST python3-venv" ; # meson/ninja
+# Other OS-provided dependencies
+#
+# We pull in most of Mesa rather than building it from scratch as
+# Mesa dependencies (notably the rust compiler version) can be
+# problematic
+APT_PKG_LIST="$APT_PKG_LIST mesa-common-dev" ; # See above
+APT_PKG_LIST="$APT_PKG_LIST libfreetype-dev" ; # Needed by libXfont
+APT_PKG_LIST="$APT_PKG_LIST libudev-dev" ; # Needed by xserver
+APT_PKG_LIST="$APT_PKG_LIST libssl-dev" ; # Needed by xserver
+APT_PKG_LIST="$APT_PKG_LIST libepoxy-dev" ; # Needed by xserver
+
+# We use 'pip' to get the latest meson and ninja build tools down. These
+# are installed for the build user.
+PIP_PKG_LIST="meson ninja"
+
+# The modular packages supported by the xserver build tool which we need to
+# build. This includes the xserver package
+#
+# This list of packages is sorted into dependency order before use.
+MODULAR_PKG_LIST="util/macros"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST font/util"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST proto/xorgproto proto/xcbproto"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libxcvt lib/libxtrans lib/libXau"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libXdmcp lib/libxcb lib/libX11"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libfontenc lib/libXfont lib/libxkbfile"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libxshmfence"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST mesa/drm"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST pixman/pixman"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST xserver"
+
+# Check the XDG_RUNTIME_DIR is specified, and use it for the autoresume file
+if [ -z "$XDG_RUNTIME_DIR" ]; then
+    export XDG_RUNTIME_DIR=/run/user/$(id -u)
+fi
+AUTORESUME_FILE="$XDG_RUNTIME_DIR/xserver-autores.txt"
+
+# Our source dir. This is currently hard-coded
+SOURCE_DIR="$HOME/xserver-src"
+
+# Dependencies in the source dir
+BUILDER="$SOURCE_DIR/util/modular/build.sh" ; # xorg modular build script
+MODFILE="$SOURCE_DIR/modfile.txt"           ; # Used by above
+PYTHON_VENV="$SOURCE_DIR/python"            ; # Used for meson/ninja
+
+# The build directory (set later)
+BUILD_DIR=
+
+# ------------------------------------------------------------------------------
+# C R E A T E   B U I L D   M O D F I L E
+#
+# Creates the modfile used by utils/modular/build.sh on stdout
+# Parameters:-
+# 1..) List of modules to add to the file
+#
+# Return : != 0 for error
+# The modules are sorted into dependency order before being added.
+# ------------------------------------------------------------------------------
+create_build_modfile()
+{
+    tmp=$(mktemp -t "modfile-XXXXXXXX")
+    $BUILDER -L >$tmp
+    while read mod; do
+        newlist=
+        for m in "$@"; do
+            if [ "$m" = "$mod" ]; then
+                echo $mod
+            else
+                newlist="$newlist $m"
+            fi
+        done
+        set -- $newlist
+        if [ $# -eq 0 ]; then
+            break
+        fi
+    done <$tmp
+    rm $tmp
+    if [ $# -gt 0 ]; then
+        echo "** The following modules are not supported by build.sh: $*" >&2
+    fi
+    return $#
+}
+
+# ------------------------------------------------------------------------------
+# I N S T A L L   S O U R C E S
+#
+# Installs the sources used by the modular build utility
+# Parameters:-
+# 1..) List of modules to get source for
+#
+# Return : != 0 for error
+# ------------------------------------------------------------------------------
+install_sources()
+{
+    rv=0
+    tmp=$(mktemp -t "modfile-XXXXXXXX")
+    for mod in "$@"; do
+        if ! [ -d "$mod" ]; then
+            echo "$mod"
+        fi
+    done >$tmp
+    if [ -s "$tmp" ]; then
+        $BUILDER --modfile "$tmp" -a -m --clone "$BUILD_DIR"
+        rv=$?
+
+        # Most autoconf-enabled modules required an 'm4' directory. If
+        # we fetch from git, these directories are only created if there
+        # are not empty. If the directory isn't present, the module
+        # builds can fail.
+        #
+        # Add m4 directories for autoconf-enabled modules
+        for mod in "$@"; do
+            if [ -f "$mod/configure.ac" ]; then
+                mkdir -p "$mod/m4"
+            fi
+        done
+    fi
+    rm -f "$tmp"
+    return $rv
+}
+
+# ------------------------------------------------------------------------------
+# T I T L E
+#
+# Outputs a log title
+# ------------------------------------------------------------------------------
+title()
+{
+    echo
+    echo '==============================================================================='
+    echo $(date +%T)": $*"
+    echo '==============================================================================='
+}
+
+# ------------------------------------------------------------------------------
+# M A I N
+# ------------------------------------------------------------------------------
+
+# Check parameters
+if [ "$1" = "-r" ]; then
+    shift
+else
+    rm -f "$AUTORESUME_FILE"
+fi
+
+if [ $# != 1 ]; then
+    echo "Usage : $0 [-r] <build-dir>" >&2
+    exit 1
+fi
+
+# Set up the BUILD_DIR, after resolving it to an absolute path
+mkdir -p "$1"
+if ! cd "$1" || ! [ -w . ]; then
+    echo "** Build directory $BUILD_DIR is invalid or unwriteable" >&2
+    exit 1
+fi
+BUILD_DIR=$(pwd)
+
+# Debian has an extra pkgconfig directory to consider in
+# lib/$(uname -p)-linux-gnu/, which meson from pip doesn't pick up on.
+# Rather than messing with PKG_CONFIG_PATH, we'll use a soft-link to make
+# this work, so the resulting output directory can be more easily managed
+debian_extra_pkgconf="$BUILD_DIR/lib/$(uname -p)-linux-gnu/pkgconfig"
+if ! [ -L "$debian_extra_pkgconf" ]; then
+    mkdir -p "${debian_extra_pkgconf%/*}"
+    ln -sf ../pkgconfig "$debian_extra_pkgconf"
+fi
+
+# Set up the SOURCE_DIR, and work in it.
+mkdir -p "$SOURCE_DIR"
+cd "$SOURCE_DIR" || exit $?
+
+# Install all dependencies
+title "Installing dependencies"
+sudo apt-get install -y $APT_PKG_LIST || exit $?
+if ! [ -d "$PYTHON_VENV" ]; then
+    python3 -m venv "$PYTHON_VENV" || exit $?
+fi
+PATH="$PYTHON_VENV/bin:$PATH"
+pip3 install $PIP_PKG_LIST || exit $?
+
+title "Installing modular build script"
+if ! [ -x "$BUILDER" ]; then
+    git clone https://gitlab.freedesktop.org/xorg/util/modular.git util/modular || exit $?
+fi
+
+title "Creating module file"
+create_build_modfile $MODULAR_PKG_LIST >$MODFILE || exit $?
+
+title "Installing sources"
+install_sources $MODULAR_PKG_LIST || exit $?
+
+# If there are meson builddir files without build.ninja files, delete them.
+# This can happen if a previous build failed in the configure stage with
+# missing dependencies.
+title "Removing failed meson build directories"
+for dir in $(find . -name builddir); do
+    if [ ! -e $dir/build.ninja ]; then
+        rm -rf $dir
+    fi
+done
+
+title "Building sources"
+$BUILDER \
+    --modfile "$MODFILE" \
+    --autoresume "$AUTORESUME_FILE" \
+    "$BUILD_DIR"

--- a/scripts/build_latest_xorg_apt.sh
+++ b/scripts/build_latest_xorg_apt.sh
@@ -55,7 +55,8 @@ MODULAR_PKG_LIST="$MODULAR_PKG_LIST xserver"
 
 # Check the XDG_RUNTIME_DIR is specified, and use it for the autoresume file
 if [ -z "$XDG_RUNTIME_DIR" ]; then
-    export XDG_RUNTIME_DIR=/run/user/$(id -u)
+    XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    export XDG_RUNTIME_DIR
 fi
 AUTORESUME_FILE="$XDG_RUNTIME_DIR/xserver-autores.txt"
 
@@ -83,22 +84,23 @@ BUILD_DIR=
 create_build_modfile()
 {
     tmp=$(mktemp -t "modfile-XXXXXXXX")
-    $BUILDER -L >$tmp
-    while read mod; do
+    $BUILDER -L >"$tmp"
+    while read -r mod; do
         newlist=
         for m in "$@"; do
             if [ "$m" = "$mod" ]; then
-                echo $mod
+                echo "$mod"
             else
                 newlist="$newlist $m"
             fi
         done
+        # shellcheck disable=SC2086
         set -- $newlist
         if [ $# -eq 0 ]; then
             break
         fi
-    done <$tmp
-    rm $tmp
+    done <"$tmp"
+    rm "$tmp"
     if [ $# -gt 0 ]; then
         echo "** The following modules are not supported by build.sh: $*" >&2
     fi
@@ -122,7 +124,7 @@ install_sources()
         if ! [ -d "$mod" ]; then
             echo "$mod"
         fi
-    done >$tmp
+    done >"$tmp"
     if [ -s "$tmp" ]; then
         $BUILDER --modfile "$tmp" -a -m --clone "$BUILD_DIR"
         rv=$?
@@ -152,7 +154,7 @@ title()
 {
     echo
     echo '==============================================================================='
-    echo $(date +%T)": $*"
+    echo "$(date +%T): $*"
     echo '==============================================================================='
 }
 
@@ -196,11 +198,13 @@ cd "$SOURCE_DIR" || exit $?
 
 # Install all dependencies
 title "Installing dependencies"
+# shellcheck disable=SC2086
 sudo apt-get install -y $APT_PKG_LIST || exit $?
 if ! [ -d "$PYTHON_VENV" ]; then
     python3 -m venv "$PYTHON_VENV" || exit $?
 fi
 PATH="$PYTHON_VENV/bin:$PATH"
+# shellcheck disable=SC2086
 pip3 install $PIP_PKG_LIST || exit $?
 
 title "Installing modular build script"
@@ -209,18 +213,21 @@ if ! [ -x "$BUILDER" ]; then
 fi
 
 title "Creating module file"
-create_build_modfile $MODULAR_PKG_LIST >$MODFILE || exit $?
+# shellcheck disable=SC2086
+create_build_modfile $MODULAR_PKG_LIST >"$MODFILE" || exit $?
 
 title "Installing sources"
+# shellcheck disable=SC2086
 install_sources $MODULAR_PKG_LIST || exit $?
 
 # If there are meson builddir files without build.ninja files, delete them.
 # This can happen if a previous build failed in the configure stage with
 # missing dependencies.
 title "Removing failed meson build directories"
-for dir in $(find . -name builddir); do
-    if [ ! -e $dir/build.ninja ]; then
-        rm -rf $dir
+find . -name builddir | \
+while read -r dir; do
+    if [ ! -e "$dir/build.ninja" ]; then
+        rm -rf "$dir"
     fi
 done
 

--- a/scripts/build_latest_xorg_apt.sh
+++ b/scripts/build_latest_xorg_apt.sh
@@ -65,6 +65,7 @@ SOURCE_DIR="$HOME/xserver-src"
 
 # Dependencies in the source dir
 BUILDER="$SOURCE_DIR/util/modular/build.sh" ; # xorg modular build script
+                                              # (Installed below)
 MODFILE="$SOURCE_DIR/modfile.txt"           ; # Used by above
 PYTHON_VENV="$SOURCE_DIR/python"            ; # Used for meson/ninja
 
@@ -210,6 +211,10 @@ pip3 install $PIP_PKG_LIST || exit $?
 title "Installing modular build script"
 if ! [ -x "$BUILDER" ]; then
     git clone https://gitlab.freedesktop.org/xorg/util/modular.git util/modular || exit $?
+    if ! [ -x "$BUILDER" ]; then
+        echo "** Failed to install modular build script" >&2
+        exit 1
+    fi
 fi
 
 title "Creating module file"


### PR DESCRIPTION
Created mainly for discussion at this point. I've got to a point where I need some input to make this workable.

This PR has been prompted by #340 and #362.

The PR adds a script which runs as part of the standard CI to make a basic build of the xorgxrdp module against the latest master from https://gitlab.freedesktop.org/xorg/xserver

The script has been tested on Ubuntu 22.04, 24.04 and Debian testing

I've got a couple of questions which I'd like anyone (including @metux) to comment on:-
1) Is the checkin CI the right place for this, or should we be doing a nightly or weekly run, like the Coverity scan for xrdp? 
2) Is a basic build OK, or should we be going for as comprehensive a build as possible?

Personally I'm thinking a nightly or weekly run would be better, but a checkin is fine, in which case I need to add some caching to this.
