### PR TITLE
Include <sys/stat.h> in rdpRandRGrid.c

### DIFF
--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -28,6 +28,7 @@ NVidia Grid RandR
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 /* this should be before all X11 .h files */
 #include <xorg-server.h>


### PR DESCRIPTION
On FreeBSD you get the an error due to S_IRUSR and S_IWUSR usage
