### PR TITLE
Update logging

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -55,10 +55,6 @@ capture
 #include <glamor.h>
 #endif
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #define RGB_SPLIT(A, R, G, B, pixel) \
     A = (pixel >> 24) & UCHAR_MAX; \
     R = (pixel >> 16) & UCHAR_MAX; \

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -62,10 +62,6 @@ Client connection to xrdp
 #include "rdpRandRGrid.h"
 #endif
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #define LTOUI32(_in) ((unsigned int)(_in))
 
 #define USE_MAX_OS_BYTES 1

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -224,7 +224,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     rdpClientCon *clientCon;
     int new_sck;
 
-    LLOGLN(0, ("rdpClientConGotConnection:"));
+    LLOGLN(10, ("rdpClientConGotConnection:"));
     clientCon = g_new0(rdpClientCon, 1);
     clientCon->shmemstatus = SHM_UNINITIALIZED;
     clientCon->updateRetries = 0;
@@ -378,7 +378,7 @@ rdpShutdownAccelAssist(rdpPtr dev, rdpClientCon *clientCon) {
     int index;
     int exit_code = 0;
 
-    LLOGLN(0, ("rdpShutdownAccelAssist:"));
+    LLOGLN(10, ("rdpShutdownAccelAssist:"));
     if (clientCon->accel_assist_pid <= 0)
     {
         return 0;
@@ -432,7 +432,7 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
 {
     int index;
 
-    LLOGLN(0, ("rdpClientConDisconnect:"));
+    LLOGLN(10, ("rdpClientConDisconnect:"));
 
     if (dev->idleDisconnectTimer != NULL && dev->idle_disconnect_timeout_s > 0)
     {
@@ -845,7 +845,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
 
     enum shared_memory_status shmemstatus;
 
-    LLOGLN(0, ("rdpClientConResizeAllMemoryAreas:"));
+    LLOGLN(10, ("rdpClientConResizeAllMemoryAreas:"));
 
     // Updare the rdp size from the client size
     clientCon->rdp_width = width;
@@ -1350,7 +1350,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     int bytes;
     int i1;
 
-    LLOGLN(0, ("rdpClientConProcessMsgClientInfo:"));
+    LLOGLN(10, ("rdpClientConProcessMsgClientInfo:"));
     s = clientCon->in_s;
     in_uint32_le(s, bytes);
     if (bytes > sizeof(clientCon->client_info))
@@ -1625,7 +1625,7 @@ static int
 rdpClientConGotControlConnection(ScreenPtr pScreen, rdpPtr dev,
                                  rdpClientCon *clientCon)
 {
-    LLOGLN(0, ("rdpClientConGotControlConnection:"));
+    LLOGLN(10, ("rdpClientConGotControlConnection:"));
     return 0;
 }
 
@@ -1634,7 +1634,7 @@ static int
 rdpClientConGotControlData(ScreenPtr pScreen, rdpPtr dev,
                            rdpClientCon *clientCon)
 {
-    LLOGLN(0, ("rdpClientConGotControlData:"));
+    LLOGLN(10, ("rdpClientConGotControlData:"));
     return 0;
 }
 
@@ -1954,7 +1954,7 @@ rdpClientConInit(rdpPtr dev)
 int
 rdpClientConDeinit(rdpPtr dev)
 {
-    LLOGLN(0, ("rdpClientConDeinit:"));
+    LLOGLN(10, ("rdpClientConDeinit:"));
 
     while (dev->clientConTail != NULL)
     {

--- a/module/rdpComposite.c
+++ b/module/rdpComposite.c
@@ -43,13 +43,9 @@ composite(alpha blending) calls
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpComposite.h"
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpCompositeRects.c
+++ b/module/rdpCompositeRects.c
@@ -41,13 +41,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpCompositeRects.h"
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpCopyArea.c
+++ b/module/rdpCopyArea.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpCopyArea.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static RegionPtr

--- a/module/rdpCopyPlane.c
+++ b/module/rdpCopyPlane.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpCopyPlane.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static RegionPtr

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -51,6 +51,7 @@ cursor
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpCursor.h"
 
 #ifndef X_BYTE_ORDER
@@ -95,11 +96,6 @@ static uint8_t g_reverse_byte[0x100] =
     0x1f, 0x9f, 0x5f, 0xdf, 0x3f, 0xbf, 0x7f, 0xff
 };
 #endif
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 Bool

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -360,7 +360,7 @@ rdpCloseScreen(int index, ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(0, ("rdpCloseScreen:"));
+    LLOGLN(10, ("rdpCloseScreen:"));
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(index, pScreen);
@@ -378,7 +378,7 @@ rdpCloseScreen(ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(0, ("rdpCloseScreen:"));
+    LLOGLN(10, ("rdpCloseScreen:"));
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(pScreen);

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -51,10 +51,6 @@ misc draw calls
 #include "rdpReg.h"
 #include "rdpMain.h"
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #if !defined(XORG_VERSION_CURRENT)
 #warning XORG_VERSION_CURRENT not defined
 #endif

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -284,10 +284,6 @@ void main()\n\
                         ((crc >> 24) & 0xFF) / 255.0);\n\
 }\n";
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 /******************************************************************************/
 void *
 rdpEglCreate(ScreenPtr screen)

--- a/module/rdpFillPolygon.c
+++ b/module/rdpFillPolygon.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpFillPolygon.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 void

--- a/module/rdpFillSpans.c
+++ b/module/rdpFillSpans.c
@@ -57,7 +57,7 @@ void
 rdpFillSpans(DrawablePtr pDrawable, GCPtr pGC, int nInit,
              DDXPointPtr pptInit, int *pwidthInit, int fSorted)
 {
-    LLOGLN(0, ("rdpFillSpans:"));
+    LLOGLN(10, ("rdpFillSpans:"));
     /* do original call */
     rdpFillSpansOrg(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted);
 }

--- a/module/rdpFillSpans.c
+++ b/module/rdpFillSpans.c
@@ -37,11 +37,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "rdp.h"
 #include "rdpDraw.h"
+#include "rdpMisc.h"
 #include "rdpFillSpans.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpGC.c
+++ b/module/rdpGC.c
@@ -54,6 +54,7 @@ GC related calls
 #include "rdpPolyRectangle.h"
 #include "rdpPolyArc.h"
 #include "rdpFillPolygon.h"
+#include "rdpMisc.h"
 #include "rdpPolyFillRect.h"
 #include "rdpPolyFillArc.h"
 #include "rdpPolyText8.h"
@@ -65,11 +66,6 @@ GC related calls
 #include "rdpPushPixels.h"
 #include "rdpDraw.h"
 #include "rdpGC.h"
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 #define GC_FUNC_VARS rdpPtr dev; rdpGCPtr priv;

--- a/module/rdpGlyphs.c
+++ b/module/rdpGlyphs.c
@@ -47,11 +47,6 @@ glyph (font) calls
 #include "rdpReg.h"
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
-/******************************************************************************/
 int
 rdpGlyphDeleteRdpText(struct rdp_text *rtext)
 {

--- a/module/rdpImageGlyphBlt.c
+++ b/module/rdpImageGlyphBlt.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpImageGlyphBlt.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpImageGlyphBlt.c
+++ b/module/rdpImageGlyphBlt.c
@@ -67,7 +67,7 @@ rdpImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(0, ("rdpImageGlyphBlt:"));
+    LLOGLN(10, ("rdpImageGlyphBlt:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);

--- a/module/rdpImageText16.c
+++ b/module/rdpImageText16.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpImageText16.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpImageText8.c
+++ b/module/rdpImageText8.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpImageText8.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -40,10 +40,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdpInput.h"
 #include "rdpMisc.h"
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #define MAX_INPUT_PROC 4
 
 struct input_proc_list

--- a/module/rdpLRandR.c
+++ b/module/rdpLRandR.c
@@ -985,7 +985,7 @@ ProcLRRDispatch(ClientPtr client)
 static int
 SProcLRRDispatch(ClientPtr client)
 {
-    LLOGLN(0, ("SProcLRRDispatch:"));
+    LLOGLN(10, ("SProcLRRDispatch:"));
     return 0;
 }
 

--- a/module/rdpLRandR.c
+++ b/module/rdpLRandR.c
@@ -25,10 +25,6 @@
 #endif
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 /* 
             start   end
 crtc ids    1       16

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -80,10 +80,6 @@ rdp module main
 #endif
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 static Bool g_initialised = FALSE;
 
 static Bool g_nvidia_wrap_done = FALSE;

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -100,7 +100,7 @@ xorgxrdpPreInit(ScrnInfoPtr pScrn, int flags)
     Bool rv;
     const char *env;
 
-    LLOGLN(0, ("xorgxrdpPreInit:"));
+    LLOGLN(10, ("xorgxrdpPreInit:"));
     env = getenv("XRDP_NVIDIA_GRID");
     if (env != NULL)
     {
@@ -160,7 +160,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpCreateScreenResources:"));
+    LLOGLN(10, ("rdpCreateScreenResources:"));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -232,7 +232,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(0, ("xorgxrdpDamageDestroy:"));
+    LLOGLN(10, ("xorgxrdpDamageDestroy:"));
 }
 
 #ifdef XACE_DISABLE_DRI3_PRESENT
@@ -264,7 +264,7 @@ xorgxrdpDeferredStartup(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(0, ("xorgxrdpDeferredStartup:"));
+    LLOGLN(10, ("xorgxrdpDeferredStartup:"));
     pScreen = (ScreenPtr)arg;
     if (pScreen->root != NULL)
     {
@@ -309,7 +309,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
     miPointerScreenPtr PointPriv;
     rrScrPrivPtr pRRScrPriv;
 
-    LLOGLN(0, ("xorgxrdpScreenInit:"));
+    LLOGLN(10, ("xorgxrdpScreenInit:"));
     rv = g_orgScreenInit(pScreen, argc, argv);
     if (rv)
     {
@@ -445,7 +445,7 @@ xorgxrdpPciProbe(struct _DriverRec * drv, int entity_num,
 {
     Bool rv;
 
-    LLOGLN(0, ("xorgxrdpPciProbe:"));
+    LLOGLN(10, ("xorgxrdpPciProbe:"));
     rv = g_saved_driver.PciProbe(drv, entity_num, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -457,7 +457,7 @@ xorgxrdpPlatformProbe(struct _DriverRec * drv, int entity_num, int flags,
 {
     Bool rv;
 
-    LLOGLN(0, ("xorgxrdpPlatformProbe:"));
+    LLOGLN(10, ("xorgxrdpPlatformProbe:"));
     rv = g_saved_driver.platformProbe(drv, entity_num, flags, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -469,7 +469,7 @@ xorgxrdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
     xorgHWFlags *flags;
     Bool rv;
 
-    LLOGLN(0, ("xorgxrdpDriverFunc:"));
+    LLOGLN(10, ("xorgxrdpDriverFunc:"));
     rv = g_saved_driver.driverFunc(pScrn, op, ptr);
     if (op == GET_REQUIRED_HW_INTERFACES)
     {
@@ -514,7 +514,7 @@ static pointer
 xorgxrdpSetup(pointer Module, pointer Options,
               int *ErrorMajor, int *ErrorMinor)
 {
-    LLOGLN(0, ("xorgxrdpSetup:"));
+    LLOGLN(10, ("xorgxrdpSetup:"));
     if (!g_initialised)
     {
         g_initialised = TRUE;
@@ -528,14 +528,14 @@ xorgxrdpSetup(pointer Module, pointer Options,
 static void
 xorgxrdpTearDown(pointer Module)
 {
-    LLOGLN(0, ("xorgxrdpTearDown:"));
+    LLOGLN(10, ("xorgxrdpTearDown:"));
 }
 
 /*****************************************************************************/
 void
 xorgxrdpDownDown(ScreenPtr pScreen)
 {
-    LLOGLN(0, ("xorgxrdpDownDown:"));
+    LLOGLN(10, ("xorgxrdpDownDown:"));
     if (g_initialised)
     {
         g_initialised = FALSE;

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -647,3 +647,46 @@ g_free_unmap_fd(void *addr, int fd, size_t size)
     munmap(addr, size);
     close(fd);
 }
+
+/******************************************************************************/
+void
+g_log_info(const char *format, ...)
+{
+    va_list ap;
+
+    va_start(ap, format);
+    LogVMessageVerb(X_INFO, 0, format, ap);
+    va_end(ap);
+    // Also need to terminate message. This seems the simplest way.
+    va_start(ap, format);
+    LogVMessageVerb(X_NONE, 0, "\n", ap);
+    va_end(ap);
+}
+
+/******************************************************************************/
+void
+g_log_debug(const char *format, ...)
+{
+    va_list ap;
+
+    va_start(ap, format);
+    LogVMessageVerb(X_DEBUG, 1, format, ap);
+    va_end(ap);
+    va_start(ap, format);
+    LogVMessageVerb(X_NONE, 1, "\n", ap);
+    va_end(ap);
+}
+
+/******************************************************************************/
+void
+g_log_trace(const char *format, ...)
+{
+    va_list ap;
+
+    va_start(ap, format);
+    LogVMessageVerb(X_DEBUG, 2, format, ap);
+    va_end(ap);
+    va_start(ap, format);
+    LogVMessageVerb(X_NONE, 2, "\n", ap);
+    va_end(ap);
+}

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -117,6 +117,18 @@ g_log_debug(const char *format, ...) PRINTFLIKE(1,2);
 extern _X_EXPORT void
 g_log_trace(const char *format, ...) PRINTFLIKE(1,2);
 
+/* Legacy logging macro
+ *
+ * Remove when unused
+ *
+ * _level : 0=Info, 1=Debug, 10=Trace
+ * _args : Argument to logging function
+ */
+#define LLOGLN(_level, _args) \
+{ \
+    ((_level > 1) ? g_log_trace : \
+     (_level == 1) ? g_log_debug : g_log_info) _args; \
+}
 
 /* glib-style memory allocation macros */
 #define g_new(struct_type, n_structs) \

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -33,10 +33,10 @@ the rest
 #include <config_ac.h>
 
 #if defined(HAVE_FUNC_ATTRIBUTE_FORMAT)
-#define printflike(arg_format, arg_first_check) \
+#define PRINTFLIKE(arg_format, arg_first_check) \
  __attribute__((__format__(__printf__, arg_format, arg_first_check)))
 #else
-#define printflike(arg_format, arg_first_check)
+#define PRINTFLIKE(arg_format, arg_first_check)
 #endif
 
 
@@ -62,7 +62,7 @@ g_sleep(int msecs);
 extern _X_EXPORT int
 g_sck_send(int sck, const void *ptr, int len, int flags);
 extern _X_EXPORT void
-g_sprintf(char *dest, const char *format, ...);
+g_sprintf(char *dest, const char *format, ...) PRINTFLIKE(2,3);
 extern _X_EXPORT int
 g_snprintf(char *dest, unsigned int dest_size, const char *format, ...);
 extern _X_EXPORT int
@@ -108,6 +108,15 @@ extern _X_EXPORT int
 g_alloc_map_fd(void **addr, int *fd, size_t size);
 extern _X_EXPORT void
 g_free_unmap_fd(void *addr, int fd, size_t size);
+
+/* Logging. Use these for new code */
+extern _X_EXPORT void
+g_log_info(const char *format, ...) PRINTFLIKE(1,2);
+extern _X_EXPORT void
+g_log_debug(const char *format, ...) PRINTFLIKE(1,2);
+extern _X_EXPORT void
+g_log_trace(const char *format, ...) PRINTFLIKE(1,2);
+
 
 /* glib-style memory allocation macros */
 #define g_new(struct_type, n_structs) \

--- a/module/rdpPixmap.c
+++ b/module/rdpPixmap.c
@@ -39,6 +39,7 @@ pixmap calls
 
 #include "rdp.h"
 #include "rdpDraw.h"
+#include "rdpMisc.h"
 #include "rdpPixmap.h"
 
 #ifndef XRDP_PIX
@@ -46,10 +47,6 @@ pixmap calls
 #endif
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #if XRDP_PIX == 2
 
 /*****************************************************************************/

--- a/module/rdpPolyArc.c
+++ b/module/rdpPolyArc.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyArc.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPolyArc.c
+++ b/module/rdpPolyArc.c
@@ -66,7 +66,7 @@ rdpPolyArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(0, ("rdpPolyArc:"));
+    LLOGLN(10, ("rdpPolyArc:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyArcCallCount++;
     rdpRegionInit(&reg, NullBox, 0);

--- a/module/rdpPolyFillArc.c
+++ b/module/rdpPolyFillArc.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyFillArc.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPolyFillRect.c
+++ b/module/rdpPolyFillRect.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyFillRect.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPolyGlyphBlt.c
+++ b/module/rdpPolyGlyphBlt.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyGlyphBlt.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 void

--- a/module/rdpPolyGlyphBlt.c
+++ b/module/rdpPolyGlyphBlt.c
@@ -67,7 +67,7 @@ rdpPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(0, ("rdpPolyGlyphBlt:"));
+    LLOGLN(10, ("rdpPolyGlyphBlt:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);

--- a/module/rdpPolyPoint.c
+++ b/module/rdpPolyPoint.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyPoint.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPolyRectangle.c
+++ b/module/rdpPolyRectangle.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyRectangle.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPolySegment.c
+++ b/module/rdpPolySegment.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolySegment.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 void

--- a/module/rdpPolyText16.c
+++ b/module/rdpPolyText16.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyText16.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static int

--- a/module/rdpPolyText8.c
+++ b/module/rdpPolyText8.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolyText8.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static int

--- a/module/rdpPolylines.c
+++ b/module/rdpPolylines.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPolylines.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPushPixels.c
+++ b/module/rdpPushPixels.c
@@ -57,7 +57,7 @@ void
 rdpPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDst,
               int w, int h, int x, int y)
 {
-    LLOGLN(0, ("rdpPushPixels:"));
+    LLOGLN(10, ("rdpPushPixels:"));
     /* do original call */
     rdpPushPixelsOrg(pGC, pBitMap, pDst, w, h, x, y);
 }

--- a/module/rdpPushPixels.c
+++ b/module/rdpPushPixels.c
@@ -37,11 +37,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "rdp.h"
 #include "rdpDraw.h"
+#include "rdpMisc.h"
 #include "rdpPushPixels.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -38,12 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpPutImage.h"
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -78,7 +78,7 @@ Bool
 rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
                RRScreenSizePtr pSize)
 {
-    LLOGLN(0, ("rdpRRSetConfig:"));
+    LLOGLN(10, ("rdpRRSetConfig:"));
     return TRUE;
 }
 
@@ -86,7 +86,7 @@ rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
 Bool
 rdpRRGetInfo(ScreenPtr pScreen, Rotation *pRotations)
 {
-    LLOGLN(0, ("rdpRRGetInfo:"));
+    LLOGLN(10, ("rdpRRGetInfo:"));
     *pRotations = RR_Rotate_0;
     return TRUE;
 }
@@ -215,7 +215,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
              int x, int y, Rotation rotation, int numOutputs,
              RROutputPtr *outputs)
 {
-    LLOGLN(0, ("rdpRRCrtcSet:"));
+    LLOGLN(10, ("rdpRRCrtcSet:"));
     return TRUE;
 }
 
@@ -223,7 +223,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
 Bool
 rdpRRCrtcSetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
-    LLOGLN(0, ("rdpRRCrtcSetGamma:"));
+    LLOGLN(10, ("rdpRRCrtcSetGamma:"));
     return TRUE;
 }
 
@@ -241,7 +241,7 @@ Bool
 rdpRROutputSetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property,
                        RRPropertyValuePtr value)
 {
-    LLOGLN(0, ("rdpRROutputSetProperty:"));
+    LLOGLN(10, ("rdpRROutputSetProperty:"));
     return TRUE;
 }
 
@@ -250,7 +250,7 @@ Bool
 rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
                         RRModePtr mode)
 {
-    LLOGLN(0, ("rdpRROutputValidateMode:"));
+    LLOGLN(10, ("rdpRROutputValidateMode:"));
     return TRUE;
 }
 
@@ -258,14 +258,14 @@ rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
 void
 rdpRRModeDestroy(ScreenPtr pScreen, RRModePtr mode)
 {
-    LLOGLN(0, ("rdpRRModeDestroy:"));
+    LLOGLN(10, ("rdpRRModeDestroy:"));
 }
 
 /******************************************************************************/
 Bool
 rdpRROutputGetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property)
 {
-    LLOGLN(0, ("rdpRROutputGetProperty:"));
+    LLOGLN(10, ("rdpRROutputGetProperty:"));
     return TRUE;
 }
 
@@ -360,7 +360,7 @@ Bool
 rdpRRSetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
                 BoxPtr trackingArea, INT16 *border)
 {
-    LLOGLN(0, ("rdpRRSetPanning:"));
+    LLOGLN(10, ("rdpRRSetPanning:"));
     return TRUE;
 }
 
@@ -418,7 +418,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     char name[64];
     const int vfreq = 50;
 
-    LLOGLN(0, ("rdpRRConnectOutput:"));
+    LLOGLN(10, ("rdpRRConnectOutput:"));
     sprintf (name, "%dx%d", width, height);
     modeInfo.width = width;
     modeInfo.height = height;

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -55,11 +55,6 @@ RandR draw calls
 static int g_panning = 0;
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
-/******************************************************************************/
 Bool
 rdpRRRegisterSize(ScreenPtr pScreen, int width, int height)
 {

--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -47,10 +47,6 @@ NVidia Grid RandR
 #define NV_GRID_END_CMD_MAX 2048
 #define NV_GRID_CMD_FILE ".xrdp_grid_xrandr.sh"
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 struct monitor_t
 {
     int flags;

--- a/module/rdpSetSpans.c
+++ b/module/rdpSetSpans.c
@@ -37,13 +37,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "rdp.h"
 #include "rdpDraw.h"
+#include "rdpMisc.h"
 #include "rdpSetSpans.h"
 
 #define LDEBUG 0
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 void

--- a/module/rdpSetSpans.c
+++ b/module/rdpSetSpans.c
@@ -59,7 +59,7 @@ void
 rdpSetSpans(DrawablePtr pDrawable, GCPtr pGC, char *psrc,
             DDXPointPtr ppt, int *pwidth, int nspans, int fSorted)
 {
-    LLOGLN(0, ("rdpSetSpans:"));
+    LLOGLN(10, ("rdpSetSpans:"));
     /* do original call */
     rdpSetSpansOrg(pDrawable, pGC, psrc, ppt, pwidth, nspans, fSorted);
 }

--- a/module/rdpSimd.c
+++ b/module/rdpSimd.c
@@ -40,6 +40,7 @@ SIMD function assigning
 #include "rdp.h"
 #include "rdpXv.h"
 #include "rdpCapture.h"
+#include "rdpMisc.h"
 #include "rdpSimd.h"
 
 /* use simd, run time */
@@ -57,10 +58,6 @@ int g_simd_use_accel = 1;
 #include "x86/funcs_x86.h"
 #endif
 #endif
-
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 #if SIMD_USE_ACCEL
 

--- a/module/rdpTrapezoids.c
+++ b/module/rdpTrapezoids.c
@@ -41,13 +41,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpTrapezoids.h"
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpTriangles.c
+++ b/module/rdpTriangles.c
@@ -41,13 +41,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "rdp.h"
 #include "rdpDraw.h"
 #include "rdpClientCon.h"
+#include "rdpMisc.h"
 #include "rdpReg.h"
 #include "rdpTriangles.h"
-
-/******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
 
 /******************************************************************************/
 static void

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -92,7 +92,7 @@ xrdpVidPutVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(0, ("xrdpVidPutVideo:"));
+    LLOGLN(10, ("xrdpVidPutVideo:"));
     return Success;
 }
 
@@ -103,7 +103,7 @@ xrdpVidPutStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(0, ("xrdpVidPutStill:"));
+    LLOGLN(10, ("xrdpVidPutStill:"));
     return Success;
 }
 
@@ -114,7 +114,7 @@ xrdpVidGetVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(0, ("xrdpVidGetVideo:"));
+    LLOGLN(10, ("xrdpVidGetVideo:"));
     return Success;
 }
 
@@ -125,7 +125,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(0, ("FBDevTIVidGetStill:"));
+    LLOGLN(10, ("FBDevTIVidGetStill:"));
     return Success;
 }
 
@@ -133,7 +133,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
 static void
 xrdpVidStopVideo(ScrnInfoPtr pScrn, pointer data, Bool Cleanup)
 {
-    LLOGLN(0, ("xrdpVidStopVideo:"));
+    LLOGLN(10, ("xrdpVidStopVideo:"));
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ static int
 xrdpVidSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 value, pointer data)
 {
-    LLOGLN(0, ("xrdpVidSetPortAttribute:"));
+    LLOGLN(10, ("xrdpVidSetPortAttribute:"));
     return Success;
 }
 
@@ -150,7 +150,7 @@ static int
 xrdpVidGetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 *value, pointer data)
 {
-    LLOGLN(0, ("xrdpVidGetPortAttribute:"));
+    LLOGLN(10, ("xrdpVidGetPortAttribute:"));
     return Success;
 }
 
@@ -160,7 +160,7 @@ xrdpVidQueryBestSize(ScrnInfoPtr pScrn, Bool motion,
                      short vid_w, short vid_h, short drw_w, short drw_h,
                      unsigned int *p_w, unsigned int *p_h, pointer data)
 {
-    LLOGLN(0, ("xrdpVidQueryBestSize:"));
+    LLOGLN(10, ("xrdpVidQueryBestSize:"));
 }
 
 /*****************************************************************************/
@@ -451,7 +451,7 @@ rdpDeferredXvCleanup(OsTimerPtr timer, CARD32 now, pointer arg)
 {
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpDeferredXvCleanup:"));
+    LLOGLN(10, ("rdpDeferredXvCleanup:"));
     dev = (rdpPtr) arg;
     dev->xv_timer_scheduled = 0;
     dev->xv_data_bytes = 0;

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -55,10 +55,6 @@ XVideo
 
 static char g_xv_image[] = "XV_IMAGE";
 
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 #define T_NUM_ENCODINGS 1
 static XF86VideoEncodingRec g_xrdpVidEncodings[T_NUM_ENCODINGS] =
 { { 0, g_xv_image, 2046, 2046, { 1, 1 } } };

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -394,9 +394,9 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
     int *src32;
     int *dst32;
 
-    LLOGLN(10, ("stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov));
     oh = (src_w << 16) / dst_w;
     ov = (src_h << 16) / dst_h;
+    LLOGLN(10, ("stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov));
     iv = ov;
     lndex = src_y;
     last_lndex = -1;

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -148,7 +148,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     DisplayModePtr mode;
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpPreInit:"));
+    LLOGLN(10, ("rdpPreInit:"));
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -413,7 +413,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(0, ("xorgxrdpDamageDestroy:"));
+    LLOGLN(10, ("xorgxrdpDamageDestroy:"));
 }
 
 /******************************************************************************/
@@ -451,7 +451,7 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
 
     pScreen = (ScreenPtr) arg;
     dev = rdpGetDevFromScreen(pScreen);
-    LLOGLN(0, ("rdpDeferredRandR:"));
+    LLOGLN(10, ("rdpDeferredRandR:"));
     pRRScrPriv = rrGetScrPriv(pScreen);
     if (pRRScrPriv == 0)
     {
@@ -571,7 +571,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpCreateScreenResources:"));
+    LLOGLN(10, ("rdpCreateScreenResources:"));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -833,7 +833,7 @@ rdpSwitchMode(int a, DisplayModePtr b, int c)
 rdpSwitchMode(ScrnInfoPtr a, DisplayModePtr b)
 #endif
 {
-    LLOGLN(0, ("rdpSwitchMode:"));
+    LLOGLN(10, ("rdpSwitchMode:"));
     return TRUE;
 }
 
@@ -856,7 +856,7 @@ rdpEnterVT(int a, int b)
 rdpEnterVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(0, ("rdpEnterVT:"));
+    LLOGLN(10, ("rdpEnterVT:"));
     return TRUE;
 }
 
@@ -868,7 +868,7 @@ rdpLeaveVT(int a, int b)
 rdpLeaveVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(0, ("rdpLeaveVT:"));
+    LLOGLN(10, ("rdpLeaveVT:"));
 }
 
 /*****************************************************************************/
@@ -879,7 +879,7 @@ rdpValidMode(int a, DisplayModePtr b, Bool c, int d)
 rdpValidMode(ScrnInfoPtr a, DisplayModePtr b, Bool c, int d)
 #endif
 {
-    LLOGLN(0, ("rdpValidMode:"));
+    LLOGLN(10, ("rdpValidMode:"));
     return 0;
 }
 
@@ -891,7 +891,7 @@ rdpFreeScreen(int a, int b)
 rdpFreeScreen(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(0, ("rdpFreeScreen:"));
+    LLOGLN(10, ("rdpFreeScreen:"));
 }
 
 /*****************************************************************************/
@@ -906,7 +906,7 @@ rdpProbe(DriverPtr drv, int flags)
     ScrnInfoPtr pscrn;
     const char *val;
 
-    LLOGLN(0, ("rdpProbe:"));
+    LLOGLN(10, ("rdpProbe:"));
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -1002,7 +1002,7 @@ rdpProbe(DriverPtr drv, int flags)
 static const OptionInfoRec *
 rdpAvailableOptions(int chipid, int busid)
 {
-    LLOGLN(0, ("rdpAvailableOptions:"));
+    LLOGLN(10, ("rdpAvailableOptions:"));
     return 0;
 }
 
@@ -1032,7 +1032,7 @@ rdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
 static void
 rdpIdentify(int flags)
 {
-    LLOGLN(0, ("rdpIdentify:"));
+    LLOGLN(10, ("rdpIdentify:"));
     xf86PrintChipsets(XRDP_DRIVER_NAME, "driver for xrdp", g_Chipsets);
 }
 
@@ -1051,7 +1051,7 @@ _X_EXPORT DriverRec g_DriverRec =
 static pointer
 xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 {
-    LLOGLN(0, ("xrdpdevSetup:"));
+    LLOGLN(10, ("xrdpdevSetup:"));
     if (!g_setup_done)
     {
         g_setup_done = 1;
@@ -1072,7 +1072,7 @@ xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 static void
 xrdpdevTearDown(pointer Module)
 {
-    LLOGLN(0, ("xrdpdevTearDown:"));
+    LLOGLN(10, ("xrdpdevTearDown:"));
 }
 
 /* <drivername>ModuleData */

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -77,18 +77,6 @@ Bool g_use_dri3 = TRUE;
 char g_drm_allow_list[128] = "";
 #endif
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
-    { \
-      ErrorF _args ; \
-      ErrorF("\n"); \
-    } \
-  } \
-  while (0)
-
 static int g_setup_done = 0;
 static OsTimerPtr g_randr_timer = 0;
 static OsTimerPtr g_damage_timer = 0;

--- a/xrdpdev/xrdpdri2.c
+++ b/xrdpdev/xrdpdri2.c
@@ -51,24 +51,13 @@ dri2
 #include <xf86Modes.h>
 
 #include "rdp.h"
+#include "rdpMisc.h"
 #include "rdpPri.h"
 #include "rdpDraw.h"
 
 #if defined(XORGXRDP_GLAMOR)
 #include <glamor.h>
 #endif
-
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
-    { \
-      ErrorF _args ; \
-      ErrorF("\n"); \
-    } \
-  } \
-  while (0)
 
 static DevPrivateKeyRec g_rdpDri2ClientKey;
 

--- a/xrdpdev/xrdpdri3.c
+++ b/xrdpdev/xrdpdri3.c
@@ -49,24 +49,13 @@ dri3
 #include <xf86Modes.h>
 
 #include "rdp.h"
+#include "rdpMisc.h"
 #include "rdpPri.h"
 
 #include <glamor.h>
 #include <dri3.h>
 
 extern char g_drm_device[]; /* in xrdpdev.c */
-
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
-    { \
-      ErrorF _args ; \
-      ErrorF("\n"); \
-    } \
-  } \
-  while (0)
 
 /*****************************************************************************/
 static PixmapPtr

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -299,21 +299,21 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
 static void
 rdpkeybDeviceOn(void)
 {
-    LLOGLN(0, ("rdpkeybDeviceOn:"));
+    LLOGLN(10, ("rdpkeybDeviceOn:"));
 }
 
 /******************************************************************************/
 static void
 rdpkeybDeviceOff(void)
 {
-    LLOGLN(0, ("rdpkeybDeviceOff:"));
+    LLOGLN(10, ("rdpkeybDeviceOff:"));
 }
 
 /******************************************************************************/
 static void
 rdpkeybBell(int volume, DeviceIntPtr pDev, pointer ctrl, int cls)
 {
-    LLOGLN(0, ("rdpkeybBell:"));
+    LLOGLN(10, ("rdpkeybBell:"));
 }
 
 /******************************************************************************/
@@ -324,7 +324,7 @@ rdpInDeferredRepeatCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     DeviceIntPtr it;
     Bool found;
 
-    LLOGLN(0, ("rdpInDeferredRepeatCallback:"));
+    LLOGLN(10, ("rdpInDeferredRepeatCallback:"));
     TimerFree(timer);
     pDev = (DeviceIntPtr) arg;
     found = FALSE;
@@ -351,7 +351,7 @@ rdpkeybChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl *ctrl)
 {
     XkbControlsPtr ctrls;
 
-    LLOGLN(0, ("rdpkeybChangeKeyboardControl:"));
+    LLOGLN(10, ("rdpkeybChangeKeyboardControl:"));
     ctrls = 0;
     if (pDev != 0)
     {
@@ -487,7 +487,7 @@ static InputDriverRec rdpkeyb =
 static pointer
 rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(0, ("rdpkeybPlug:"));
+    LLOGLN(10, ("rdpkeybPlug:"));
     xf86AddInputDriver(&rdpkeyb, module, 0);
     xorgxrdpCheckWrap();
     return module;
@@ -497,7 +497,7 @@ rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpkeybUnplug(pointer p)
 {
-    LLOGLN(0, ("rdpkeybUnplug:"));
+    LLOGLN(10, ("rdpkeybUnplug:"));
 }
 
 /******************************************************************************/

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -57,10 +57,6 @@ xrdp keyboard module
 #include "xrdp_scancode_defs.h"
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 /* A few hard-coded evdev keycodes (see g_evdev_str) */
 #define CAPS_LOCK_KEY_CODE 66
 #define NUM_LOCK_KEY_CODE 77

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -48,16 +48,13 @@ xrdp mouse module
 
 #include "rdp.h"
 #include "rdpInput.h"
+#include "rdpMisc.h"
 #include "rdpDraw.h"
 
 #define NBUTTONS 9
 #define NAXES 4
 
 /******************************************************************************/
-#define LOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { ErrorF _args ; ErrorF("\n"); } } while (0)
-
 static char g_Mouse_str[] = XI_MOUSE;
 static char g_xrdp_mouse_name[] = XRDP_MOUSE_NAME;
 

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -62,28 +62,28 @@ static char g_xrdp_mouse_name[] = XRDP_MOUSE_NAME;
 static void
 rdpmouseDeviceInit(void)
 {
-    LLOGLN(0, ("rdpmouseDeviceInit:"));
+    LLOGLN(10, ("rdpmouseDeviceInit:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOn(DeviceIntPtr pDev)
 {
-    LLOGLN(0, ("rdpmouseDeviceOn:"));
+    LLOGLN(10, ("rdpmouseDeviceOn:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOff(void)
 {
-    LLOGLN(0, ("rdpmouseDeviceOff:"));
+    LLOGLN(10, ("rdpmouseDeviceOff:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseCtrl(DeviceIntPtr pDevice, PtrCtrl *pCtrl)
 {
-    LLOGLN(0, ("rdpmouseCtrl:"));
+    LLOGLN(10, ("rdpmouseCtrl:"));
 }
 
 /******************************************************************************/
@@ -446,7 +446,7 @@ static InputDriverRec rdpmouse =
 static pointer
 rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(0, ("rdpmousePlug:"));
+    LLOGLN(10, ("rdpmousePlug:"));
     xf86AddInputDriver(&rdpmouse, module, 0);
     return module;
 }
@@ -455,7 +455,7 @@ rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpmouseUnplug(pointer p)
 {
-    LLOGLN(0, ("rdpmouseUnplug:"));
+    LLOGLN(10, ("rdpmouseUnplug:"));
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes #410 

See #410 for the background to this. Thanks to @rowlap for some very useful comments. I'd appreciate more, @rowlap, if you have them!

Major features:
1. The `LLOGLN()` macro is now centralised in `rdpMisc.h`, rather than being source-file specific.
2. Some logging levels have been reduced to reduce noise
3. Messages are preceded with `(II)` or `(DB)`.
4. Previous behaviour can be achieved by starting `Xorg` with `-verbose 2 -logverbose 2`

The syntax of `LLOGLN()` is a little odd, and this is reflected in the new definition. I've checked the output of gcc under x86_64, and because constants are used, the compiler is able to choose the correct function to call at compile-time. Here is the code produced for the `rdpmousePlug()` function with `-g -O2`:

```
1:(gdb) disassemble/s
2:Dump of assembler code for function rdpmousePlug:
3:rdpMouse.c:
4:448	{
5:=> 0x00007ffff74113a0 <+0>:	endbr64
6:
7:449	    LLOGLN(10, ("rdpmousePlug:"));
8:   0x00007ffff74113a4 <+4>:	push   %rbx
9:   0x00007ffff74113a5 <+5>:	xor    %eax,%eax
10:
11:448	{
12:   0x00007ffff74113a7 <+7>:	mov    %rdi,%rbx
13:
14:449	    LLOGLN(10, ("rdpmousePlug:"));
15:   0x00007ffff74113aa <+10>:	lea    0xc6d(%rip),%rdi        # 0x7ffff741201e
16:   0x00007ffff74113b1 <+17>:	call   0x7ffff7411170 <g_log_trace@plt>
17:
18:450	    xf86AddInputDriver(&rdpmouse, module, 0);
19:   0x00007ffff74113b6 <+22>:	mov    %rbx,%rsi
20:   0x00007ffff74113b9 <+25>:	xor    %edx,%edx
21:   0x00007ffff74113bb <+27>:	lea    0x2d7e(%rip),%rdi        # 0x7ffff7414140 <rdpmouse>
22:   0x00007ffff74113c2 <+34>:	call   0x7ffff7411260 <xf86AddInputDriver@plt>
23:
24:451	    return module;
25:   0x00007ffff74113c7 <+39>:	mov    %rbx,%rax
26:   0x00007ffff74113ca <+42>:	pop    %rbx
27:   0x00007ffff74113cb <+43>:	ret
28:End of assembler dump.
```

The correct function is called directly at line 16.