### PR TITLE
xinput: Use standard type name in InputInfoPtr

### DIFF
--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -70,7 +70,7 @@ static char g_evdev_str[] = "evdev";
 static char g_pc104_str[] = "pc104";
 static char g_us_str[] = "us";
 static char g_empty_str[] = "";
-static char g_Keyboard_str[] = "Keyboard";
+static char g_Keyboard_str[] = XI_KEYBOARD;
 
 static char g_xrdp_keyb_name[] = XRDP_KEYB_NAME;
 
@@ -443,7 +443,7 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
     info->device_control = rdpkeybControl;
     info->flags = XI86_CONFIGURED | XI86_ALWAYS_CORE | XI86_SEND_DRAG_EVENTS |
                   XI86_CORE_KEYBOARD | XI86_KEYBOARD_CAPABLE;
-    info->type_name = "Keyboard";
+    info->type_name = g_Keyboard_str;
     info->fd = -1;
     info->conf_idev = dev;
 

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -58,7 +58,7 @@ xrdp mouse module
 #define LLOGLN(_level, _args) \
     do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
-static char g_Mouse_str[] = "Mouse";
+static char g_Mouse_str[] = XI_MOUSE;
 static char g_xrdp_mouse_name[] = XRDP_MOUSE_NAME;
 
 /******************************************************************************/
@@ -402,7 +402,7 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
     info->device_control = rdpmouseControl;
     info->flags = XI86_CONFIGURED | XI86_ALWAYS_CORE | XI86_SEND_DRAG_EVENTS |
                   XI86_CORE_POINTER | XI86_POINTER_CAPABLE;
-    info->type_name = "Mouse";
+    info->type_name = g_Mouse_str;
     info->fd = -1;
     info->conf_idev = dev;
 


### PR DESCRIPTION
We should use strings defined in XI.h for the type field here. This fixes pointer detection issue in Chromium, resolves #394.

See also:
- https://issues.chromium.org/issues/443001333

-----

Tested with Chromium 141.0.7390.122 (FreeBSD port).

### Before applying the fix (no pointers)
<img width="415" alt="508020565-7dc531ea-ea22-4d08-ace9-c40ae56ac5fc" src="https://github.com/user-attachments/assets/5dbae5f2-3657-4060-b2c8-b2d1c20fcf74" />

### After applying the fix (pointers are detected)
<img width="361" height="647" alt="508094556-0262667d-fbba-4390-aa4d-fefe37c3c4fc" src="https://github.com/user-attachments/assets/d919d0f3-12d6-4c0f-99bb-8cdc89ef56b8" />

