### PR TITLE
Add incubate capability to xorg build script

### DIFF
--- a/.github/workflows/incubate.yml
+++ b/.github/workflows/incubate.yml
@@ -1,0 +1,34 @@
+name: Incubate
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  build_with_xorg_incubate:
+    name: Build with xorg Incubate branch
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CONF_FLAGS: --enable-glamor
+      XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
+      # Use a PKG_CONFIG_PATH to pick up the pkg-config file for Xorg
+      PKG_CONFIG_PATH: ${{ github.workspace }}/xorg-incubate-build/lib/pkgconfig
+      # This is used for the tests
+      XORG: ${{ github.workspace }}/xorg-incubate-build/bin/Xorg
+      # How to access the incubate branch
+      GIT_CLONE_INCUBATE: -b incubate https://gitlab.freedesktop.org/metux/xserver.git
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
+      - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
+      - name: Remove OS xserver-xorg-dev package
+        run: sudo apt-get remove -y xserver-xorg-dev
+      - name: Build xorg incubate branch
+        run: scripts/build_latest_xorg_apt.sh -x "$GIT_CLONE_INCUBATE" ${{ github.workspace }}/xorg-incubate-build
+      - run: ./bootstrap
+      - run: ./configure $CONF_FLAGS
+      - run: make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"
+      - run: make check

--- a/scripts/build_latest_xorg_apt.sh
+++ b/scripts/build_latest_xorg_apt.sh
@@ -4,12 +4,19 @@
 #
 # Builds the latest version of the xserver from gitlab.freedesktop.org
 #
-# (c) Matt Burt  2025
+# (c) Matt Burt 2025
 #
-# Usage ./build_with_latest_xorg_apt.sh [-r] <build_dir>
+# Usage ./build_with_latest_xorg_apt.sh [-r] [-x git.clone.args] <build_dir>
 #
-# Add [-r] to use an autoresume file. This can be useful when tracking down
-# problems with the build script. It can also make things very confusing!
+# Options:-
+# -r  Use an autoresume file. This can be useful when
+#     tracking down problems with the build script. It can also make
+#     things very confusing!
+# -x git.clone.args
+#     Use the specified arguments to the git clone command which
+#    fetches the xserver. This can be useful to get the xserver
+#    source from another repository (e.g.
+#    -x '-b incubate https://gitlab.freedesktop.org/metux/xserver.git')
 #
 # sudo is used to install build dependencies, plus a few package
 # dependencies.
@@ -46,8 +53,9 @@ MODULAR_PKG_LIST="util/macros"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST font/util"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST proto/xorgproto proto/xcbproto"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libxcvt lib/libxtrans lib/libXau"
-MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libXdmcp lib/libxcb lib/libX11"
-MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libfontenc lib/libXfont lib/libxkbfile"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libXdmcp lib/libxcb lib/libxcb-util"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libxcb-wm lib/libX11 lib/libfontenc"
+MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libXfont lib/libxkbfile"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST lib/libxshmfence"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST mesa/drm"
 MODULAR_PKG_LIST="$MODULAR_PKG_LIST pixman/pixman"
@@ -60,21 +68,26 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
 fi
 AUTORESUME_FILE="$XDG_RUNTIME_DIR/xserver-autores.txt"
 
-# Our source dir. This is currently hard-coded
-SOURCE_DIR="$HOME/xserver-src"
+# Our source dir (set from the BUILD_DIR)
+SOURCE_DIR=
 
-# Dependencies in the source dir
-BUILDER="$SOURCE_DIR/util/modular/build.sh" ; # xorg modular build script
-                                              # (Installed below)
-MODFILE="$SOURCE_DIR/modfile.txt"           ; # Used by above
-PYTHON_VENV="$SOURCE_DIR/python"            ; # Used for meson/ninja
+# Dependencies within the SOURCE_DIR. These are evaluated when
+# the SOURCE_DIR is known (which is why the '$' is escaped)
+BUILDER="\$SOURCE_DIR/util/modular/build.sh" ; # xorg modular build script
+                                               # (Installed below)
+MODFILE="\$SOURCE_DIR/modfile.txt"           ; # Used by above
+PYTHON_VENV="\$SOURCE_DIR/python"            ; # Used for meson/ninja
 
 # The build directory (set later)
 BUILD_DIR=
 
-# Dependencies within the BUILD_DIR. When we know the BUILD_DIR, it
-# is added as a prefix to these
-BUILD_TARGET=lib/pkgconfig/xorg-server.pc    ; # What we are trying to make
+# Dependencies within the BUILD_DIR. These are evaluated when the
+# BUILD_DIR is known
+BUILD_TARGET="\$BUILD_DIR/lib/pkgconfig/xorg-server.pc"
+                                              # What we are trying to make
+
+# Command used to clone the xserver repository
+XSERVER_CLONE_ARGS=
 
 # ------------------------------------------------------------------------------
 # C R E A T E   B U I L D   M O D F I L E
