### PR TITLE
Add Xlibre support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,8 +4,16 @@ FreeBSD_task:
   env:
     XRDP_REPO: https://github.com/neutrinolabs/xrdp
     BUILD_TOOLS: git autoconf automake libtool pkgconf
-    BUILD_DEPS: nasm xorg-server
+    BUILD_DEPS: nasm $XORG_SERVER
     TEST_DEPS: xdpyinfo
+
+  matrix:
+    - name: FreeBSD build with Xorg
+      env:
+        XORG_SERVER: xorg-server
+    - name: FreeBSD build with Xlibre
+      env:
+        XORG_SERVER: xlibre-server
   prepare_script:
     - pkg install -y $BUILD_TOOLS $BUILD_DEPS $TEST_DEPS
     - git clone --depth 1 --branch=v0.10 $XRDP_REPO

--- a/m4/axrdp_prog_nasm.m4
+++ b/m4/axrdp_prog_nasm.m4
@@ -40,7 +40,7 @@ case "$host_os" in
         ;;
     esac
   ;;
-  kfreebsd* | freebsd* | netbsd* | openbsd*)
+  kfreebsd* | freebsd* | netbsd* | openbsd* | dragonfly* )
     if echo __ELF__ | $CC -E - | grep __ELF__ > /dev/null; then
       objfmt='BSD-a.out'
     else

--- a/module/rdp.h
+++ b/module/rdp.h
@@ -95,6 +95,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define RegionUnionRect DONOTUSE
 #endif
 
+/* NullClient is removed in Xlibre */
+#ifndef NullClient
+#define NullClient ((ClientPtr) 0)
+#endif
+
 struct image_data
 {
     int left;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -1356,6 +1356,7 @@ copy_vmem(rdpPtr dev, RegionPtr in_reg)
     {
         tmpval[0].val = GXcopy;
         ChangeGC(NullClient, copyGC, GCFunction, tmpval);
+
         ValidateGC(&(hwPixmap->drawable), copyGC);
         count = REGION_NUM_RECTS(in_reg);
         pbox = REGION_RECTS(in_reg);

--- a/tests/xorg-test-run.sh
+++ b/tests/xorg-test-run.sh
@@ -75,7 +75,7 @@ $XORG \
   -modulepath $moduledir \
   -config $top_srcdir/xrdpdev/xorg.conf \
   -logfile $XORG_LOG \
-  -novtswitch -sharevts -once -terminate -ac \
+  -novtswitch -sharevts -terminate -ac \
   $TEST_DISPLAY $XORG_ARGS >$XORG_OUT 2>$XORG_ERR </dev/null &
 
 # Record Xorg PID so it can be killed

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -863,8 +863,8 @@ rdpLoadLayout(rdpKeyboard *keyboard, struct xrdp_client_info *client_info)
 
     int keylayout = client_info->keylayout;
 
-    LLOGLN(0, ("rdpLoadLayout: keylayout 0x%8.8x variant %s display %s",
-               keylayout, client_info->variant, display));
+    LLOGLN(0, ("rdpLoadLayout: keylayout 0x%8.8x variant %s",
+               keylayout, client_info->variant));
     memset(&set, 0, sizeof(set));
     set.rules = g_base_str;
 


### PR DESCRIPTION
Based on work by @b-aaz on [FreeBSD bug 291595](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291595).

See also:
- https://github.com/b-aaz/xlibre-ports/commits/master/x11-drivers/xorgxrdp

I'll forward this to devel once merged.