### PR TITLE
Update autoconf scripts from 2.65 to 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script
 
-AC_PREREQ(2.65)
+AC_PREREQ(2.69)
 # package version must be x.y.z
 AC_INIT([xorgxrdp], [0.10.80], [xrdp-devel@googlegroups.com])
 package_version_major=$(echo ${PACKAGE_VERSION}|cut -d. -f1)
@@ -12,8 +12,9 @@ AC_SUBST([package_version_patchlevel], [${package_version_patchlevel}])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-AC_PROG_CC_C99
-AC_PROG_LIBTOOL
+# autoconf version 2.69 still uses AC_PROG_CC_C99
+m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
+LT_INIT
 
 case $host_os in
         *linux*)
@@ -87,19 +88,19 @@ AC_SUBST([moduledir])
 
 # SIMD is optional
 AC_ARG_WITH([simd],
-    AC_HELP_STRING([--without-simd],[Omit SIMD extensions.]))
+    AS_HELP_STRING([--without-simd],[Omit SIMD extensions.]))
 if test "x${with_simd}" != "xno"; then
   # Check if we're on a supported CPU
   AC_MSG_CHECKING([if we have SIMD optimisations for cpu type])
   case "$host_cpu" in
     x86_64 | amd64)
       AC_MSG_RESULT([yes (x86_64)])
-      AC_PROG_NASM
+      AXRDP_PROG_NASM
       simd_arch=x86_64
     ;;
     i*86 | x86 | ia32)
       AC_MSG_RESULT([yes (i386)])
-      AC_PROG_NASM
+      AXRDP_PROG_NASM
       simd_arch=i386
     ;;
     *)

--- a/m4/ax_append_compile_flags.m4
+++ b/m4/ax_append_compile_flags.m4
@@ -1,6 +1,6 @@
-# ===========================================================================
-#  http://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
-# ===========================================================================
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ============================================================================
 #
 # SYNOPSIS
 #
@@ -30,33 +30,12 @@
 #
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 5
+#serial 7
 
 AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
 [AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])

--- a/m4/ax_cflags_warn_all.m4
+++ b/m4/ax_cflags_warn_all.m4
@@ -1,36 +1,57 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_cflags_warn_all.html
+#    https://www.gnu.org/software/autoconf-archive/ax_cflags_warn_all.html
 # ===========================================================================
 #
 # SYNOPSIS
 #
-#   AX_CFLAGS_WARN_ALL   [(shellvar [,default, [A/NA]])]
-#   AX_CXXFLAGS_WARN_ALL [(shellvar [,default, [A/NA]])]
-#   AX_FCFLAGS_WARN_ALL  [(shellvar [,default, [A/NA]])]
+#   AX_CFLAGS_WARN_ALL   [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
+#   AX_CXXFLAGS_WARN_ALL [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
+#   AX_FCFLAGS_WARN_ALL  [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
 #
 # DESCRIPTION
 #
-#   Try to find a compiler option that enables most reasonable warnings.
+#   Specify compiler options that enable most reasonable warnings.  For the
+#   GNU Compiler Collection (GCC), for example, it will be "-Wall".  The
+#   result is added to shellvar, one of CFLAGS, CXXFLAGS or FCFLAGS if the
+#   first parameter is not specified.
 #
-#   For the GNU compiler it will be -Wall (and -ansi -pedantic) The result
-#   is added to the shellvar being CFLAGS, CXXFLAGS, or FCFLAGS by default.
+#   Each of these macros accepts the following optional arguments:
 #
-#   Currently this macro knows about the GCC, Solaris, Digital Unix, AIX,
-#   HP-UX, IRIX, NEC SX-5 (Super-UX 10), Cray J90 (Unicos 10.0.0.8), and
-#   Intel compilers.  For a given compiler, the Fortran flags are much more
-#   experimental than their C equivalents.
+#     - $1 - shellvar
+#         shell variable to use (CFLAGS, CXXFLAGS or FCFLAGS if not
+#         specified, depending on macro)
 #
-#    - $1 shell-variable-to-add-to : CFLAGS, CXXFLAGS, or FCFLAGS
-#    - $2 add-value-if-not-found : nothing
-#    - $3 action-if-found : add value to shellvariable
-#    - $4 action-if-not-found : nothing
+#     - $2 - default
+#         value to use for flags if compiler vendor cannot be determined (by
+#         default, "")
 #
