### PR TITLE
[V0.10] CI : Update FreeBSD xrdp dependency

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ FreeBSD_task:
     TEST_DEPS: xdpyinfo
   prepare_script:
     - pkg install -y $BUILD_TOOLS $BUILD_DEPS $TEST_DEPS
-    - git clone $XRDP_REPO
+    - git clone --depth 1 --branch=v0.10 $XRDP_REPO
     - ./bootstrap
   configure_script:
     ./configure


### PR DESCRIPTION
Changes the Cirrus xrdp checkout to pull in v0.10 rather than devel.

This change has already been made to Github for the Linux builds.