### PR TITLE
logging: Fix default log levels for debug and trace

### DIFF
--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -670,10 +670,10 @@ g_log_debug(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
-    LogVMessageVerb(X_DEBUG, 1, format, ap);
+    LogVMessageVerb(X_DEBUG, 4, format, ap);
     va_end(ap);
     va_start(ap, format);
-    LogVMessageVerb(X_NONE, 1, "\n", ap);
+    LogVMessageVerb(X_NONE, 4, "\n", ap);
     va_end(ap);
 }
 
@@ -684,9 +684,9 @@ g_log_trace(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
-    LogVMessageVerb(X_DEBUG, 2, format, ap);
+    LogVMessageVerb(X_DEBUG, 5, format, ap);
     va_end(ap);
     va_start(ap, format);
-    LogVMessageVerb(X_NONE, 2, "\n", ap);
+    LogVMessageVerb(X_NONE, 5, "\n", ap);
     va_end(ap);
 }


### PR DESCRIPTION
Follow-on from #411

The default file logging level is 3, not 0. Set debug and trace logging levels to 4 and 5, so by default the log file is not full of messages.

I'll add a commented-out line to sesman.ini too, to indicate how to turn on full logging.