-#   NOTE: These macros depend on AX_APPEND_FLAG.
+#     - $3 - action-if-found
+#         action to take if the compiler vendor has been successfully
+#         determined (by default, add the appropriate compiler flags to
+#         shellvar)
+#
+#     - $4 - action-if-not-found
+#         action to take if the compiler vendor has not been determined or
+#         is unknown (by default, add the default flags, or "" if not
+#         specified, to shellvar)
+#
+#   These macros use AX_COMPILER_VENDOR to determine which flags should be
+#   returned for a given compiler.  Not all compilers currently have flags
+#   defined for them; patches are welcome.  If need be, compiler flags may
+#   be made language-dependent: use a construct like the following:
+#
+#     [vendor_name], [m4_if(_AC_LANG_PREFIX,[C],   VAR="--relevant-c-flags",dnl
+#                     m4_if(_AC_LANG_PREFIX,[CXX], VAR="--relevant-c++-flags",dnl
+#                     m4_if(_AC_LANG_PREFIX,[FC],  VAR="--relevant-fortran-flags",dnl
+#                     VAR="$2"; FOUND="no")))],
+#
+#   Note: These macros also depend on AX_PREPEND_FLAG.
 #
 # LICENSE
 #
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2010 Rhys Ulerich <rhys.ulerich@gmail.com>
+#   Copyright (c) 2018 John Zaitseff <J.Zaitseff@zap.org.au>
 #
 #   This program is free software; you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -43,7 +64,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -58,65 +79,80 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 15
+#serial 25
 
