### PR TITLE
Rename struct from xrdp

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -34,7 +34,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "rdpPri.h"
 
-#include "xrdp_client_info.h"
+#include "xup_client_info.h"
 #include "xrdp_constants.h"
 
 #define XRDP_MODULE_NAME "XORGXRDP"

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -729,7 +729,7 @@ rdpClientConSendCaps(rdpPtr dev, rdpClientCon *clientCon)
 
     out_uint16_le(ls, 100);   /* Version capability */
     out_uint16_le(ls, 2 + 2 + 4);
-    out_uint32_le(ls, CLIENT_INFO_CURRENT_VERSION);
+    out_uint32_le(ls, XUP_CLIENT_INFO_CURRENT_VERSION);
     cap_count++;
 
     s_mark_end(ls);
@@ -1366,10 +1366,10 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
 
     // This shouldn't happen - xrdp should check the version we send it
     // before sending client info.
-    if (clientCon->client_info.version != CLIENT_INFO_CURRENT_VERSION)
+    if (clientCon->client_info.version != XUP_CLIENT_INFO_CURRENT_VERSION)
     {
         LLOGLN(0, ("expected xrdp client_info version %d, got %d",
-                   CLIENT_INFO_CURRENT_VERSION,
+                   XUP_CLIENT_INFO_CURRENT_VERSION,
                    clientCon->client_info.version));
         FatalError("Incompatible xrdp version detected  - please recompile");
     }

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -21,14 +21,14 @@ Client connection to xrdp
 
 */
 
+#ifndef _RDPCLIENTCON_H
+#define _RDPCLIENTCON_H
+
 #include <xorg-server.h>
 #include <xorgVersion.h>
 #include <xf86.h>
 
-#include "xrdp_client_info.h"
-
-#ifndef _RDPCLIENTCON_H
-#define _RDPCLIENTCON_H
+#include "xup_client_info.h"
 
 /* used in rdpGlyphs.c */
 struct font_cache
@@ -104,7 +104,7 @@ struct _rdpClientCon
     struct font_cache font_cache[12][256];
     int font_stamp;
 
-    struct xrdp_client_info client_info;
+    struct xup_client_info client_info;
 
     uint8_t *shmemptr;
     int shmemfd;

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -273,12 +273,8 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
     client_max_height = 32;
     sending_bpp = 0;
     can_do_new = clientCon->client_info.pointer_flags & 1;
-#if CLIENT_INFO_CURRENT_VERSION >= 20230425
     can_do_large = (clientCon->client_info.large_pointer_support_flags &
                     LARGE_POINTER_FLAG_96x96);
-#else
-    can_do_large = 0;
-#endif
     if ((pCurs == NULL) || (pCurs->bits == NULL))
     {
         /* None cursor */

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -54,11 +54,6 @@ xrdp keyboard module
 #include "rdpMisc.h"
 #include "rdpMain.h"
 
-// Check the minimum xrdp client version.
-#if CLIENT_INFO_CURRENT_VERSION < 20240805
-#error "xrdp is too old to contain evdev keyboard support"
-#endif
-
 #include "xrdp_scancode_defs.h"
 
 /******************************************************************************/
@@ -80,7 +75,7 @@ static char g_Keyboard_str[] = "Keyboard";
 static char g_xrdp_keyb_name[] = XRDP_KEYB_NAME;
 
 static int
-rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info);
+rdpLoadLayout(rdpKeyboard *keyboard, struct xup_client_info *client_info);
 
 /******************************************************************************/
 static void
@@ -297,7 +292,7 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
             KbdSync(keyboard, param1);
             break;
         case 18:
-            rdpLoadLayout(keyboard, (struct xrdp_client_info *) param1);
+            rdpLoadLayout(keyboard, (struct xup_client_info *) param1);
             break;
 
     }
@@ -573,7 +568,7 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
 
 /******************************************************************************/
 static int
-rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info)
+rdpLoadLayout(rdpKeyboard *keyboard, struct xup_client_info *client_info)
 {
     // Load default layout parameters
     XkbRMLVOSet set =


### PR DESCRIPTION
Supercedes #384 

xrdp now passes us 'struct xup_client_info' rather than 'struct xrdp_client_info'.

The macro CLIENT_INFO_CURRENT_VERSION is replaced with XUP_CLIENT_INFO_CURRENT_VERSION. This allows us to remove some obsolete checks for the old macro.

This PR won't compile until neutrinolabs/xrdp#3534 is merged.