@@ -125,28 +138,44 @@ install_sources()
 {
     rv=0
     tmp=$(mktemp -t "modfile-XXXXXXXX")
+    defer_xserver=
+
+    # Create a modfile for all the components. Defer the xserver
+    # if it's present, and we have a custom command
     for mod in "$@"; do
-        if ! [ -d "$mod" ]; then
+        if [ -n "$XSERVER_CLONE_ARGS" ] && [ "$mod" = xserver ]; then
+	       defer_xserver=1
+       elif ! [ -d "$mod" ]; then
             echo "$mod"
         fi
     done >"$tmp"
+
     if [ -s "$tmp" ]; then
         $BUILDER --modfile "$tmp" -a -m --clone "$BUILD_DIR"
         rv=$?
-
-        # Most autoconf-enabled modules required an 'm4' directory. If
-        # we fetch from git, these directories are only created if there
-        # are not empty. If the directory isn't present, the module
-        # builds can fail.
-        #
-        # Add m4 directories for autoconf-enabled modules
-        for mod in "$@"; do
-            if [ -f "$mod/configure.ac" ]; then
-                mkdir -p "$mod/m4"
-            fi
-        done
     fi
     rm -f "$tmp"
+
+    if [ "$rv" -eq 0 ] && [ "$defer_xserver" ] && ! [ -d xserver ]; then
+        echo "======================================================================"
+        echo "Processing: xserver (git clone $XSERVER_CLONE_ARGS)"
+        # shellcheck disable=SC2086
+        git clone $XSERVER_CLONE_ARGS
+	rv=$?
+    fi
+
+    # Most autoconf-enabled modules required an 'm4' directory. If
+    # we fetch from git, these directories are only created if there
+    # are not empty. If the directory isn't present, the module
+    # builds can fail.
+    #
+    # Add m4 directories for autoconf-enabled modules
+    for mod in "$@"; do
+        if [ -f "$mod/configure.ac" ]; then
+            mkdir -p "$mod/m4"
+        fi
+    done
+
     return $rv
 }
 
@@ -168,15 +197,27 @@ title()
 # ------------------------------------------------------------------------------
 
 # Check parameters
-if [ "$1" = "-r" ]; then
+use_autoresume=
+while [ $# -gt 1 ]; do
+    case "$1" in
+        -r) use_autoresume=1
+            ;;
+	-x) shift  ; # Next param is guaranteed to exist
+            XSERVER_CLONE_ARGS="$1"
+	    ;;
+        *)  echo "** Unexpected argument '$1'" >&2
+            exit 1
+    esac
     shift
-else
-    rm -f "$AUTORESUME_FILE"
-fi
+done
 
 if [ $# != 1 ]; then
-    echo "Usage : $0 [-r] <build-dir>" >&2
+    echo "Usage : $0 [-r] [-x git.clone.args] <build-dir>" >&2
     exit 1
+fi
+
+if ! [ "$use_autoresume" ]; then
+    rm -f "$AUTORESUME_FILE"
 fi
 
 # Set up the BUILD_DIR, after resolving it to an absolute path
@@ -186,7 +227,8 @@ if ! cd "$1" || ! [ -w . ]; then
     exit 1
 fi
 BUILD_DIR=$(pwd)
-BUILD_TARGET="$BUILD_DIR/$BUILD_TARGET"
+# Resolve BUILD_DIR dependencies
+eval BUILD_TARGET="$BUILD_TARGET"
 
 # Have we run this script before?
 if [ -e "$BUILD_TARGET" ]; then
@@ -204,14 +246,24 @@ if ! [ -L "$debian_extra_pkgconf" ]; then
     ln -sf ../pkgconfig "$debian_extra_pkgconf"
 fi
 
-# Set up the SOURCE_DIR, and work in it.
+# Base the SOURCE_DIR on the BUILD_DIR, and work in it.
+SOURCE_DIR="$BUILD_DIR.src"
+
 mkdir -p "$SOURCE_DIR"
 cd "$SOURCE_DIR" || exit $?
 
-# Install all dependencies
+# Resolve SOURCE_DIR dependencies
+eval BUILDER="$BUILDER"
+eval MODFILE="$MODFILE"
+eval PYTHON_VENV="$PYTHON_VENV"
+
+# Install all dependencies. Before running 'sudo', make sure we need to
 title "Installing dependencies"
 # shellcheck disable=SC2086
-sudo apt-get install -y $APT_PKG_LIST || exit $?
+if ! dpkg-query -W $APT_PKG_LIST >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    sudo apt-get install -y $APT_PKG_LIST || exit $?
+fi
 if ! [ -d "$PYTHON_VENV" ]; then
     python3 -m venv "$PYTHON_VENV" || exit $?
 fi


### PR DESCRIPTION
~~Draft PR, more to capture some ideas than anything else. No review required yet, but comments welcome~~

See #369 for the background.

There are two commits in this PR:-

1) Updates to build_latest_xorg_apt.sh:-

    1) Add -x option to build_latest_xorg_apt.sh<br>This option allows the Xorg server to be built from @metux's incubate branch (and maybe other sources)
    
    2) Add extra freedesktop packages needed to build the incubate branch.<br>The packages libxcb-util and libxcb-wm are needed to build the current incubate branch.
    
    3) Remove hard-coded SOURCE_DIR<br>This allows two branches to be stored on the same development machine. The SOURCE_DIR is now dependent on the BUILD_DIR
    
     4) Don't run sudo unless we need to<br>This checks whether OS packages are installed before using  'sudo apt install' to install them. This is intended for interactive use.

2) Add a github workflow to run the script every Sunday, and also on demand.

An example of the results of a manual run of the script can be found [here](/matt335672/xorgxrdp/actions/runs/13566596152)