-AC_DEFUN([AX_FLAGS_WARN_ALL],[dnl
-AS_VAR_PUSHDEF([FLAGS],[_AC_LANG_PREFIX[]FLAGS])dnl
-AS_VAR_PUSHDEF([VAR],[ac_cv_[]_AC_LANG_ABBREV[]flags_warn_all])dnl
-AC_CACHE_CHECK([m4_ifval($1,$1,FLAGS) for maximum warnings],
-VAR,[VAR="no, unknown"
-ac_save_[]FLAGS="$[]FLAGS"
-for ac_arg dnl
-in "-warn all  % -warn all"   dnl Intel
-   "-pedantic  % -Wall"       dnl GCC
-   "-xstrconst % -v"          dnl Solaris C
-   "-std1      % -verbose -w0 -warnprotos" dnl Digital Unix
-   "-qlanglvl=ansi % -qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd" dnl AIX
-   "-ansi -ansiE % -fullwarn" dnl IRIX
-   "+ESlit     % +w1"         dnl HP-UX C
-   "-Xc        % -pvctl[,]fullmsg" dnl NEC SX-5 (Super-UX 10)
-   "-h conform % -h msglevel 2" dnl Cray C (Unicos)
-   #
-do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
-   AC_COMPILE_IFELSE([AC_LANG_PROGRAM],
-                     [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
-done
-FLAGS="$ac_save_[]FLAGS"
-])
-AS_VAR_POPDEF([FLAGS])dnl
-AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
-case ".$VAR" in
-     .ok|.ok,*) m4_ifvaln($3,$3) ;;
-   .|.no|.no,*) m4_default($4,[m4_ifval($2,[AX_APPEND_FLAG([$2], [$1])])]) ;;
-   *) m4_default($3,[AX_APPEND_FLAG([$VAR], [$1])]) ;;
-esac
-AS_VAR_POPDEF([VAR])dnl
+AC_DEFUN([AX_FLAGS_WARN_ALL], [
+    AX_REQUIRE_DEFINED([AX_PREPEND_FLAG])dnl
+    AC_REQUIRE([AX_COMPILER_VENDOR])dnl
+
+    AS_VAR_PUSHDEF([FLAGS], [m4_default($1,_AC_LANG_PREFIX[]FLAGS)])dnl
+    AS_VAR_PUSHDEF([VAR],   [ac_cv_[]_AC_LANG_ABBREV[]flags_warn_all])dnl
+    AS_VAR_PUSHDEF([FOUND], [ac_save_[]_AC_LANG_ABBREV[]flags_warn_all_found])dnl
+
+    AC_CACHE_CHECK([FLAGS for most reasonable warnings], VAR, [
+	VAR=""
+	FOUND="yes"
+	dnl  Cases are listed in the order found in ax_compiler_vendor.m4
+	AS_CASE("$ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor",
+	    [intel],		[VAR="-w2"],
+	    [ibm],		[VAR="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd"],
+	    [pathscale],	[],
+	    [clang],		[VAR="-Wall"],
+	    [cray],		[VAR="-h msglevel 2"],
+	    [fujitsu],		[],
+	    [sdcc],		[],
+	    [sx],		[VAR="-pvctl[,]fullmsg"],
+	    [portland],		[],
+	    [gnu],		[VAR="-Wall"],
+	    [sun],		[VAR="-v"],
+	    [hp],		[VAR="+w1"],
+	    [dec],		[VAR="-verbose -w0 -warnprotos"],
+	    [borland],		[],
+	    [comeau],		[],
+	    [kai],		[],
+	    [lcc],		[],
+	    [sgi],		[VAR="-fullwarn"],
+	    [microsoft],	[],
+	    [metrowerks],	[],
+	    [watcom],		[],
+	    [tcc],		[],
+	    [unknown],		[
+				    VAR="$2"
+				    FOUND="no"
+				],
+				[
+				    AC_MSG_WARN([Unknown compiler vendor returned by [AX_COMPILER_VENDOR]])
+				    VAR="$2"
+				    FOUND="no"
+				]
+	)
+
+	AS_IF([test "x$FOUND" = "xyes"], [dnl
+	    m4_default($3, [AS_IF([test "x$VAR" != "x"], [AX_PREPEND_FLAG([$VAR], [FLAGS])])])
+	], [dnl
+	    m4_default($4, [m4_ifval($2, [AX_PREPEND_FLAG([$VAR], [FLAGS])], [true])])
+	])dnl
+    ])dnl
+
+    AS_VAR_POPDEF([FOUND])dnl
+    AS_VAR_POPDEF([VAR])dnl
+    AS_VAR_POPDEF([FLAGS])dnl
 ])dnl AX_FLAGS_WARN_ALL
-dnl  implementation tactics:
-dnl   the for-argument contains a list of options. The first part of
-dnl   these does only exist to detect the compiler - usually it is
-dnl   a global option to enable -ansi or -extrawarnings. All other
-dnl   compilers will fail about it. That was needed since a lot of
-dnl   compilers will give false positives for some option-syntax
-dnl   like -Woption or -Xoption as they think of it is a pass-through
-dnl   to later compile stages or something. The "%" is used as a
-dnl   delimiter. A non-option comment can be given after "%%" marks
-dnl   which will be shown but not added to the respective C/CXXFLAGS.
 
-AC_DEFUN([AX_CFLAGS_WARN_ALL],[dnl
-AC_LANG_PUSH([C])
-AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
-AC_LANG_POP([C])
-])
+AC_DEFUN([AX_CFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([C])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([C])
+])dnl
 
-AC_DEFUN([AX_CXXFLAGS_WARN_ALL],[dnl
-AC_LANG_PUSH([C++])
-AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
-AC_LANG_POP([C++])
-])
+AC_DEFUN([AX_CXXFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([C++])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([C++])
+])dnl
 
-AC_DEFUN([AX_FCFLAGS_WARN_ALL],[dnl
-AC_LANG_PUSH([Fortran])
-AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
-AC_LANG_POP([Fortran])
-])
+AC_DEFUN([AX_FCFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([Fortran])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([Fortran])
+])dnl

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -29,40 +29,29 @@
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 4
+#serial 11
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
 AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
-AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+AC_CACHE_CHECK([whether the _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  if test x"m4_case(_AC_LANG,
+                     [C], [$GCC],
+                     [C++], [$GXX],
+                     [Fortran], [$GFC],
+                     [Fortran 77], [$G77],
+                     [Objective C], [$GOBJC],
+                     [Objective C++], [$GOBJCXX],
+                     [no])" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1 $add_gnu_werror"
   AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
     [AS_VAR_SET(CACHEVAR,[yes])],
     [AS_VAR_SET(CACHEVAR,[no])])

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -1,0 +1,119 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C, C++ or Fortran compiler.  The vendor is
+#   returned in the cache variable $ax_cv_c_compiler_vendor for C,
+#   $ax_cv_cxx_compiler_vendor for C++ or $ax_cv_fc_compiler_vendor for
+#   (modern) Fortran.  The value is one of "intel", "ibm", "pathscale",
+#   "clang" (LLVM), "cray", "fujitsu", "sdcc", "sx", "nvhpc" (NVIDIA HPC
+#   Compiler), "portland" (PGI), "gnu" (GCC), "sun" (Oracle Developer
+#   Studio), "hp", "dec", "borland", "comeau", "kai", "lcc", "sgi",
+#   "microsoft", "metrowerks", "watcom", "tcc" (Tiny CC) or "unknown" (if
+#   the compiler cannot be determined).
+#
+#   To check for a Fortran compiler, you must first call AC_FC_PP_SRCEXT
+#   with an appropriate preprocessor-enabled extension.  For example:
+#
+#     AC_LANG_PUSH([Fortran])
+#     AC_PROG_FC
+#     AC_FC_PP_SRCEXT([F])
+#     AX_COMPILER_VENDOR
+#     AC_LANG_POP([Fortran])
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#   Copyright (c) 2018-19 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 32
+
+AC_DEFUN([AX_COMPILER_VENDOR], [dnl
+    AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor, [dnl
+	dnl  If you modify this list of vendors, please add similar support
+	dnl  to ax_compiler_version.m4 if at all possible.
+	dnl
+	dnl  Note: Do NOT check for GCC first since some other compilers
+	dnl  define __GNUC__ to remain compatible with it.  Compilers that
+	dnl  are very slow to start (such as Intel) are listed first.
+
+	vendors="
+		intel:		__ICC,__ECC,__INTEL_COMPILER
+		ibm:		__xlc__,__xlC__,__IBMC__,__IBMCPP__,__ibmxl__
+		pathscale:	__PATHCC__,__PATHSCALE__
+		clang:		__clang__
+		cray:		_CRAYC
+		fujitsu:	__FUJITSU
+		sdcc:		SDCC,__SDCC
+		sx:		_SX
+		nvhpc:		__NVCOMPILER
+		portland:	__PGI
+		gnu:		__GNUC__
+		sun:		__SUNPRO_C,__SUNPRO_CC,__SUNPRO_F90,__SUNPRO_F95
+		hp:		__HP_cc,__HP_aCC
+		dec:		__DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+		borland:	__BORLANDC__,__CODEGEARC__,__TURBOC__
+		comeau:		__COMO__
+		kai:		__KCC
+		lcc:		__LCC__
+		sgi:		__sgi,sgi
+		microsoft:	_MSC_VER
+		metrowerks:	__MWERKS__
+		watcom:		__WATCOMC__
+		tcc:		__TINYC__
+		unknown:	UNKNOWN
+	"
+	for ventest in $vendors; do
+	    case $ventest in
+		*:)
+		    vendor=$ventest
+		    continue
+		    ;;
+		*)
+		    vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")"
+		    ;;
+	    esac
+
+	    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#if !($vencpp)
+      thisisanerror;
+#endif
+	    ]])], [break])
+	done
+
+	ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+    ])
+])dnl

