### PR TITLE
Use different struct from xrdp

### DIFF
--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -104,7 +104,7 @@ struct _rdpClientCon
     struct font_cache font_cache[12][256];
     int font_stamp;
 
-    struct xrdp_client_info client_info;
+    struct xorgxrdp_client_info client_info;
 
     uint8_t *shmemptr;
     int shmemfd;

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -80,7 +80,7 @@ static char g_Keyboard_str[] = "Keyboard";
 static char g_xrdp_keyb_name[] = XRDP_KEYB_NAME;
 
 static int
-rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info);
+rdpLoadLayout(rdpKeyboard *keyboard, struct xorgxrdp_client_info *client_info);
 
 /******************************************************************************/
 static void
@@ -297,7 +297,7 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
             KbdSync(keyboard, param1);
             break;
         case 18:
-            rdpLoadLayout(keyboard, (struct xrdp_client_info *) param1);
+            rdpLoadLayout(keyboard, (struct xorgxrdp_client_info *) param1);
             break;
 
     }
@@ -573,7 +573,7 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
 
 /******************************************************************************/
 static int
-rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info)
+rdpLoadLayout(rdpKeyboard *keyboard, struct xorgxrdp_client_info *client_info)
 {
     // Load default layout parameters
     XkbRMLVOSet set =


### PR DESCRIPTION
In the proposed neutrinolabs/xrdp#3492,  xrdp now passes us `struct xorgxrdp_client_con`, rather than `struct xrdp_client_con`

This PR won't compile until neutrinolabs/xrdp#3492 is merged.