### PR TITLE
Fix build against latest version of Xorg

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -1125,7 +1125,11 @@ rdpStartAccelAssist(rdpPtr dev, rdpClientCon *clientCon)
         open("/dev/null", O_RDWR);
         open("/dev/null", O_RDWR);
         open("/dev/null", O_RDWR);
+#ifdef HAS_DIX_GET_DISPLAY_NAME
+        snprintf(text, 63, ":%s", dixGetDisplayName(&dev->pScreen));
+#else
         snprintf(text, 63, ":%s", display);
+#endif
         text[63] = 0;
         setenv("DISPLAY", text, 1);
         snprintf(text, 63, "%d", spair[0]);

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -46,7 +46,7 @@ rdp module main
 #include <xf86xv.h>
 #include <xf86Crtc.h>
 
-#if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(21, 1, 4, 0, 0)
+#if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 21, 1, 4, 0)
 #define XACE_DISABLE_DRI3_PRESENT
 #endif
 

--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -148,6 +148,7 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     struct cmd_file_t *cmd_file;
     char *env;
     int fd;
+    int system_rv;
 
     cmd_file = g_new0(struct cmd_file_t, 1);
     if (cmd_file == NULL)
@@ -196,7 +197,14 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
              "sh %s&", cmd_file->filename);
     LLOGLN(0, ("rdpRandRGridUpdateRunCmds: running command %s",
            cmd_file->cmd));
-    System(cmd_file->cmd);
+    system_rv = system(cmd_file->cmd);
+    if (system_rv != 0)
+    {
+        LLOGLN(0, ("rdpRandRGridUpdateRunCmds: command %s returned %d",
+               cmd_file->cmd, system_rv));
+        free(cmd_file);
+        return 1;
+    }
     free(cmd_file);
     return 0;
 }


### PR DESCRIPTION
PR #369 was merged after PR #354, and found a few problems with the changes in #354

This PR updates #354 to make it compatible with the latest Xorg server in `master`.

Comments on each commit in this PR. See also [this comment](/neutrinolabs/xorgxrdp/pull/354#issuecomment-2684522501)