--- a/m4/ax_gcc_func_attribute.m4
+++ b/m4/ax_gcc_func_attribute.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_gcc_func_attribute.html
+#  https://www.gnu.org/software/autoconf-archive/ax_gcc_func_attribute.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -38,9 +38,11 @@
 #    dllimport
 #    error
 #    externally_visible
+#    fallthrough
 #    flatten
 #    format
 #    format_arg
+#    gnu_format
 #    gnu_inline
 #    hot
 #    ifunc
@@ -53,6 +55,8 @@
 #    nothrow
 #    optimize
 #    pure
+#    sentinel
+#    sentinel_position
 #    unused
 #    used
 #    visibility
@@ -61,9 +65,9 @@
 #    weak
 #    weakref
 #
-#   Unsuppored function attributes will be tested with a prototype returning
-#   an int and not accepting any arguments and the result of the check might
-#   be wrong or meaningless so use with care.
+#   Unsupported function attributes will be tested with a prototype
+#   returning an int and not accepting any arguments and the result of the
+#   check might be wrong or meaningless so use with care.
 #
 # LICENSE
 #
@@ -74,7 +78,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 13
 
 AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
     AS_VAR_PUSHDEF([ac_var], [ax_cv_have_func_attribute_$1])
@@ -128,11 +132,17 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                 [externally_visible], [
                     int foo( void ) __attribute__(($1));
                 ],
+                [fallthrough], [
+                    void foo( int x ) {switch (x) { case 1: __attribute__(($1)); case 2: break ; }};
+                ],
                 [flatten], [
                     int foo( void ) __attribute__(($1));
                 ],
                 [format], [
                     int foo(const char *p, ...) __attribute__(($1(printf, 1, 2)));
+                ],
+                [gnu_format], [
+                    int foo(const char *p, ...) __attribute__((format(gnu_printf, 1, 2)));
                 ],
                 [format_arg], [
                     char *foo(const char *p) __attribute__(($1(1)));
@@ -175,6 +185,15 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                 [pure], [
                     int foo( void ) __attribute__(($1));
                 ],
+                [sentinel], [
+                    int foo(void *p, ...) __attribute__(($1));
+                ],
+                [sentinel_position], [
+                    int foo(void *p, ...) __attribute__(($1(1)));
+                ],
+                [returns_nonnull], [
+                    void *foo( void ) __attribute__(($1));
+                ],
                 [unused], [
                     int foo( void ) __attribute__(($1));
                 ],
@@ -209,7 +228,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
             dnl GCC doesn't exit with an error if an unknown attribute is
             dnl provided but only outputs a warning, so accept the attribute
             dnl only if no warning were issued.
-            [AS_IF([test -s conftest.err],
+            [AS_IF([grep -- -Wattributes conftest.err],
                 [AS_VAR_SET([ac_var], [no])],
                 [AS_VAR_SET([ac_var], [yes])])],
             [AS_VAR_SET([ac_var], [no])])

--- a/m4/ax_prepend_flag.m4
+++ b/m4/ax_prepend_flag.m4
@@ -1,36 +1,37 @@
 # ===========================================================================
-#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+#     https://www.gnu.org/software/autoconf-archive/ax_prepend_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
 #
-#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#   AX_PREPEND_FLAG(FLAG, [FLAGS-VARIABLE])
 #
 # DESCRIPTION
 #
-#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
-#   added in between.
+#   FLAG is added to the front of the FLAGS-VARIABLE shell variable, with a
+#   space added in between.
 #
 #   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
 #   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
 #   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
 #   FLAG.
 #
-#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#   NOTE: Implementation based on AX_APPEND_FLAG.
 #
 # LICENSE
 #
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#   Copyright (c) 2018 John Zaitseff <J.Zaitseff@zap.org.au>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 2
 
-AC_DEFUN([AX_APPEND_FLAG],
+AC_DEFUN([AX_PREPEND_FLAG],
 [dnl
 AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
 AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
@@ -38,7 +39,7 @@ AS_VAR_SET_IF(FLAGS,[
   AS_CASE([" AS_VAR_GET(FLAGS) "],
     [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
     [
-     AS_VAR_APPEND(FLAGS,[" $1"])
+     FLAGS="$1 $FLAGS"
      AC_RUN_LOG([: FLAGS="$FLAGS"])
     ])
   ],
@@ -47,4 +48,4 @@ AS_VAR_SET_IF(FLAGS,[
   AC_RUN_LOG([: FLAGS="$FLAGS"])
   ])
 AS_VAR_POPDEF([FLAGS])dnl
-])dnl AX_APPEND_FLAG
+])dnl AX_PREPEND_FLAG

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
   m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])

--- a/m4/axrdp_prog_nasm.m4
+++ b/m4/axrdp_prog_nasm.m4
@@ -1,7 +1,7 @@
-# AC_PROG_NASM
+# AXRDP_PROG_NASM
 # --------------------------
 # Check that NASM exists and determine flags
-AC_DEFUN([AC_PROG_NASM],[
+AC_DEFUN([AXRDP_PROG_NASM],[
 
 AC_CHECK_PROGS(NASM, [nasm nasmw yasm])
 test -z "$NASM" && AC_MSG_ERROR([no nasm (Netwide Assembler) found])
@@ -116,8 +116,8 @@ try_nasm='$NASM $NAFLAGS -o conftest-nasm.o conftest.asm'
 if AC_TRY_EVAL(try_nasm) && test -s conftest-nasm.o; then
   AC_MSG_RESULT(yes)
 else
-  echo "configure: failed program was:" >&AC_FD_CC
-  cat conftest.asm >&AC_FD_CC
+  echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+  cat conftest.asm >&AS_MESSAGE_LOG_FD
   rm -rf conftest*
   AC_MSG_RESULT(no)
   AC_MSG_ERROR([installation or configuration problem: assembler cannot create object files.])


### PR DESCRIPTION
Tested on Ubuntu 16.04 (autoconf 2.69) and Ubuntu 24.04 (autoconf 2.71)

2.69 is not the latest version, but it is the version used by xrdp.

Various obsolete macros have been updated. In addition:-
1) The file m4/nasm.m4 has been renamed to m4/axrdp_prog_nasm.m4, and the private macro it contains has been renamed from `AC_PROG_NASM` to `AXRDP_PROG_NASM`. This is because the AC_* namespace is reserved for autoconf macros.
2) The m4/ax_*.m4 library files have been update to the latest versions from https://git.savannah.gnu.org/cgit/autoconf-archive.git
3) Following 2), missing macros `AX_COMPILER_VENDOR` and `AX_PREPEND_FLAG` have also been added.