### PR TITLE
Move to LOG() macro

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -829,8 +829,9 @@ rdpCaptureSimple(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     LOG(LOG_LEVEL_TRACE, "rdpCaptureSimple:");
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureSimple: WARNING -- Shared memory is not configured."
-                   " Aborting capture!");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureSimple: WARNING -- Shared memory is not configured."
+            " Aborting capture!");
         return FALSE;
     }
 
@@ -951,8 +952,9 @@ rdpCaptureSufA16(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     LOG(LOG_LEVEL_TRACE, "rdpCaptureSufA16:");
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA16: WARNING -- Shared memory is not configured."
-               " Aborting capture!");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureSufA16: WARNING -- Shared memory is not configured."
+            " Aborting capture!");
         return FALSE;
     }
 
@@ -1102,8 +1104,9 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
-                   " for RFX. Aborting capture!");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
+            " for RFX. Aborting capture!");
         return FALSE;
     }
 
@@ -1139,8 +1142,9 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     num_crcs = crc_stride * ((id->height + 63) / 64);
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxPro: resize the crc list was %d now %d",
-               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
+        LOG(LOG_LEVEL_INFO,
+            "rdpCaptureGfxPro: resize the crc list was %d now %d",
+            clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
         free(clientCon->rfx_crcs[mon_index]);
@@ -1196,8 +1200,9 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 crc_offset = (y / XRDP_RFX_ALIGN) * crc_stride
                              + (x / XRDP_RFX_ALIGN);
-                LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
-                       crc, clientCon->rfx_crcs[mon_index][crc_offset]);
+                LOG(LOG_LEVEL_TRACE,
+                    "rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
+                    crc, clientCon->rfx_crcs[mon_index][crc_offset]);
                 if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
                     LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: crc skip at x %d y %d", x, y);
@@ -1257,8 +1262,9 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA2: WARNING -- Shared memory is not configured."
-               " Aborting capture!");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureSufA2: WARNING -- Shared memory is not configured."
+            " Aborting capture!");
         return FALSE;
     }
 
@@ -1300,13 +1306,13 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     {
         rect = psrc_rects[index];
         LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
-               rect.x2, rect.y2);
+            rect.x2, rect.y2);
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
         rect.y2 += rect.y2 & 1;
         LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
-               rect.x2, rect.y2);
+            rect.x2, rect.y2);
         (*out_rects)[index] = rect;
         index++;
     }
@@ -1366,8 +1372,9 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
-               " Aborting capture!");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
+            " Aborting capture!");
         return FALSE;
     }
 
@@ -1389,7 +1396,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     {
         rect = psrc_rects[index];
         LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
-               rect.x2, rect.y2);
+            rect.x2, rect.y2);
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
@@ -1403,7 +1410,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             rect.y2 = id->height & ~1;
         }
         LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
-               rect.x2, rect.y2);
+            rect.x2, rect.y2);
         (*out_rects)[index] = rect;
         index++;
     }
@@ -1411,8 +1418,9 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     monitor_index = (id->flags >> 28) & 0xF;
     if (clientCon->accelAssistPixmaps[monitor_index] != NULL)
     {
-        LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxA2: a monitor_index %d left %d top %d",
-               monitor_index, id->left, id->top);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpCaptureGfxA2: a monitor_index %d left %d top %d",
+            monitor_index, id->left, id->top);
         /* copy vmem to vmem */
         rv = rdpCopyBoxList(clientCon,
                             clientCon->accelAssistPixmaps[monitor_index],
@@ -1424,8 +1432,9 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else if (clientCon->dev->glamor || clientCon->dev->nvidia)
     {
-        LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxA2: b monitor_index %d left %d top %d",
-               monitor_index, id->left, id->top);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpCaptureGfxA2: b monitor_index %d left %d top %d",
+            monitor_index, id->left, id->top);
         /* copy vmem to smem */
         if (!rdpCopyBoxList(clientCon,
                             clientCon->dev->screenSwPixmap,
@@ -1456,7 +1465,8 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxA2: unimplemented color conversion");
+        LOG(LOG_LEVEL_WARNING,
+            "rdpCaptureGfxA2: unimplemented color conversion");
     }
 
     return rv;
@@ -1490,7 +1500,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             /* used for even align capture */
             return rdpCaptureGfxA2(clientCon, in_reg, out_rects, num_out_rects, id);
         default:
-            LOG(LOG_LEVEL_INFO, "rdpCapture: mode %d not implemented", mode);
+            LOG(LOG_LEVEL_WARNING, "rdpCapture: mode %d not implemented", mode);
             break;
     }
     return FALSE;

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -742,7 +742,7 @@ rdpCopyBoxList(rdpClientCon *clientCon, PixmapPtr dstPixmap,
     char pix1[16];
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpCopyBoxList:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyBoxList:"));
 
     dev = clientCon->dev;
     pScreen = dev->pScreen;
@@ -826,10 +826,10 @@ rdpCaptureSimple(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_stride;
     int dst_format;
 
-    LLOGLN(10, ("rdpCaptureSimple:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSimple:"));
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LLOGLN(0, ("rdpCaptureSimple: WARNING -- Shared memory is not configured."
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSimple: WARNING -- Shared memory is not configured."
                    " Aborting capture!"));
         return FALSE;
     }
@@ -908,7 +908,7 @@ rdpCaptureSimple(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(0, ("rdpCaptureSimple: unimplemented color conversion"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSimple: unimplemented color conversion"));
     }
     return rv;
 }
@@ -948,10 +948,10 @@ rdpCaptureSufA16(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_stride;
     int dst_format;
 
-    LLOGLN(10, ("rdpCaptureSufA16:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSufA16:"));
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LLOGLN(0, ("rdpCaptureSufA16: WARNING -- Shared memory is not configured."
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA16: WARNING -- Shared memory is not configured."
                " Aborting capture!"));
         return FALSE;
     }
@@ -1068,7 +1068,7 @@ rdpCaptureSufA16(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(0, ("rdpCaptureSufA16: unimplemented color conversion"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA16: unimplemented color conversion"));
     }
     return rv;
 }
@@ -1098,11 +1098,11 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int num_crcs;
     int mon_index;
 
-    LLOGLN(10, ("rdpCaptureGfxPro:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro:"));
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(0, ("rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
                    " for RFX. Aborting capture!"));
         return FALSE;
     }
@@ -1139,7 +1139,7 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     num_crcs = crc_stride * ((id->height + 63) / 64);
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
-        LLOGLN(0, ("rdpCaptureGfxPro: resize the crc list was %d now %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxPro: resize the crc list was %d now %d",
                clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
@@ -1159,11 +1159,11 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             rect.x2 = rect.x1 + XRDP_RFX_ALIGN;
             rect.y2 = rect.y1 + XRDP_RFX_ALIGN;
             rcode = rdpRegionContainsRect(in_reg, &rect);
-            LLOGLN(10, ("rdpCaptureGfxPro: rcode %d", rcode));
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rcode %d", rcode));
 
             if (rcode == rgnOUT)
             {
-                LLOGLN(10, ("rdpCaptureGfxPro: rgnOUT"));
+                LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnOUT"));
                 rdpRegionInit(&tile_reg, &rect, 0);
                 rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                 rdpRegionUninit(&tile_reg);
@@ -1174,7 +1174,7 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 crc = WYHASH_SEED;
                 if (rcode == rgnPART)
                 {
-                    LLOGLN(10, ("rdpCaptureGfxPro: rgnPART"));
+                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnPART"));
                     rdpFillBox_yuvalp(x, y, dst, dst_stride);
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionIntersect(&tile_reg, in_reg, &tile_reg);
@@ -1191,16 +1191,16 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 else /* rgnIN */
                 {
-                    LLOGLN(10, ("rdpCaptureGfxPro: rgnIN"));
+                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnIN"));
                     crc = wyhash_rfx_tile(src, src_stride, x, y, crc);
                 }
                 crc_offset = (y / XRDP_RFX_ALIGN) * crc_stride
                              + (x / XRDP_RFX_ALIGN);
-                LLOGLN(10, ("rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
+                LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
                        crc, clientCon->rfx_crcs[mon_index][crc_offset]));
                 if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
-                    LLOGLN(10, ("rdpCaptureGfxPro: crc skip at x %d y %d", x, y));
+                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: crc skip at x %d y %d", x, y));
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                     rdpRegionUninit(&tile_reg);
@@ -1253,11 +1253,11 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
     int monitor_index;
 
-    LLOGLN(10, ("rdpCaptureSufA2:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSufA2:"));
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(0, ("rdpCaptureSufA2: WARNING -- Shared memory is not configured."
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA2: WARNING -- Shared memory is not configured."
                " Aborting capture!"));
         return FALSE;
     }
@@ -1299,13 +1299,13 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LLOGLN(10, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LLOGLN(LOG_LEVEL_TRACE, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
                rect.x2, rect.y2));
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
         rect.y2 += rect.y2 & 1;
-        LLOGLN(10, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LLOGLN(LOG_LEVEL_TRACE, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
                rect.x2, rect.y2));
         (*out_rects)[index] = rect;
         index++;
@@ -1337,7 +1337,7 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(0, ("rdpCaptureSufA2: unimplemented color conversion"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA2: unimplemented color conversion"));
     }
 
     return rv;
@@ -1362,11 +1362,11 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
     int monitor_index;
 
-    LLOGLN(10, ("rdpCaptureGfxA2:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2:"));
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(0, ("rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
                " Aborting capture!"));
         return FALSE;
     }
@@ -1388,7 +1388,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LLOGLN(10, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
+        LLOGLN(LOG_LEVEL_TRACE, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
                rect.x2, rect.y2));
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
@@ -1402,7 +1402,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         {
             rect.y2 = id->height & ~1;
         }
-        LLOGLN(10, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
+        LLOGLN(LOG_LEVEL_TRACE, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
                rect.x2, rect.y2));
         (*out_rects)[index] = rect;
         index++;
@@ -1411,7 +1411,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     monitor_index = (id->flags >> 28) & 0xF;
     if (clientCon->accelAssistPixmaps[monitor_index] != NULL)
     {
-        LLOGLN(10, ("rdpCaptureGfxA2: a monitor_index %d left %d top %d",
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2: a monitor_index %d left %d top %d",
                monitor_index, id->left, id->top));
         /* copy vmem to vmem */
         rv = rdpCopyBoxList(clientCon,
@@ -1424,7 +1424,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else if (clientCon->dev->glamor || clientCon->dev->nvidia)
     {
-        LLOGLN(10, ("rdpCaptureGfxA2: b monitor_index %d left %d top %d",
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2: b monitor_index %d left %d top %d",
                monitor_index, id->left, id->top));
         /* copy vmem to smem */
         if (!rdpCopyBoxList(clientCon,
@@ -1456,7 +1456,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(0, ("rdpCaptureGfxA2: unimplemented color conversion"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxA2: unimplemented color conversion"));
     }
 
     return rv;
@@ -1471,7 +1471,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 {
     enum xrdp_capture_code mode;
 
-    LLOGLN(10, ("rdpCapture:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapture:"));
     mode = clientCon->client_info.capture_code;
     switch (mode)
     {
@@ -1490,7 +1490,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             /* used for even align capture */
             return rdpCaptureGfxA2(clientCon, in_reg, out_rects, num_out_rects, id);
         default:
-            LLOGLN(0, ("rdpCapture: mode %d not implemented", mode));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpCapture: mode %d not implemented", mode));
             break;
     }
     return FALSE;
@@ -1505,7 +1505,7 @@ rdpCaptureResetState(rdpClientCon *clientCon)
     int mode;
     int i;
 
-    LLOGLN(10, ("rdpCapReset:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapReset:"));
     mode = clientCon->client_info.capture_code;
     switch (mode)
     {

--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -742,7 +742,7 @@ rdpCopyBoxList(rdpClientCon *clientCon, PixmapPtr dstPixmap,
     char pix1[16];
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyBoxList:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyBoxList:");
 
     dev = clientCon->dev;
     pScreen = dev->pScreen;
@@ -826,11 +826,11 @@ rdpCaptureSimple(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_stride;
     int dst_format;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSimple:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCaptureSimple:");
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSimple: WARNING -- Shared memory is not configured."
-                   " Aborting capture!"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSimple: WARNING -- Shared memory is not configured."
+                   " Aborting capture!");
         return FALSE;
     }
 
@@ -908,7 +908,7 @@ rdpCaptureSimple(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSimple: unimplemented color conversion"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSimple: unimplemented color conversion");
     }
     return rv;
 }
@@ -948,11 +948,11 @@ rdpCaptureSufA16(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_stride;
     int dst_format;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSufA16:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCaptureSufA16:");
 
     if (!isShmStatusActive(clientCon->shmemstatus)) {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA16: WARNING -- Shared memory is not configured."
-               " Aborting capture!"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA16: WARNING -- Shared memory is not configured."
+               " Aborting capture!");
         return FALSE;
     }
 
@@ -1068,7 +1068,7 @@ rdpCaptureSufA16(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA16: unimplemented color conversion"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA16: unimplemented color conversion");
     }
     return rv;
 }
@@ -1098,12 +1098,12 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int num_crcs;
     int mon_index;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro:");
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
-                   " for RFX. Aborting capture!"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxPro: WARNING -- Shared memory is not configured"
+                   " for RFX. Aborting capture!");
         return FALSE;
     }
 
@@ -1139,8 +1139,8 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     num_crcs = crc_stride * ((id->height + 63) / 64);
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxPro: resize the crc list was %d now %d",
-               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxPro: resize the crc list was %d now %d",
+               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
         free(clientCon->rfx_crcs[mon_index]);
@@ -1159,11 +1159,11 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             rect.x2 = rect.x1 + XRDP_RFX_ALIGN;
             rect.y2 = rect.y1 + XRDP_RFX_ALIGN;
             rcode = rdpRegionContainsRect(in_reg, &rect);
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rcode %d", rcode));
+            LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: rcode %d", rcode);
 
             if (rcode == rgnOUT)
             {
-                LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnOUT"));
+                LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: rgnOUT");
                 rdpRegionInit(&tile_reg, &rect, 0);
                 rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                 rdpRegionUninit(&tile_reg);
@@ -1174,7 +1174,7 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 crc = WYHASH_SEED;
                 if (rcode == rgnPART)
                 {
-                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnPART"));
+                    LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: rgnPART");
                     rdpFillBox_yuvalp(x, y, dst, dst_stride);
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionIntersect(&tile_reg, in_reg, &tile_reg);
@@ -1191,16 +1191,16 @@ rdpCaptureGfxPro(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 else /* rgnIN */
                 {
-                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: rgnIN"));
+                    LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: rgnIN");
                     crc = wyhash_rfx_tile(src, src_stride, x, y, crc);
                 }
                 crc_offset = (y / XRDP_RFX_ALIGN) * crc_stride
                              + (x / XRDP_RFX_ALIGN);
-                LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
-                       crc, clientCon->rfx_crcs[mon_index][crc_offset]));
+                LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: crc 0x%" PRIx64 " 0x%" PRIx64,
+                       crc, clientCon->rfx_crcs[mon_index][crc_offset]);
                 if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
-                    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxPro: crc skip at x %d y %d", x, y));
+                    LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxPro: crc skip at x %d y %d", x, y);
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                     rdpRegionUninit(&tile_reg);
@@ -1253,12 +1253,12 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
     int monitor_index;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureSufA2:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCaptureSufA2:");
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA2: WARNING -- Shared memory is not configured."
-               " Aborting capture!"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA2: WARNING -- Shared memory is not configured."
+               " Aborting capture!");
         return FALSE;
     }
 
@@ -1299,14 +1299,14 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LLOGLN(LOG_LEVEL_TRACE, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
-               rect.x2, rect.y2));
+        LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+               rect.x2, rect.y2);
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
         rect.y2 += rect.y2 & 1;
-        LLOGLN(LOG_LEVEL_TRACE, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
-               rect.x2, rect.y2));
+        LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+               rect.x2, rect.y2);
         (*out_rects)[index] = rect;
         index++;
     }
@@ -1337,7 +1337,7 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureSufA2: unimplemented color conversion"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureSufA2: unimplemented color conversion");
     }
 
     return rv;
@@ -1362,12 +1362,12 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     int dst_format;
     int monitor_index;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxA2:");
 
     if (!isShmStatusActive(clientCon->shmemstatus))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
-               " Aborting capture!"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxA2: WARNING -- Shared memory is not configured."
+               " Aborting capture!");
         return FALSE;
     }
 
@@ -1388,8 +1388,8 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LLOGLN(LOG_LEVEL_TRACE, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
-               rect.x2, rect.y2));
+        LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
+               rect.x2, rect.y2);
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
@@ -1402,8 +1402,8 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
         {
             rect.y2 = id->height & ~1;
         }
-        LLOGLN(LOG_LEVEL_TRACE, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
-               rect.x2, rect.y2));
+        LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
+               rect.x2, rect.y2);
         (*out_rects)[index] = rect;
         index++;
     }
@@ -1411,8 +1411,8 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     monitor_index = (id->flags >> 28) & 0xF;
     if (clientCon->accelAssistPixmaps[monitor_index] != NULL)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2: a monitor_index %d left %d top %d",
-               monitor_index, id->left, id->top));
+        LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxA2: a monitor_index %d left %d top %d",
+               monitor_index, id->left, id->top);
         /* copy vmem to vmem */
         rv = rdpCopyBoxList(clientCon,
                             clientCon->accelAssistPixmaps[monitor_index],
@@ -1424,8 +1424,8 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else if (clientCon->dev->glamor || clientCon->dev->nvidia)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpCaptureGfxA2: b monitor_index %d left %d top %d",
-               monitor_index, id->left, id->top));
+        LOG(LOG_LEVEL_TRACE, "rdpCaptureGfxA2: b monitor_index %d left %d top %d",
+               monitor_index, id->left, id->top);
         /* copy vmem to smem */
         if (!rdpCopyBoxList(clientCon,
                             clientCon->dev->screenSwPixmap,
@@ -1456,7 +1456,7 @@ rdpCaptureGfxA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCaptureGfxA2: unimplemented color conversion"));
+        LOG(LOG_LEVEL_INFO, "rdpCaptureGfxA2: unimplemented color conversion");
     }
 
     return rv;
@@ -1471,7 +1471,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
 {
     enum xrdp_capture_code mode;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapture:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCapture:");
     mode = clientCon->client_info.capture_code;
     switch (mode)
     {
@@ -1490,7 +1490,7 @@ rdpCapture(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
             /* used for even align capture */
             return rdpCaptureGfxA2(clientCon, in_reg, out_rects, num_out_rects, id);
         default:
-            LLOGLN(LOG_LEVEL_INFO, ("rdpCapture: mode %d not implemented", mode));
+            LOG(LOG_LEVEL_INFO, "rdpCapture: mode %d not implemented", mode);
             break;
     }
     return FALSE;
@@ -1505,7 +1505,7 @@ rdpCaptureResetState(rdpClientCon *clientCon)
     int mode;
     int i;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapReset:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCapReset:");
     mode = clientCon->client_info.capture_code;
     switch (mode)
     {

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -176,13 +176,13 @@ rdpAddClientConToDev(rdpPtr dev, rdpClientCon *clientCon)
 
     if (dev->clientConTail == NULL)
     {
-        LLOGLN(0, ("rdpAddClientConToDev: adding first clientCon %p",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpAddClientConToDev: adding first clientCon %p",
                    clientCon));
         dev->clientConHead = clientCon;
     }
     else
     {
-        LLOGLN(0, ("rdpAddClientConToDev: adding clientCon %p",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpAddClientConToDev: adding clientCon %p",
                    clientCon));
         dev->clientConTail->next = clientCon;
     }
@@ -193,7 +193,7 @@ rdpAddClientConToDev(rdpPtr dev, rdpClientCon *clientCon)
 static void
 rdpRemoveClientConFromDev(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(0, ("rdpRemoveClientConFromDev: removing clientCon %p",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRemoveClientConFromDev: removing clientCon %p",
                clientCon));
 
     if (clientCon->prev == NULL)
@@ -224,7 +224,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     rdpClientCon *clientCon;
     int new_sck;
 
-    LLOGLN(10, ("rdpClientConGotConnection:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotConnection:"));
     clientCon = g_new0(rdpClientCon, 1);
     clientCon->shmemstatus = SHM_UNINITIALIZED;
     clientCon->updateRetries = 0;
@@ -241,11 +241,11 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     new_sck = g_sck_accept(dev->listen_sck);
     if (new_sck == -1)
     {
-        LLOGLN(0, ("rdpClientConGotConnection: g_sck_accept failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: g_sck_accept failed"));
     }
     else
     {
-        LLOGLN(0, ("rdpClientConGotConnection: g_sck_accept ok new_sck %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: g_sck_accept ok new_sck %d",
                new_sck));
         clientCon->sck = new_sck;
         g_sck_set_non_blocking(clientCon->sck);
@@ -261,7 +261,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     if (dev->clientConTail != NULL)
     {
         /* Only allow one client at a time */
-        LLOGLN(0, ("rdpClientConGotConnection: "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
                    "marking only clientCon %p for disconnect",
                    dev->clientConTail));
         dev->clientConTail->connected = FALSE;
@@ -271,14 +271,14 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     /* set idle timer to disconnect */
     if (dev->idle_disconnect_timeout_s > 0)
     {
-        LLOGLN(0, ("rdpClientConGotConnection: "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
                    "engaging idle timer, timeout [%d] sec", dev->idle_disconnect_timeout_s));
         dev->idleDisconnectTimer = TimerSet(dev->idleDisconnectTimer, 0, dev->idle_disconnect_timeout_s * 1000,
                                             rdpDeferredIdleDisconnectCallback, dev);
     }
     else
     {
-        LLOGLN(0, ("rdpClientConGotConnection: "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
                    "idle_disconnect_timeout set to non-positive value, idle timer turned off"));
     }
 
@@ -297,14 +297,14 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
 
     dev = (rdpPtr) arg;
-    LLOGLN(10, ("rdpDeferredDisconnectCallback"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredDisconnectCallback"));
     if (dev->clientConHead != NULL)
     {
         /* this should not happen */
-        LLOGLN(0, ("rdpDeferredDisconnectCallback: connected"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: connected"));
         if (dev->disconnectTimer != NULL)
         {
-            LLOGLN(0, ("rdpDeferredDisconnectCallback: disengaging disconnect timer"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: disengaging disconnect timer"));
             TimerCancel(dev->disconnectTimer);
             TimerFree(dev->disconnectTimer);
             dev->disconnectTimer = NULL;
@@ -314,11 +314,11 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     }
     else
     {
-        LLOGLN(10, ("rdpDeferredDisconnectCallback: not connected"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredDisconnectCallback: not connected"));
     }
     if (now - dev->disconnect_time_ms > dev->disconnect_timeout_s * 1000)
     {
-        LLOGLN(0, ("rdpDeferredDisconnectCallback: "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: "
                    "disconnect timeout exceeded, exiting"));
         kill(getpid(), SIGTERM);
         return 0;
@@ -332,7 +332,7 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
 static CARD32
 rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
 {
-    LLOGLN(10, ("rdpDeferredIdleDisconnectCallback:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredIdleDisconnectCallback:"));
 
     rdpPtr dev;
 
@@ -346,7 +346,7 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     /* we MUST compare to equal otherwise we could restart the idle timer with 0! */
     if (millis_since_last_event >= (dev->idle_disconnect_timeout_s * 1000))
     {
-        LLOGLN(0, ("rdpDeferredIdleDisconnectCallback: session has been idle for %d seconds, disconnecting",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: session has been idle for %d seconds, disconnecting",
                     dev->idle_disconnect_timeout_s));
 
         /* disconnect all clients */
@@ -355,12 +355,12 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             rdpClientConDisconnect(dev, dev->clientConHead);
         }
 
-        LLOGLN(0, ("rdpDeferredIdleDisconnectCallback: disconnected idle session"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: disconnected idle session"));
 
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
-        LLOGLN(0, ("rdpDeferredIdleDisconnectCallback: idle timer disengaged"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: idle timer disengaged"));
         return 0;
     }
 
@@ -378,7 +378,7 @@ rdpShutdownAccelAssist(rdpPtr dev, rdpClientCon *clientCon) {
     int index;
     int exit_code = 0;
 
-    LLOGLN(10, ("rdpShutdownAccelAssist:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpShutdownAccelAssist:"));
     if (clientCon->accel_assist_pid <= 0)
     {
         return 0;
@@ -432,11 +432,11 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
 {
     int index;
 
-    LLOGLN(10, ("rdpClientConDisconnect:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDisconnect:"));
 
     if (dev->idleDisconnectTimer != NULL && dev->idle_disconnect_timeout_s > 0)
     {
-        LLOGLN(0, ("rdpClientConDisconnect: disconnected, idle timer disengaged"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDisconnect: disconnected, idle timer disengaged"));
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
@@ -446,7 +446,7 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
     {
         if (dev->disconnect_scheduled == FALSE)
         {
-            LLOGLN(0, ("rdpClientConDisconnect: engaging disconnect timer, "
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDisconnect: engaging disconnect timer, "
                        "exit after %d seconds", dev->disconnect_timeout_s));
             dev->disconnectTimer = TimerSet(dev->disconnectTimer, 0, 1000 * 10,
                                             rdpDeferredDisconnectCallback, dev);
@@ -505,7 +505,7 @@ rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
     int sent;
     int retries = 0;
 
-    LLOGLN(10, ("rdpClientConSend - sending %d bytes", len));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSend - sending %d bytes", len));
 
     if (!clientCon->connected)
     {
@@ -531,14 +531,14 @@ rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
             }
             else
             {
-                LLOGLN(0, ("rdpClientConSend: g_tcp_send failed(returned -1)"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSend: g_tcp_send failed(returned -1)"));
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (sent == 0)
         {
-            LLOGLN(0, ("rdpClientConSend: g_tcp_send failed(returned zero)"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSend: g_tcp_send failed(returned zero)"));
             clientCon->connected = FALSE;
             return 1;
         }
@@ -568,7 +568,7 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
 
         if (len > s->size)
         {
-            LLOGLN(0, ("rdpClientConSendMsg: overrun error len, %d "
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendMsg: overrun error len, %d "
                        "stream size %d, client count %d",
                        len, s->size, clientCon->count));
         }
@@ -582,7 +582,7 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(0, ("rdpClientConSendMsg: error in rdpup_send_msg"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendMsg: error in rdpup_send_msg"));
     }
 
     return rv;
@@ -603,7 +603,7 @@ rdpClientConSendPending(rdpPtr dev, rdpClientCon *clientCon)
         s_mark_end(clientCon->out_s);
         if (rdpClientConSendMsg(dev, clientCon) != 0)
         {
-            LLOGLN(0, ("rdpClientConSendPending: rdpClientConSendMsg failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendPending: rdpClientConSendMsg failed"));
             rv = 1;
         }
     }
@@ -636,14 +636,14 @@ rdpClientConRecv(rdpPtr dev, rdpClientCon *clientCon, char *data, int len)
             }
             else
             {
-                LLOGLN(0, ("rdpClientConRecv: g_sck_recv failed(returned -1)"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecv: g_sck_recv failed(returned -1)"));
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (rcvd == 0)
         {
-            LLOGLN(0, ("rdpClientConRecv: g_sck_recv failed(returned 0)"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecv: g_sck_recv failed(returned 0)"));
             clientCon->connected = FALSE;
             return 1;
         }
@@ -692,7 +692,7 @@ rdpClientConRecvMsg(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(0, ("rdpClientConRecvMsg: error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecvMsg: error"));
     }
 
     return rv;
@@ -739,7 +739,7 @@ rdpClientConSendCaps(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(0, ("rdpClientConSendCaps: rdpup_send failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendCaps: rdpup_send failed"));
     }
 
     free_stream(ls);
@@ -751,7 +751,7 @@ static int
 rdpClientConProcessMsgVersion(rdpPtr dev, rdpClientCon *clientCon,
                               int param1, int param2, int param3, int param4)
 {
-    LLOGLN(0, ("rdpClientConProcessMsgVersion: version %d %d %d %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgVersion: version %d %d %d %d",
            param1, param2, param3, param4));
 
     if ((param1 > 0) || (param2 > 0) || (param3 > 0) || (param4 > 0))
@@ -779,7 +779,7 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
 
     if (clientCon->shmemptr != NULL && clientCon->shmem_bytes == bytes)
     {
-        LLOGLN(0, ("rdpClientConAllocateSharedMemory: reusing shmemfd %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: reusing shmemfd %d",
                clientCon->shmemfd));
         return;
     }
@@ -794,13 +794,13 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
     }
     if (g_alloc_shm_map_fd(&shmemptr, &shmemfd, bytes) != 0)
     {
-        LLOGLN(0, ("rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
                "failed"));
     }
     clientCon->shmemptr = shmemptr;
     clientCon->shmemfd = shmemfd;
     clientCon->shmem_bytes = bytes;
-    LLOGLN(0, ("rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
+    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
             "bytes %d",
             clientCon->shmemfd, clientCon->shmemptr,
             clientCon->shmem_bytes));
@@ -845,7 +845,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
 
     enum shared_memory_status shmemstatus;
 
-    LLOGLN(10, ("rdpClientConResizeAllMemoryAreas:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConResizeAllMemoryAreas:"));
 
     // Updare the rdp size from the client size
     clientCon->rdp_width = width;
@@ -856,11 +856,11 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
     {
         case CC_SUF_RFX: /* RFX */
         case CC_GFX_PRO:
-            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
             /* RFX capture needs fixed-size rectangles */
             clientCon->cap_width = RDPALIGN(width, XRDP_RFX_ALIGN);
             clientCon->cap_height = RDPALIGN(height, XRDP_RFX_ALIGN);
-            LLOGLN(0, ("  cap_width %d cap_height %d",
+            LLOGLN(LOG_LEVEL_INFO, ("  cap_width %d cap_height %d",
                    clientCon->cap_width, clientCon->cap_height));
 
             bytes = clientCon->cap_width * clientCon->cap_height *
@@ -874,7 +874,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
         case CC_SUF_A2: /* H264 */
         case CC_GFX_A2:
-            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
             clientCon->cap_width = width;
             clientCon->cap_height = height;
 
@@ -887,7 +887,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             dev->msFrameInterval = clientCon->client_info.h264_frame_interval;
             break;
         default:
-            LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got normal capture"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got normal capture"));
             clientCon->cap_width = width;
             clientCon->cap_width = width;
             clientCon->cap_height = height;
@@ -902,7 +902,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
     }
 
-    LLOGLN(0, ("    msFrameInterval %ld", (long)dev->msFrameInterval));
+    LLOGLN(LOG_LEVEL_INFO, ("    msFrameInterval %ld", (long)dev->msFrameInterval));
     rdpClientConAllocateSharedMemory(clientCon, bytes);
 
     if (clientCon->client_info.capture_format != 0)
@@ -961,7 +961,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
         dev->allow_screen_resize = 1;
         ok = RRScreenSizeSet(dev->pScreen, width, height, mmwidth, mmheight);
         dev->allow_screen_resize = 0;
-        LLOGLN(0, ("rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok));
     }
 
     rdpCaptureResetState(clientCon);
@@ -981,7 +981,7 @@ rdpClientConProcessMonitorUpdateMsg(rdpPtr dev, rdpClientCon *clientCon,
                                     struct monitor_info monitors[])
 {
     int i;
-    LLOGLN(0, ("rdpClientConProcessMonitorUpdateMsg: (%dx%d) #%d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMonitorUpdateMsg: (%dx%d) #%d",
            width, height, num_monitors));
 
     // Update the client_info we have
@@ -1031,7 +1031,7 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, param3);
     in_uint32_le(s, param4);
 
-    LLOGLN(10, ("rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
            "param3 %d param4 %d", msg, param1, param2, param3, param4));
 
     if (msg < 100)
@@ -1048,13 +1048,13 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         y = param1 & 0xffff;
         cx = (param2 >> 16) & 0xffff;
         cy = param2 & 0xffff;
-        LLOGLN(0, ("rdpClientConProcessMsgClientInput: invalidate x %d y %d "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: invalidate x %d y %d "
                "cx %d cy %d", x, y, cx, cy));
         rdpClientConAddDirtyScreen(dev, clientCon, x, y, cx, cy);
     }
     else if (msg == 300) /* resize desktop */
     {
-        LLOGLN(0, ("rdpClientConProcessMsgClientInput: obsolete msg %d", msg));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: obsolete msg %d", msg));
     }
     else if (msg == 301) /* version */
     {
@@ -1074,12 +1074,12 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         }
         else
         {
-            LLOGLN(0, ("rdpClientConProcessMsgClientInput: bad monitor count %d", param3));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: bad monitor count %d", param3));
         }
     }
     else
     {
-        LLOGLN(0, ("rdpClientConProcessMsgClientInput: unknown msg %d", msg));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: unknown msg %d", msg));
     }
 
     return 0;
@@ -1142,7 +1142,7 @@ rdpStartAccelAssist(rdpPtr dev, rdpClientCon *clientCon)
     else
     {
         /* parent */
-        LLOGLN(0, ("rdpStartAccelAssist: started accel assist pid %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpStartAccelAssist: started accel assist pid %d",
                clientCon->accel_assist_pid));
         rdpClientConRemoveEnabledDevice(clientCon->sck);
         close(clientCon->sck);
@@ -1165,7 +1165,7 @@ rdpSendAccelAssistMonitors(rdpPtr dev, rdpClientCon *clientCon)
     int height;
     const int layer_size = 8;
 
-    LLOGLN(0, ("rdpSendAccelAssistMonitors: monitorCount %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpSendAccelAssistMonitors: monitorCount %d",
            dev->monitorCount));
     rdpClientConSendPending(dev, clientCon);
     init_stream(clientCon->out_s, 0);
@@ -1276,8 +1276,8 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
     BoxRec box;
     if (clientCon->client_info.display_sizes.monitorCount > 0)
     {
-        LLOGLN(0, ("  client can do multimon"));
-        LLOGLN(0, ("  client monitor data, monitorCount=%d", clientCon->client_info.display_sizes.monitorCount));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can do multimon"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client monitor data, monitorCount=%d", clientCon->client_info.display_sizes.monitorCount));
         clientCon->doMultimon = 1;
         dev->doMultimon = 1;
         memcpy(dev->minfo, clientCon->client_info.display_sizes.minfo, sizeof(dev->minfo));
@@ -1301,7 +1301,7 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
             dev->minfo[index].top -= box.y1;
             dev->minfo[index].right -= box.x1;
             dev->minfo[index].bottom -= box.y1;
-            LLOGLN(0, ("    left %d top %d right %d bottom %d",
+            LLOGLN(LOG_LEVEL_INFO, ("    left %d top %d right %d bottom %d",
                    dev->minfo[index].left,
                    dev->minfo[index].top,
                    dev->minfo[index].right,
@@ -1310,7 +1310,7 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
     }
     else
     {
-        LLOGLN(0, ("  client can not do multimon"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can not do multimon"));
         clientCon->doMultimon = 0;
         dev->doMultimon = 0;
         dev->monitorCount = 0;
@@ -1350,7 +1350,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     int bytes;
     int i1;
 
-    LLOGLN(10, ("rdpClientConProcessMsgClientInfo:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientInfo:"));
     s = clientCon->in_s;
     in_uint32_le(s, bytes);
     if (bytes > sizeof(clientCon->client_info))
@@ -1364,20 +1364,20 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     // before sending client info.
     if (clientCon->client_info.version != XUP_CLIENT_INFO_CURRENT_VERSION)
     {
-        LLOGLN(0, ("expected xrdp client_info version %d, got %d",
+        LLOGLN(LOG_LEVEL_INFO, ("expected xrdp client_info version %d, got %d",
                    XUP_CLIENT_INFO_CURRENT_VERSION,
                    clientCon->client_info.version));
         FatalError("Incompatible xrdp version detected  - please recompile");
     }
 
-    LLOGLN(0, ("  got client info bytes %d", bytes));
-    LLOGLN(0, ("  jpeg support %d", clientCon->client_info.jpeg));
+    LLOGLN(LOG_LEVEL_INFO, ("  got client info bytes %d", bytes));
+    LLOGLN(LOG_LEVEL_INFO, ("  jpeg support %d", clientCon->client_info.jpeg));
     i1 = clientCon->client_info.offscreen_support_level;
-    LLOGLN(0, ("  offscreen support %d", i1));
+    LLOGLN(LOG_LEVEL_INFO, ("  offscreen support %d", i1));
     i1 = clientCon->client_info.offscreen_cache_size;
-    LLOGLN(0, ("  offscreen size %d", i1));
+    LLOGLN(LOG_LEVEL_INFO, ("  offscreen size %d", i1));
     i1 = clientCon->client_info.offscreen_cache_entries;
-    LLOGLN(0, ("  offscreen entries %d", i1));
+    LLOGLN(LOG_LEVEL_INFO, ("  offscreen entries %d", i1));
 
     /* Monitor info */
     int bpp = clientCon->client_info.bpp;
@@ -1418,7 +1418,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
 
     if (clientCon->client_info.orders[0x1b])   /* 27 NEG_GLYPH_INDEX_INDEX */
     {
-        LLOGLN(0, ("  client supports glyph cache but server disabled"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client supports glyph cache but server disabled"));
         //clientCon->doGlyphCache = 1;
     }
     if (clientCon->client_info.order_flags_ex & 0x100)
@@ -1427,30 +1427,30 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     }
     if (clientCon->doGlyphCache)
     {
-        LLOGLN(0, ("  using glyph cache"));
+        LLOGLN(LOG_LEVEL_INFO, ("  using glyph cache"));
     }
     if (clientCon->doComposite)
     {
-        LLOGLN(0, ("  using client composite"));
+        LLOGLN(LOG_LEVEL_INFO, ("  using client composite"));
     }
-    LLOGLN(10, ("order_flags_ex 0x%x", clientCon->client_info.order_flags_ex));
+    LLOGLN(LOG_LEVEL_TRACE, ("order_flags_ex 0x%x", clientCon->client_info.order_flags_ex));
     if (clientCon->client_info.offscreen_cache_entries == 2000)
     {
-        LLOGLN(0, ("  client can do offscreen to offscreen blits"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can do offscreen to offscreen blits"));
         clientCon->canDoPixToPix = 1;
     }
     else
     {
-        LLOGLN(0, ("  client can not do offscreen to offscreen blits"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can not do offscreen to offscreen blits"));
         clientCon->canDoPixToPix = 0;
     }
     if (clientCon->client_info.pointer_flags & 1)
     {
-        LLOGLN(0, ("  client can do new(color) cursor"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can do new(color) cursor"));
     }
     else
     {
-        LLOGLN(0, ("  client can not do new(color) cursor"));
+        LLOGLN(LOG_LEVEL_INFO, ("  client can not do new(color) cursor"));
     }
 
     /* rdpLoadLayout */
@@ -1485,7 +1485,7 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     RegionRec reg;
     BoxRec box;
 
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegion:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion:"));
     s = clientCon->in_s;
 
     in_uint32_le(s, flags);
@@ -1494,9 +1494,9 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, y);
     in_uint32_le(s, cx);
     in_uint32_le(s, cy);
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
            x, y, cx, cy, flags));
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
            clientCon->rect_id, clientCon->rect_id_ack));
 
     box.x1 = x;
@@ -1505,7 +1505,7 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     box.y2 = box.y1 + cy;
 
     rdpRegionInit(&reg, &box, 0);
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegion: %d %d %d %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: %d %d %d %d",
            box.x1, box.y1, box.x2, box.y2));
     rdpRegionSubtract(clientCon->shmRegion, clientCon->shmRegion, &reg);
     rdpRegionUninit(&reg);
@@ -1520,7 +1520,7 @@ rdpClientConProcessMsgClientRegionEx(rdpPtr dev, rdpClientCon *clientCon)
     struct stream *s;
     int flags;
 
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegionEx:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx:"));
     s = clientCon->in_s;
 
     in_uint32_le(s, flags);
@@ -1530,8 +1530,8 @@ rdpClientConProcessMsgClientRegionEx(rdpPtr dev, rdpClientCon *clientCon)
         // Client just wishes to ack all in-flight frames
         clientCon->rect_id_ack = clientCon->rect_id;
     }
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags));
-    LLOGLN(10, ("rdpClientConProcessMsgClientRegionEx: rect_id %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx: rect_id %d "
            "rect_id_ack %d", clientCon->rect_id, clientCon->rect_id_ack));
     rdpScheduleDeferredUpdate(clientCon);
     return 0;
@@ -1554,7 +1554,7 @@ rdpClientConProcessMsgClientSuppressOutput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, top);
     in_uint32_le(s, right);
     in_uint32_le(s, bottom);
-    LLOGLN(10, ("rdpClientConProcessMsgClientSuppressOutput: "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientSuppressOutput: "
            "suppress %d left %d top %d right %d bottom %d",
            suppress, left, top, right, bottom));
     clientCon->suppress_output = suppress;
@@ -1573,10 +1573,10 @@ rdpClientConProcessMsg(rdpPtr dev, rdpClientCon *clientCon)
     int msg_type;
     struct stream *s;
 
-    LLOGLN(10, ("rdpClientConProcessMsg:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsg:"));
     s = clientCon->in_s;
     in_uint16_le(s, msg_type);
-    LLOGLN(10, ("rdpClientConProcessMsg: msg_type %d", msg_type));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsg: msg_type %d", msg_type));
     switch (msg_type)
     {
         case 103: /* client input */
@@ -1595,7 +1595,7 @@ rdpClientConProcessMsg(rdpPtr dev, rdpClientCon *clientCon)
             rdpClientConProcessMsgClientSuppressOutput(dev, clientCon);
             break;
         default:
-            LLOGLN(0, ("rdpClientConProcessMsg: unknown msg_type %d",
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsg: unknown msg_type %d",
                    msg_type));
             break;
     }
@@ -1609,7 +1609,7 @@ rdpClientConGotData(ScreenPtr pScreen, rdpPtr dev, rdpClientCon *clientCon)
 {
     int rv;
 
-    LLOGLN(10, ("rdpClientConGotData:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotData:"));
 
     rv = rdpClientConRecvMsg(dev, clientCon);
     if (rv == 0)
@@ -1625,7 +1625,7 @@ static int
 rdpClientConGotControlConnection(ScreenPtr pScreen, rdpPtr dev,
                                  rdpClientCon *clientCon)
 {
-    LLOGLN(10, ("rdpClientConGotControlConnection:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotControlConnection:"));
     return 0;
 }
 
@@ -1634,7 +1634,7 @@ static int
 rdpClientConGotControlData(ScreenPtr pScreen, rdpPtr dev,
                            rdpClientCon *clientCon)
 {
-    LLOGLN(10, ("rdpClientConGotControlData:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotControlData:"));
     return 0;
 }
 
@@ -1652,7 +1652,7 @@ rdpClientConCheck(ScreenPtr pScreen)
     int count;
     char buf[8];
 
-    LLOGLN(10, ("rdpClientConCheck:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCheck:"));
     dev = rdpGetDevFromScreen(pScreen);
     time.tv_sec = 0;
     time.tv_usec = 0;
@@ -1715,7 +1715,7 @@ rdpClientConCheck(ScreenPtr pScreen)
     }
     if (sel < 1)
     {
-        LLOGLN(10, ("rdpClientConCheck: no select"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCheck: no select"));
         return 0;
     }
 
@@ -1734,7 +1734,7 @@ rdpClientConCheck(ScreenPtr pScreen)
 
             if (g_sck_recv(dev->disconnect_sck, buf, sizeof(buf), 0))
             {
-                LLOGLN(0, ("rdpClientConCheck: got disconnection request"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: got disconnection request"));
 
                 /* disconnect all clients */
                 while (dev->clientConHead != NULL)
@@ -1755,7 +1755,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotData(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(0, ("rdpClientConCheck: rdpClientConGotData failed"));
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotData failed"));
                     continue; /* skip other socket checks for this clientCon */
                 }
             }
@@ -1766,7 +1766,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlConnection(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(0, ("rdpClientConCheck: rdpClientConGotControlConnection failed"));
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotControlConnection failed"));
                     continue;
                 }
             }
@@ -1777,7 +1777,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlData(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(0, ("rdpClientConCheck: rdpClientConGotControlData failed"));
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotControlData failed"));
                     continue;
                 }
             }
@@ -1840,7 +1840,7 @@ rdpClientConInit(rdpPtr dev)
         {
             if (!g_directory_exist(socket_dir))
             {
-                LLOGLN(0, ("rdpClientConInit: g_create_dir(%s) failed", socket_dir));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_create_dir(%s) failed", socket_dir));
                 return 0;
             }
         }
@@ -1874,7 +1874,7 @@ rdpClientConInit(rdpPtr dev)
         dev->listen_sck = g_sck_local_socket_stream();
         if (g_sck_local_bind(dev->listen_sck, dev->uds_data) != 0)
         {
-            LLOGLN(0, ("rdpClientConInit: g_tcp_local_bind failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_tcp_local_bind failed"));
             return 1;
         }
         g_sck_listen(dev->listen_sck);
@@ -1892,7 +1892,7 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_sck = g_sck_local_socket_dgram();
         if (g_sck_local_bind(dev->disconnect_sck, dev->disconnect_uds) != 0)
         {
-            LLOGLN(0, ("rdpClientConInit: g_tcp_local_bind failed at %s:%d", __FILE__, __LINE__));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_tcp_local_bind failed at %s:%d", __FILE__, __LINE__));
             return 1;
         }
         g_sck_listen(dev->disconnect_sck);
@@ -1911,7 +1911,7 @@ rdpClientConInit(rdpPtr dev)
         }
 
     }
-    LLOGLN(0, ("rdpClientConInit: disconnect idle session after [%d] sec",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: disconnect idle session after [%d] sec",
                dev->idle_disconnect_timeout_s));
 
     /* kill disconnected */
@@ -1943,7 +1943,7 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_timeout_s = 60;
     }
 
-    LLOGLN(0, ("rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
                dev->do_kill_disconnected, dev->disconnect_timeout_s));
 
 
@@ -1954,11 +1954,11 @@ rdpClientConInit(rdpPtr dev)
 int
 rdpClientConDeinit(rdpPtr dev)
 {
-    LLOGLN(10, ("rdpClientConDeinit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeinit:"));
 
     while (dev->clientConTail != NULL)
     {
-        LLOGLN(0, ("rdpClientConDeinit: disconnecting clientCon"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: disconnecting clientCon"));
         rdpClientConDisconnect(dev, dev->clientConTail);
     }
 
@@ -1966,10 +1966,10 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->listen_sck);
         g_sck_close(dev->listen_sck);
-        LLOGLN(0, ("rdpClientConDeinit: deleting file %s", dev->uds_data));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: deleting file %s", dev->uds_data));
         if (unlink(dev->uds_data) < 0)
         {
-            LLOGLN(0, ("rdpClientConDeinit: failed to delete %s (%s)",
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: failed to delete %s (%s)",
                         dev->uds_data, strerror(errno)));
         }
     }
@@ -1978,10 +1978,10 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->disconnect_sck);
         g_sck_close(dev->disconnect_sck);
-        LLOGLN(0, ("rdpClientConDeinit: deleting file %s", dev->disconnect_uds));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: deleting file %s", dev->disconnect_uds));
         if (unlink(dev->disconnect_uds) < 0)
         {
-            LLOGLN(0, ("rdpClientConDeinit: failed to delete %s (%s)",
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: failed to delete %s (%s)",
                         dev->disconnect_uds, strerror(errno)));
         }
     }
@@ -1993,7 +1993,7 @@ rdpClientConDeinit(rdpPtr dev)
 int
 rdpClientConBeginUpdate(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(10, ("rdpClientConBeginUpdate:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConBeginUpdate:"));
 
     if (clientCon->begin)
     {
@@ -2013,7 +2013,7 @@ rdpClientConBeginUpdate(rdpPtr dev, rdpClientCon *clientCon)
 int
 rdpClientConEndUpdate(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(10, ("rdpClientConEndUpdate"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConEndUpdate"));
 
     if (clientCon->connected && clientCon->begin)
     {
@@ -2049,7 +2049,7 @@ rdpClientConPreCheck(rdpPtr dev, rdpClientCon *clientCon, int in_size)
         s_mark_end(clientCon->out_s);
         if (rdpClientConSendMsg(dev, clientCon) != 0)
         {
-            LLOGLN(0, ("rdpClientConPreCheck: rdpup_send_msg failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConPreCheck: rdpup_send_msg failed"));
             rv = 1;
         }
         clientCon->count = 0;
@@ -2067,7 +2067,7 @@ rdpClientConFillRect(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConFillRect:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConFillRect:"));
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 3); /* fill rect */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2088,7 +2088,7 @@ rdpClientConScreenBlt(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConScreenBlt: x %d y %d cx %d cy %d "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConScreenBlt: x %d y %d cx %d cy %d "
                "srcx %d srcy %d",
                x, y, cx, cy, srcx, srcy));
         rdpClientConPreCheck(dev, clientCon, 16);
@@ -2113,7 +2113,7 @@ rdpClientConSetClip(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetClip:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetClip:"));
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 10); /* set clip */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2133,7 +2133,7 @@ rdpClientConResetClip(rdpPtr dev, rdpClientCon *clientCon)
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConResetClip:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConResetClip:"));
         rdpClientConPreCheck(dev, clientCon, 4);
         out_uint16_le(clientCon->out_s, 11); /* reset clip */
         out_uint16_le(clientCon->out_s, 4); /* size */
@@ -2298,7 +2298,7 @@ rdpClientConSetFgcolor(rdpPtr dev, rdpClientCon *clientCon, int fgcolor)
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetFgcolor:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetFgcolor:"));
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 12); /* set fgcolor */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2318,7 +2318,7 @@ rdpClientConSetBgcolor(rdpPtr dev, rdpClientCon *clientCon, int bgcolor)
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetBgcolor:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetBgcolor:"));
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 13); /* set bg color */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2338,7 +2338,7 @@ rdpClientConSetOpcode(rdpPtr dev, rdpClientCon *clientCon, int opcode)
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetOpcode:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetOpcode:"));
         rdpClientConPreCheck(dev, clientCon, 6);
         out_uint16_le(clientCon->out_s, 14); /* set opcode */
         out_uint16_le(clientCon->out_s, 6); /* size */
@@ -2355,7 +2355,7 @@ rdpClientConSetPen(rdpPtr dev, rdpClientCon *clientCon, int style, int width)
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetPen:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetPen:"));
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 17); /* set pen */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2374,7 +2374,7 @@ rdpClientConDrawLine(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConDrawLine:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDrawLine:"));
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 18); /* draw line */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2397,7 +2397,7 @@ rdpClientConSetCursorSystem(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetCursor:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
         size = 2 + 2 + 4;
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 65); /* set cursor system */
@@ -2417,7 +2417,7 @@ rdpClientConMoveCursor(rdpPtr dev, rdpClientCon *clientCon, int x, int y)
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetCursor:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
         size = 2 + 2 + 2 + 2;
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 66); /* move cursor */
@@ -2439,7 +2439,7 @@ rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetCursor:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
         size = 8 + 32 * (32 * 3) + 32 * (32 / 8);
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 19); /* set cursor */
@@ -2469,7 +2469,7 @@ rdpClientConSetCursorEx(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetCursorEx:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorEx:"));
         Bpp = (bpp == 0) ? 3 : (bpp + 7) / 8;
         size = 10 + 32 * (32 * Bpp) + 32 * (32 / 8);
         rdpClientConPreCheck(dev, clientCon, size);
@@ -2507,12 +2507,12 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConSetCursorShm:"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorShm:"));
         Bpp = (bpp == 0) ? 3 : (bpp + 7) / 8;
         shmsize = width * height * Bpp + width * height / 8;
         if (g_alloc_shm_map_fd(&addr, &fd, shmsize) != 0)
         {
-            LLOGLN(0, ("rdpClientConSetCursorShmFd: rdpGetShmFd failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSetCursorShmFd: rdpGetShmFd failed"));
             return 0;
         }
         shmemptr = (uint8_t *)addr;
@@ -2534,7 +2534,7 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         memcpy(shmemptr + width * height * Bpp, cur_mask, width * height / 8);
         rdpClientConSendPending(clientCon->dev, clientCon);
         rv = g_sck_send_fd_set(clientCon->sck, "int", 4, &fd, 1);
-        LLOGLN(10, ("rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv));
         g_free_unmap_fd(shmemptr, fd, shmsize);
     }
     return rv;
@@ -2545,11 +2545,11 @@ int
 rdpClientConCreateOsSurface(rdpPtr dev, rdpClientCon *clientCon,
                             int rdpindex, int width, int height)
 {
-    LLOGLN(10, ("rdpClientConCreateOsSurface:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurface:"));
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConCreateOsSurface: width %d height %d", width, height));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurface: width %d height %d", width, height));
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 20);
         out_uint16_le(clientCon->out_s, 12);
@@ -2567,10 +2567,10 @@ int
 rdpClientConCreateOsSurfaceBpp(rdpPtr dev, rdpClientCon *clientCon,
                                int rdpindex, int width, int height, int bpp)
 {
-    LLOGLN(10, ("rdpClientConCreateOsSurfaceBpp:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurfaceBpp:"));
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConCreateOsSurfaceBpp: width %d height %d "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurfaceBpp: width %d height %d "
                "bpp %d", width, height, bpp));
         rdpClientConPreCheck(dev, clientCon, 13);
         out_uint16_le(clientCon->out_s, 31);
@@ -2588,7 +2588,7 @@ rdpClientConCreateOsSurfaceBpp(rdpPtr dev, rdpClientCon *clientCon,
 int
 rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 {
-    LLOGLN(10, ("rdpClientConSwitchOsSurface:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSwitchOsSurface:"));
 
     if (clientCon->connected)
     {
@@ -2598,7 +2598,7 @@ rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         }
 
         clientCon->rdpIndex = rdpindex;
-        LLOGLN(10, ("rdpClientConSwitchOsSurface: rdpindex %d", rdpindex));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSwitchOsSurface: rdpindex %d", rdpindex));
         /* switch surface */
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 21);
@@ -2614,11 +2614,11 @@ rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 int
 rdpClientConDeleteOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 {
-    LLOGLN(10, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
 
     if (clientCon->connected)
     {
-        LLOGLN(10, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 22);
         out_uint16_le(clientCon->out_s, 8);
@@ -2641,23 +2641,23 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     int oldest_index;
     int this_bytes;
 
-    LLOGLN(10, ("rdpClientConAddOsBitmap:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap:"));
     if (clientCon->connected == FALSE)
     {
-        LLOGLN(10, ("rdpClientConAddOsBitmap: test error 1"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 1"));
         return -1;
     }
 
     if (clientCon->osBitmaps == NULL)
     {
-        LLOGLN(10, ("rdpClientConAddOsBitmap: test error 2"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 2"));
         return -1;
     }
 
     this_bytes = pixmap->devKind * pixmap->drawable.height;
     if (this_bytes > MAX_OS_BYTES)
     {
-        LLOGLN(10, ("rdpClientConAddOsBitmap: error, too big this_bytes %d "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: error, too big this_bytes %d "
                "width %d height %d", this_bytes,
                pixmap->drawable.height, pixmap->drawable.height));
         return -1;
@@ -2696,11 +2696,11 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     {
         if (oldest_index == -1)
         {
-            LLOGLN(0, ("rdpClientConAddOsBitmap: error"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error"));
         }
         else
         {
-            LLOGLN(10, ("rdpClientConAddOsBitmap: too many pixmaps removing "
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: too many pixmaps removing "
                    "oldest_index %d", oldest_index));
             rdpClientConRemoveOsBitmap(dev, clientCon, oldest_index);
             rdpClientConDeleteOsSurface(dev, clientCon, oldest_index);
@@ -2716,18 +2716,18 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
 
     if (rv < 0)
     {
-        LLOGLN(10, ("rdpClientConAddOsBitmap: test error 3"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 3"));
         return rv;
     }
 
     clientCon->osBitmapAllocSize += this_bytes;
-    LLOGLN(10, ("rdpClientConAddOsBitmap: this_bytes %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: this_bytes %d "
            "clientCon->osBitmapAllocSize %d",
            this_bytes, clientCon->osBitmapAllocSize));
 #if USE_MAX_OS_BYTES
     while (clientCon->osBitmapAllocSize > MAX_OS_BYTES)
     {
-        LLOGLN(10, ("rdpClientConAddOsBitmap: must delete "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: must delete "
                "clientCon->osBitmapNumUsed %d",
                clientCon->osBitmapNumUsed));
         /* find oldest */
@@ -2746,20 +2746,20 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
         }
         if (oldest_index == -1)
         {
-            LLOGLN(0, ("rdpClientConAddOsBitmap: error 1"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error 1"));
             break;
         }
         if (oldest_index == rv)
         {
-            LLOGLN(0, ("rdpClientConAddOsBitmap: error 2"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error 2"));
             break;
         }
         rdpClientConRemoveOsBitmap(dev, clientCon, oldest_index);
         rdpClientConDeleteOsSurface(dev, clientCon, oldest_index);
     }
 #endif
-    LLOGLN(10, ("rdpClientConAddOsBitmap: new bitmap index %d", rv));
-    LLOGLN(10, ("rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: new bitmap index %d", rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
            "clientCon->osBitmapStamp 0x%8.8x",
            clientCon->osBitmapNumUsed, clientCon->osBitmapStamp));
     return rv;
@@ -2775,16 +2775,16 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 
     if (clientCon->osBitmaps == NULL)
     {
-        LLOGLN(10, ("rdpClientConRemoveOsBitmap: test error 1"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: test error 1"));
         return 1;
     }
 
-    LLOGLN(10, ("rdpClientConRemoveOsBitmap: index %d stamp %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: index %d stamp %d",
            rdpindex, clientCon->osBitmaps[rdpindex].stamp));
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
     {
-        LLOGLN(10, ("rdpClientConRemoveOsBitmap: test error 2"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: test error 2"));
         return 1;
     }
 
@@ -2795,7 +2795,7 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         rdpDrawItemRemoveAll(dev, priv);
         this_bytes = pixmap->devKind * pixmap->drawable.height;
         clientCon->osBitmapAllocSize -= this_bytes;
-        LLOGLN(10, ("rdpClientConRemoveOsBitmap: this_bytes %d "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: this_bytes %d "
                "clientCon->osBitmapAllocSize %d", this_bytes,
                clientCon->osBitmapAllocSize));
         clientCon->osBitmaps[rdpindex].used = 0;
@@ -2808,10 +2808,10 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
     else
     {
-        LLOGLN(0, ("rdpup_remove_os_bitmap: error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpup_remove_os_bitmap: error"));
     }
 
-    LLOGLN(10, ("rdpup_remove_os_bitmap: clientCon->osBitmapNumUsed %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpup_remove_os_bitmap: clientCon->osBitmapNumUsed %d",
            clientCon->osBitmapNumUsed));
     return 0;
 }
@@ -2825,7 +2825,7 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LLOGLN(10, ("rdpClientConUpdateOsUse: index %d stamp %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConUpdateOsUse: index %d stamp %d",
            rdpindex, clientCon->osBitmaps[rdpindex].stamp));
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
@@ -2840,7 +2840,7 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
     else
     {
-        LLOGLN(0, ("rdpClientConUpdateOsUse: error rdpindex %d", rdpindex));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConUpdateOsUse: error rdpindex %d", rdpindex));
     }
 
     return 0;
@@ -2853,7 +2853,7 @@ rdpClientConDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
     rdpClientCon *clientCon;
 
-    LLOGLN(10, ("rdpClientConDeferredUpdateCallback"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeferredUpdateCallback"));
 
     dev = (rdpPtr) arg;
     clientCon = dev->clientConHead;
@@ -2918,7 +2918,7 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LLOGLN(10, ("out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
+        LLOGLN(LOG_LEVEL_TRACE, ("out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
                index, x, y, cx, cy));
     }
     out_uint16_le(s, num_rects_c);
@@ -2933,7 +2933,7 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LLOGLN(10, ("out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
+        LLOGLN(LOG_LEVEL_TRACE, ("out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
                index, x, y, cx, cy));
     }
     return 0;
@@ -2957,24 +2957,24 @@ rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
     int end_frame_bytes;
     int surface_id;
 
-    LLOGLN(10, ("rdpClientConSendPaintRectShmFd:"));
-    LLOGLN(10, ("rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
            "cap_width %d cap_height %d",
            clientCon->cap_left, clientCon->cap_top,
            clientCon->cap_width, clientCon->cap_height));
-    LLOGLN(10, ("rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
            "id->left %d id->top %d id->width %d id->height %d",
            id->flags, id->left, id->top, id->width, id->height));
 
     capture_code = clientCon->client_info.capture_code;
-    LLOGLN(10, ("rdpClientConSendPaintRectShmFd: capture_code %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: capture_code %d",
            capture_code));
 
     num_rects_d = REGION_NUM_RECTS(dirtyReg);
     num_rects_c = numCopyRects;
     if ((num_rects_c < 1) || (num_rects_d < 1))
     {
-        LLOGLN(10, ("rdpClientConSendPaintRectShmFd: nothing to send"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: nothing to send"));
         return 0;
     }
 
@@ -3182,7 +3182,7 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
     int num_rects;
 
     cap_dirty = rdpRegionCreate(cap_rect, 0);
-    LLOGLN(10, ("rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
                cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2));
     rdpRegionIntersect(cap_dirty, cap_dirty, clientCon->dirtyRegion);
     num_rects = REGION_NUM_RECTS(cap_dirty);
@@ -3202,11 +3202,11 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
     {
         rects = 0;
         num_rects = 0;
-        LLOGLN(10, ("rdpCapRect: capture_code %d",
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: capture_code %d",
                     clientCon->client_info.capture_code));
         if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, id))
         {
-            LLOGLN(10, ("rdpCapRect: num_rects %d", num_rects));
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: num_rects %d", num_rects));
             if (clientCon->send_key_frame[mon])
             {
                 clientCon->send_key_frame[mon] = 0;
@@ -3219,7 +3219,7 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
         }
         else
         {
-            LLOGLN(0, ("rdpCapRect: rdpCapture failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpCapRect: rdpCapture failed"));
         }
     }
     rdpRegionSubtract(clientCon->dirtyRegion, clientCon->dirtyRegion,
@@ -3240,15 +3240,15 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     int monitor_count;
     BoxRec cap_rect;
 
-    LLOGLN(10, ("rdpDeferredUpdateCallback:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback:"));
     clientCon->updateScheduled = FALSE;
     if (clientCon->suppress_output)
     {
-        LLOGLN(10, ("rdpDeferredUpdateCallback: suppress_output set"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: suppress_output set"));
         return 0;
     }
     if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
-        LLOGLN(10, ("rdpDeferredUpdateCallback: clientCon->shmemstatus "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: clientCon->shmemstatus "
                "is not valid for capture operations: %d"
                " reschedule rect_id %d rect_id_ack %d",
                clientCon->shmemstatus, clientCon->rect_id, clientCon->rect_id_ack));
@@ -3261,7 +3261,7 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
         return 0;
     }
     clientCon->lastUpdateTime = now;
-    LLOGLN(10, ("rdpDeferredUpdateCallback: sending"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: sending"));
     clientCon->updateRetries = 0;
     if (clientCon->dev->monitorCount < 1)
     {
@@ -3285,7 +3285,7 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             // Did we get anything from the last monitor?
             if (clientCon->rect_id > clientCon->rect_id_ack)
             {
-                LLOGLN(10, ("rdpDeferredUpdateCallback: reschedule rect_id %d "
+                LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: reschedule rect_id %d "
                        "rect_id_ack %d",
                        clientCon->rect_id, clientCon->rect_id_ack));
                 break;
@@ -3361,7 +3361,7 @@ int
 rdpClientConAddDirtyScreenReg(rdpPtr dev, rdpClientCon *clientCon,
                               RegionPtr reg)
 {
-    LLOGLN(10, ("rdpClientConAddDirtyScreenReg:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddDirtyScreenReg:"));
     rdpRegionUnion(clientCon->dirtyRegion, clientCon->dirtyRegion, reg);
     rdpScheduleDeferredUpdate(clientCon);
     return 0;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -177,13 +177,13 @@ rdpAddClientConToDev(rdpPtr dev, rdpClientCon *clientCon)
     if (dev->clientConTail == NULL)
     {
         LOG(LOG_LEVEL_INFO, "rdpAddClientConToDev: adding first clientCon %p",
-                   clientCon);
+            clientCon);
         dev->clientConHead = clientCon;
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "rdpAddClientConToDev: adding clientCon %p",
-                   clientCon);
+            clientCon);
         dev->clientConTail->next = clientCon;
     }
     dev->clientConTail = clientCon;
@@ -194,7 +194,7 @@ static void
 rdpRemoveClientConFromDev(rdpPtr dev, rdpClientCon *clientCon)
 {
     LOG(LOG_LEVEL_INFO, "rdpRemoveClientConFromDev: removing clientCon %p",
-               clientCon);
+        clientCon);
 
     if (clientCon->prev == NULL)
     {
@@ -246,7 +246,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     else
     {
         LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: g_sck_accept ok new_sck %d",
-               new_sck);
+            new_sck);
         clientCon->sck = new_sck;
         g_sck_set_non_blocking(clientCon->sck);
         g_sck_tcp_set_no_delay(clientCon->sck); /* only works if TCP */
@@ -262,8 +262,8 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     {
         /* Only allow one client at a time */
         LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
-                   "marking only clientCon %p for disconnect",
-                   dev->clientConTail);
+            "marking only clientCon %p for disconnect",
+            dev->clientConTail);
         dev->clientConTail->connected = FALSE;
     }
 #endif
@@ -272,14 +272,16 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     if (dev->idle_disconnect_timeout_s > 0)
     {
         LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
-                   "engaging idle timer, timeout [%d] sec", dev->idle_disconnect_timeout_s);
+            "engaging idle timer, timeout [%d] sec",
+            dev->idle_disconnect_timeout_s);
         dev->idleDisconnectTimer = TimerSet(dev->idleDisconnectTimer, 0, dev->idle_disconnect_timeout_s * 1000,
                                             rdpDeferredIdleDisconnectCallback, dev);
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
-                   "idle_disconnect_timeout set to non-positive value, idle timer turned off");
+            "idle_disconnect_timeout set to non-positive value, "
+            "idle timer turned off");
     }
 
     rdpAddClientConToDev(dev, clientCon);
@@ -304,7 +306,8 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
         LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: connected");
         if (dev->disconnectTimer != NULL)
         {
-            LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: disengaging disconnect timer");
+            LOG(LOG_LEVEL_INFO,
+                "rdpDeferredDisconnectCallback: disengaging disconnect timer");
             TimerCancel(dev->disconnectTimer);
             TimerFree(dev->disconnectTimer);
             dev->disconnectTimer = NULL;
@@ -319,7 +322,7 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     if (now - dev->disconnect_time_ms > dev->disconnect_timeout_s * 1000)
     {
         LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: "
-                   "disconnect timeout exceeded, exiting");
+            "disconnect timeout exceeded, exiting");
         kill(getpid(), SIGTERM);
         return 0;
     }
@@ -346,8 +349,9 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     /* we MUST compare to equal otherwise we could restart the idle timer with 0! */
     if (millis_since_last_event >= (dev->idle_disconnect_timeout_s * 1000))
     {
-        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: session has been idle for %d seconds, disconnecting",
-                    dev->idle_disconnect_timeout_s);
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: "
+            "session has been idle for %d seconds, disconnecting",
+            dev->idle_disconnect_timeout_s);
 
         /* disconnect all clients */
         while (dev->clientConHead != NULL)
@@ -355,12 +359,14 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             rdpClientConDisconnect(dev, dev->clientConHead);
         }
 
-        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: disconnected idle session");
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: "
+            "disconnected idle session");
 
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
-        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: idle timer disengaged");
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: "
+            "idle timer disengaged");
         return 0;
     }
 
@@ -436,7 +442,8 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
 
     if (dev->idleDisconnectTimer != NULL && dev->idle_disconnect_timeout_s > 0)
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: disconnected, idle timer disengaged");
+        LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: "
+            "disconnected, idle timer disengaged");
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
@@ -446,8 +453,9 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
     {
         if (dev->disconnect_scheduled == FALSE)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: engaging disconnect timer, "
-                       "exit after %d seconds", dev->disconnect_timeout_s);
+            LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: "
+                "engaging disconnect timer, "
+                "exit after %d seconds", dev->disconnect_timeout_s);
             dev->disconnectTimer = TimerSet(dev->disconnectTimer, 0, 1000 * 10,
                                             rdpDeferredDisconnectCallback, dev);
             dev->disconnect_scheduled = TRUE;
@@ -531,14 +539,16 @@ rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
             }
             else
             {
-                LOG(LOG_LEVEL_INFO, "rdpClientConSend: g_tcp_send failed(returned -1)");
+                LOG(LOG_LEVEL_INFO,
+                    "rdpClientConSend: g_tcp_send failed(returned -1)");
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (sent == 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConSend: g_tcp_send failed(returned zero)");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConSend: g_tcp_send failed(returned zero)");
             clientCon->connected = FALSE;
             return 1;
         }
@@ -569,8 +579,8 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
         if (len > s->size)
         {
             LOG(LOG_LEVEL_INFO, "rdpClientConSendMsg: overrun error len, %d "
-                       "stream size %d, client count %d",
-                       len, s->size, clientCon->count);
+                "stream size %d, client count %d",
+                len, s->size, clientCon->count);
         }
 
         s_pop_layer(s, iso_hdr);
@@ -603,7 +613,8 @@ rdpClientConSendPending(rdpPtr dev, rdpClientCon *clientCon)
         s_mark_end(clientCon->out_s);
         if (rdpClientConSendMsg(dev, clientCon) != 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConSendPending: rdpClientConSendMsg failed");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConSendPending: rdpClientConSendMsg failed");
             rv = 1;
         }
     }
@@ -636,14 +647,16 @@ rdpClientConRecv(rdpPtr dev, rdpClientCon *clientCon, char *data, int len)
             }
             else
             {
-                LOG(LOG_LEVEL_INFO, "rdpClientConRecv: g_sck_recv failed(returned -1)");
+                LOG(LOG_LEVEL_INFO,
+                    "rdpClientConRecv: g_sck_recv failed(returned -1)");
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (rcvd == 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConRecv: g_sck_recv failed(returned 0)");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConRecv: g_sck_recv failed(returned 0)");
             clientCon->connected = FALSE;
             return 1;
         }
@@ -752,7 +765,7 @@ rdpClientConProcessMsgVersion(rdpPtr dev, rdpClientCon *clientCon,
                               int param1, int param2, int param3, int param4)
 {
     LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgVersion: version %d %d %d %d",
-           param1, param2, param3, param4);
+        param1, param2, param3, param4);
 
     if ((param1 > 0) || (param2 > 0) || (param3 > 0) || (param4 > 0))
     {
@@ -779,8 +792,9 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
 
     if (clientCon->shmemptr != NULL && clientCon->shmem_bytes == bytes)
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: reusing shmemfd %d",
-               clientCon->shmemfd);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConAllocateSharedMemory: reusing shmemfd %d",
+            clientCon->shmemfd);
         return;
     }
     if (clientCon->shmemptr != NULL)
@@ -794,16 +808,18 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
     }
     if (g_alloc_shm_map_fd(&shmemptr, &shmemfd, bytes) != 0)
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
-               "failed");
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
+            "failed");
     }
     clientCon->shmemptr = shmemptr;
     clientCon->shmemfd = shmemfd;
     clientCon->shmem_bytes = bytes;
-    LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
-            "bytes %d",
-            clientCon->shmemfd, clientCon->shmemptr,
-            clientCon->shmem_bytes);
+    LOG(LOG_LEVEL_INFO,
+        "rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
+        "bytes %d",
+        clientCon->shmemfd, clientCon->shmemptr,
+        clientCon->shmem_bytes);
 }
 
 /******************************************************************************/
@@ -856,12 +872,13 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
     {
         case CC_SUF_RFX: /* RFX */
         case CC_GFX_PRO:
-            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got RFX capture");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConProcessMsgClientInfo: got RFX capture");
             /* RFX capture needs fixed-size rectangles */
             clientCon->cap_width = RDPALIGN(width, XRDP_RFX_ALIGN);
             clientCon->cap_height = RDPALIGN(height, XRDP_RFX_ALIGN);
             LOG(LOG_LEVEL_INFO, "  cap_width %d cap_height %d",
-                   clientCon->cap_width, clientCon->cap_height);
+                clientCon->cap_width, clientCon->cap_height);
 
             bytes = clientCon->cap_width * clientCon->cap_height *
                     clientCon->rdp_Bpp;
@@ -874,7 +891,8 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
         case CC_SUF_A2: /* H264 */
         case CC_GFX_A2:
-            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got H264 capture");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConProcessMsgClientInfo: got H264 capture");
             clientCon->cap_width = width;
             clientCon->cap_height = height;
 
@@ -887,7 +905,8 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             dev->msFrameInterval = clientCon->client_info.h264_frame_interval;
             break;
         default:
-            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got normal capture");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConProcessMsgClientInfo: got normal capture");
             clientCon->cap_width = width;
             clientCon->cap_width = width;
             clientCon->cap_height = height;
@@ -902,7 +921,8 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
     }
 
-    LOG(LOG_LEVEL_INFO, "    msFrameInterval %ld", (long)dev->msFrameInterval);
+    LOG(LOG_LEVEL_INFO,
+        "    msFrameInterval %ld", (long)dev->msFrameInterval);
     rdpClientConAllocateSharedMemory(clientCon, bytes);
 
     if (clientCon->client_info.capture_format != 0)
@@ -961,7 +981,8 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
         dev->allow_screen_resize = 1;
         ok = RRScreenSizeSet(dev->pScreen, width, height, mmwidth, mmheight);
         dev->allow_screen_resize = 0;
-        LOG(LOG_LEVEL_INFO, "rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok);
     }
 
     rdpCaptureResetState(clientCon);
@@ -982,7 +1003,7 @@ rdpClientConProcessMonitorUpdateMsg(rdpPtr dev, rdpClientCon *clientCon,
 {
     int i;
     LOG(LOG_LEVEL_INFO, "rdpClientConProcessMonitorUpdateMsg: (%dx%d) #%d",
-           width, height, num_monitors);
+        width, height, num_monitors);
 
     // Update the client_info we have
     clientCon->client_info.display_sizes.monitorCount = num_monitors;
@@ -1031,8 +1052,9 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, param3);
     in_uint32_le(s, param4);
 
-    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
-           "param3 %d param4 %d", msg, param1, param2, param3, param4);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
+        "param3 %d param4 %d", msg, param1, param2, param3, param4);
 
     if (msg < 100)
     {
@@ -1048,13 +1070,15 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         y = param1 & 0xffff;
         cx = (param2 >> 16) & 0xffff;
         cy = param2 & 0xffff;
-        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: invalidate x %d y %d "
-               "cx %d cy %d", x, y, cx, cy);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConProcessMsgClientInput: invalidate x %d y %d "
+            "cx %d cy %d", x, y, cx, cy);
         rdpClientConAddDirtyScreen(dev, clientCon, x, y, cx, cy);
     }
     else if (msg == 300) /* resize desktop */
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: obsolete msg %d", msg);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConProcessMsgClientInput: obsolete msg %d", msg);
     }
     else if (msg == 301) /* version */
     {
@@ -1074,12 +1098,15 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         }
         else
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: bad monitor count %d", param3);
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConProcessMsgClientInput: bad monitor count %d",
+                param3);
         }
     }
     else
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: unknown msg %d", msg);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConProcessMsgClientInput: unknown msg %d", msg);
     }
 
     return 0;
@@ -1143,7 +1170,7 @@ rdpStartAccelAssist(rdpPtr dev, rdpClientCon *clientCon)
     {
         /* parent */
         LOG(LOG_LEVEL_INFO, "rdpStartAccelAssist: started accel assist pid %d",
-               clientCon->accel_assist_pid);
+            clientCon->accel_assist_pid);
         rdpClientConRemoveEnabledDevice(clientCon->sck);
         close(clientCon->sck);
         close(spair[0]);
@@ -1166,7 +1193,7 @@ rdpSendAccelAssistMonitors(rdpPtr dev, rdpClientCon *clientCon)
     const int layer_size = 8;
 
     LOG(LOG_LEVEL_INFO, "rdpSendAccelAssistMonitors: monitorCount %d",
-           dev->monitorCount);
+        dev->monitorCount);
     rdpClientConSendPending(dev, clientCon);
     init_stream(clientCon->out_s, 0);
     s_push_layer(clientCon->out_s, iso_hdr, layer_size);
@@ -1277,7 +1304,8 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
     if (clientCon->client_info.display_sizes.monitorCount > 0)
     {
         LOG(LOG_LEVEL_INFO, "  client can do multimon");
-        LOG(LOG_LEVEL_INFO, "  client monitor data, monitorCount=%d", clientCon->client_info.display_sizes.monitorCount);
+        LOG(LOG_LEVEL_INFO, "  client monitor data, monitorCount=%d",
+            clientCon->client_info.display_sizes.monitorCount);
         clientCon->doMultimon = 1;
         dev->doMultimon = 1;
         memcpy(dev->minfo, clientCon->client_info.display_sizes.minfo, sizeof(dev->minfo));
@@ -1302,10 +1330,10 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
             dev->minfo[index].right -= box.x1;
             dev->minfo[index].bottom -= box.y1;
             LOG(LOG_LEVEL_INFO, "    left %d top %d right %d bottom %d",
-                   dev->minfo[index].left,
-                   dev->minfo[index].top,
-                   dev->minfo[index].right,
-                   dev->minfo[index].bottom);
+                dev->minfo[index].left,
+                dev->minfo[index].top,
+                dev->minfo[index].right,
+                dev->minfo[index].bottom);
         }
     }
     else
@@ -1365,8 +1393,8 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     if (clientCon->client_info.version != XUP_CLIENT_INFO_CURRENT_VERSION)
     {
         LOG(LOG_LEVEL_INFO, "expected xrdp client_info version %d, got %d",
-                   XUP_CLIENT_INFO_CURRENT_VERSION,
-                   clientCon->client_info.version);
+            XUP_CLIENT_INFO_CURRENT_VERSION,
+            clientCon->client_info.version);
         FatalError("Incompatible xrdp version detected  - please recompile");
     }
 
@@ -1494,10 +1522,12 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, y);
     in_uint32_le(s, cx);
     in_uint32_le(s, cy);
-    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
-           x, y, cx, cy, flags);
-    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
-           clientCon->rect_id, clientCon->rect_id_ack);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
+        x, y, cx, cy, flags);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
+        clientCon->rect_id, clientCon->rect_id_ack);
 
     box.x1 = x;
     box.y1 = y;
@@ -1506,7 +1536,7 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
 
     rdpRegionInit(&reg, &box, 0);
     LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: %d %d %d %d",
-           box.x1, box.y1, box.x2, box.y2);
+        box.x1, box.y1, box.x2, box.y2);
     rdpRegionSubtract(clientCon->shmRegion, clientCon->shmRegion, &reg);
     rdpRegionUninit(&reg);
     rdpScheduleDeferredUpdate(clientCon);
@@ -1530,9 +1560,11 @@ rdpClientConProcessMsgClientRegionEx(rdpPtr dev, rdpClientCon *clientCon)
         // Client just wishes to ack all in-flight frames
         clientCon->rect_id_ack = clientCon->rect_id;
     }
-    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags);
-    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegionEx: rect_id %d "
-           "rect_id_ack %d", clientCon->rect_id, clientCon->rect_id_ack);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConProcessMsgClientRegionEx: rect_id %d "
+        "rect_id_ack %d", clientCon->rect_id, clientCon->rect_id_ack);
     rdpScheduleDeferredUpdate(clientCon);
     return 0;
 }
@@ -1555,8 +1587,8 @@ rdpClientConProcessMsgClientSuppressOutput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, right);
     in_uint32_le(s, bottom);
     LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientSuppressOutput: "
-           "suppress %d left %d top %d right %d bottom %d",
-           suppress, left, top, right, bottom);
+        "suppress %d left %d top %d right %d bottom %d",
+        suppress, left, top, right, bottom);
     clientCon->suppress_output = suppress;
     if (suppress == 0)
     {
@@ -1596,7 +1628,7 @@ rdpClientConProcessMsg(rdpPtr dev, rdpClientCon *clientCon)
             break;
         default:
             LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsg: unknown msg_type %d",
-                   msg_type);
+                msg_type);
             break;
     }
 
@@ -1734,7 +1766,8 @@ rdpClientConCheck(ScreenPtr pScreen)
 
             if (g_sck_recv(dev->disconnect_sck, buf, sizeof(buf), 0))
             {
-                LOG(LOG_LEVEL_INFO, "rdpClientConCheck: got disconnection request");
+                LOG(LOG_LEVEL_INFO,
+                    "rdpClientConCheck: got disconnection request");
 
                 /* disconnect all clients */
                 while (dev->clientConHead != NULL)
@@ -1755,7 +1788,8 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotData(pScreen, dev, clientCon) != 0)
                 {
-                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotData failed");
+                    LOG(LOG_LEVEL_INFO,
+                        "rdpClientConCheck: rdpClientConGotData failed");
                     continue; /* skip other socket checks for this clientCon */
                 }
             }
@@ -1766,7 +1800,8 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlConnection(pScreen, dev, clientCon) != 0)
                 {
-                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotControlConnection failed");
+                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: "
+                        "rdpClientConGotControlConnection failed");
                     continue;
                 }
             }
@@ -1777,7 +1812,8 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlData(pScreen, dev, clientCon) != 0)
                 {
-                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotControlData failed");
+                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: "
+                        "rdpClientConGotControlData failed");
                     continue;
                 }
             }
@@ -1840,7 +1876,8 @@ rdpClientConInit(rdpPtr dev)
         {
             if (!g_directory_exist(socket_dir))
             {
-                LOG(LOG_LEVEL_INFO, "rdpClientConInit: g_create_dir(%s) failed", socket_dir);
+                LOG(LOG_LEVEL_INFO,
+                    "rdpClientConInit: g_create_dir(%s) failed", socket_dir);
                 return 0;
             }
         }
@@ -1892,7 +1929,9 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_sck = g_sck_local_socket_dgram();
         if (g_sck_local_bind(dev->disconnect_sck, dev->disconnect_uds) != 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConInit: g_tcp_local_bind failed at %s:%d", __FILE__, __LINE__);
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConInit: g_tcp_local_bind failed at %s:%d",
+                __FILE__, __LINE__);
             return 1;
         }
         g_sck_listen(dev->disconnect_sck);
@@ -1911,8 +1950,9 @@ rdpClientConInit(rdpPtr dev)
         }
 
     }
-    LOG(LOG_LEVEL_INFO, "rdpClientConInit: disconnect idle session after [%d] sec",
-               dev->idle_disconnect_timeout_s);
+    LOG(LOG_LEVEL_INFO,
+        "rdpClientConInit: disconnect idle session after [%d] sec",
+        dev->idle_disconnect_timeout_s);
 
     /* kill disconnected */
     ptext = getenv("XRDP_SESMAN_MAX_DISC_TIME");
@@ -1943,8 +1983,9 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_timeout_s = 60;
     }
 
-    LOG(LOG_LEVEL_INFO, "rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
-               dev->do_kill_disconnected, dev->disconnect_timeout_s);
+    LOG(LOG_LEVEL_INFO,
+        "rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
+        dev->do_kill_disconnected, dev->disconnect_timeout_s);
 
 
     return 0;
@@ -1970,7 +2011,7 @@ rdpClientConDeinit(rdpPtr dev)
         if (unlink(dev->uds_data) < 0)
         {
             LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: failed to delete %s (%s)",
-                        dev->uds_data, strerror(errno));
+                dev->uds_data, strerror(errno));
         }
     }
 
@@ -1978,11 +2019,13 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->disconnect_sck);
         g_sck_close(dev->disconnect_sck);
-        LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: deleting file %s", dev->disconnect_uds);
+        LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: deleting file %s",
+            dev->disconnect_uds);
         if (unlink(dev->disconnect_uds) < 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: failed to delete %s (%s)",
-                        dev->disconnect_uds, strerror(errno));
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConDeinit: failed to delete %s (%s)",
+                dev->disconnect_uds, strerror(errno));
         }
     }
 
@@ -2089,8 +2132,8 @@ rdpClientConScreenBlt(rdpPtr dev, rdpClientCon *clientCon,
     if (clientCon->connected)
     {
         LOG(LOG_LEVEL_TRACE, "rdpClientConScreenBlt: x %d y %d cx %d cy %d "
-               "srcx %d srcy %d",
-               x, y, cx, cy, srcx, srcy);
+            "srcx %d srcy %d",
+            x, y, cx, cy, srcx, srcy);
         rdpClientConPreCheck(dev, clientCon, 16);
         out_uint16_le(clientCon->out_s, 4); /* screen blt */
         out_uint16_le(clientCon->out_s, 16); /* size */
@@ -2512,7 +2555,8 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         shmsize = width * height * Bpp + width * height / 8;
         if (g_alloc_shm_map_fd(&addr, &fd, shmsize) != 0)
         {
-            LOG(LOG_LEVEL_INFO, "rdpClientConSetCursorShmFd: rdpGetShmFd failed");
+            LOG(LOG_LEVEL_INFO,
+                "rdpClientConSetCursorShmFd: rdpGetShmFd failed");
             return 0;
         }
         shmemptr = (uint8_t *)addr;
@@ -2534,7 +2578,8 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         memcpy(shmemptr + width * height * Bpp, cur_mask, width * height / 8);
         rdpClientConSendPending(clientCon->dev, clientCon);
         rv = g_sck_send_fd_set(clientCon->sck, "int", 4, &fd, 1);
-        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv);
         g_free_unmap_fd(shmemptr, fd, shmsize);
     }
     return rv;
@@ -2549,7 +2594,8 @@ rdpClientConCreateOsSurface(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurface: width %d height %d", width, height);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpClientConCreateOsSurface: width %d height %d", width, height);
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 20);
         out_uint16_le(clientCon->out_s, 12);
@@ -2570,8 +2616,9 @@ rdpClientConCreateOsSurfaceBpp(rdpPtr dev, rdpClientCon *clientCon,
     LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurfaceBpp:");
     if (clientCon->connected)
     {
-        LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurfaceBpp: width %d height %d "
-               "bpp %d", width, height, bpp);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpClientConCreateOsSurfaceBpp: width %d height %d "
+            "bpp %d", width, height, bpp);
         rdpClientConPreCheck(dev, clientCon, 13);
         out_uint16_le(clientCon->out_s, 31);
         out_uint16_le(clientCon->out_s, 13);
@@ -2598,7 +2645,8 @@ rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         }
 
         clientCon->rdpIndex = rdpindex;
-        LOG(LOG_LEVEL_TRACE, "rdpClientConSwitchOsSurface: rdpindex %d", rdpindex);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpClientConSwitchOsSurface: rdpindex %d", rdpindex);
         /* switch surface */
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 21);
@@ -2657,9 +2705,10 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     this_bytes = pixmap->devKind * pixmap->drawable.height;
     if (this_bytes > MAX_OS_BYTES)
     {
-        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: error, too big this_bytes %d "
-               "width %d height %d", this_bytes,
-               pixmap->drawable.height, pixmap->drawable.height);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpClientConAddOsBitmap: error, too big this_bytes %d "
+            "width %d height %d", this_bytes,
+            pixmap->drawable.height, pixmap->drawable.height);
         return -1;
     }
 
@@ -2700,8 +2749,9 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
         }
         else
         {
-            LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: too many pixmaps removing "
-                   "oldest_index %d", oldest_index);
+            LOG(LOG_LEVEL_TRACE,
+                "rdpClientConAddOsBitmap: too many pixmaps removing "
+                "oldest_index %d", oldest_index);
             rdpClientConRemoveOsBitmap(dev, clientCon, oldest_index);
             rdpClientConDeleteOsSurface(dev, clientCon, oldest_index);
             clientCon->osBitmaps[oldest_index].used = TRUE;
@@ -2722,14 +2772,14 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
 
     clientCon->osBitmapAllocSize += this_bytes;
     LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: this_bytes %d "
-           "clientCon->osBitmapAllocSize %d",
-           this_bytes, clientCon->osBitmapAllocSize);
+        "clientCon->osBitmapAllocSize %d",
+        this_bytes, clientCon->osBitmapAllocSize);
 #if USE_MAX_OS_BYTES
     while (clientCon->osBitmapAllocSize > MAX_OS_BYTES)
     {
         LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: must delete "
-               "clientCon->osBitmapNumUsed %d",
-               clientCon->osBitmapNumUsed);
+            "clientCon->osBitmapNumUsed %d",
+            clientCon->osBitmapNumUsed);
         /* find oldest */
         oldest = INT_MAX;
         oldest_index = -1;
@@ -2759,9 +2809,10 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     }
 #endif
     LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: new bitmap index %d", rv);
-    LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
-           "clientCon->osBitmapStamp 0x%8.8x",
-           clientCon->osBitmapNumUsed, clientCon->osBitmapStamp);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
+        "clientCon->osBitmapStamp 0x%8.8x",
+        clientCon->osBitmapNumUsed, clientCon->osBitmapStamp);
     return rv;
 }
 
@@ -2780,7 +2831,7 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
 
     LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp);
+        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
     {
@@ -2796,8 +2847,8 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         this_bytes = pixmap->devKind * pixmap->drawable.height;
         clientCon->osBitmapAllocSize -= this_bytes;
         LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: this_bytes %d "
-               "clientCon->osBitmapAllocSize %d", this_bytes,
-               clientCon->osBitmapAllocSize);
+            "clientCon->osBitmapAllocSize %d", this_bytes,
+            clientCon->osBitmapAllocSize);
         clientCon->osBitmaps[rdpindex].used = 0;
         clientCon->osBitmaps[rdpindex].pixmap = 0;
         clientCon->osBitmaps[rdpindex].priv = 0;
@@ -2812,7 +2863,7 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
 
     LOG(LOG_LEVEL_TRACE, "rdpup_remove_os_bitmap: clientCon->osBitmapNumUsed %d",
-           clientCon->osBitmapNumUsed);
+        clientCon->osBitmapNumUsed);
     return 0;
 }
 
@@ -2826,7 +2877,7 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
 
     LOG(LOG_LEVEL_TRACE, "rdpClientConUpdateOsUse: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp);
+        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
     {
@@ -2840,7 +2891,8 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
     else
     {
-        LOG(LOG_LEVEL_INFO, "rdpClientConUpdateOsUse: error rdpindex %d", rdpindex);
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConUpdateOsUse: error rdpindex %d", rdpindex);
     }
 
     return 0;
@@ -2918,8 +2970,9 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LOG(LOG_LEVEL_TRACE, "out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
-               index, x, y, cx, cy);
+        LOG(LOG_LEVEL_TRACE,
+            "out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
+            index, x, y, cx, cy);
     }
     out_uint16_le(s, num_rects_c);
     for (index = 0; index < num_rects_c; index++)
@@ -2933,8 +2986,9 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LOG(LOG_LEVEL_TRACE, "out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
-               index, x, y, cx, cy);
+        LOG(LOG_LEVEL_TRACE,
+            "out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
+            index, x, y, cx, cy);
     }
     return 0;
 }
@@ -2958,17 +3012,18 @@ rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
     int surface_id;
 
     LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd:");
-    LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
-           "cap_width %d cap_height %d",
-           clientCon->cap_left, clientCon->cap_top,
-           clientCon->cap_width, clientCon->cap_height);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
+        "cap_width %d cap_height %d",
+        clientCon->cap_left, clientCon->cap_top,
+        clientCon->cap_width, clientCon->cap_height);
     LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
-           "id->left %d id->top %d id->width %d id->height %d",
-           id->flags, id->left, id->top, id->width, id->height);
+        "id->left %d id->top %d id->width %d id->height %d",
+        id->flags, id->left, id->top, id->width, id->height);
 
     capture_code = clientCon->client_info.capture_code;
     LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: capture_code %d",
-           capture_code);
+        capture_code);
 
     num_rects_d = REGION_NUM_RECTS(dirtyReg);
     num_rects_c = numCopyRects;
@@ -3183,7 +3238,7 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
 
     cap_dirty = rdpRegionCreate(cap_rect, 0);
     LOG(LOG_LEVEL_TRACE, "rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
-               cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2);
+        cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2);
     rdpRegionIntersect(cap_dirty, cap_dirty, clientCon->dirtyRegion);
     num_rects = REGION_NUM_RECTS(cap_dirty);
     if (num_rects > MAX_CAPTURE_RECTS)
@@ -3203,7 +3258,7 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
         rects = 0;
         num_rects = 0;
         LOG(LOG_LEVEL_TRACE, "rdpCapRect: capture_code %d",
-                    clientCon->client_info.capture_code);
+            clientCon->client_info.capture_code);
         if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, id))
         {
             LOG(LOG_LEVEL_TRACE, "rdpCapRect: num_rects %d", num_rects);
@@ -3248,10 +3303,11 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
         return 0;
     }
     if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
-        LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: clientCon->shmemstatus "
-               "is not valid for capture operations: %d"
-               " reschedule rect_id %d rect_id_ack %d",
-               clientCon->shmemstatus, clientCon->rect_id, clientCon->rect_id_ack);
+        LOG(LOG_LEVEL_TRACE,
+            "rdpDeferredUpdateCallback: clientCon->shmemstatus "
+            "is not valid for capture operations: %d"
+            " reschedule rect_id %d rect_id_ack %d",
+            clientCon->shmemstatus, clientCon->rect_id, clientCon->rect_id_ack);
         return 0;
     }
     if ((clientCon->rect_id > clientCon->rect_id_ack) ||
@@ -3285,9 +3341,10 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             // Did we get anything from the last monitor?
             if (clientCon->rect_id > clientCon->rect_id_ack)
             {
-                LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: reschedule rect_id %d "
-                       "rect_id_ack %d",
-                       clientCon->rect_id, clientCon->rect_id_ack);
+                LOG(LOG_LEVEL_TRACE,
+                    "rdpDeferredUpdateCallback: reschedule rect_id %d "
+                    "rect_id_ack %d",
+                    clientCon->rect_id, clientCon->rect_id_ack);
                 break;
             }
             // Offset the monitor index by the rectangle ID so we start

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -176,14 +176,14 @@ rdpAddClientConToDev(rdpPtr dev, rdpClientCon *clientCon)
 
     if (dev->clientConTail == NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpAddClientConToDev: adding first clientCon %p",
-                   clientCon));
+        LOG(LOG_LEVEL_INFO, "rdpAddClientConToDev: adding first clientCon %p",
+                   clientCon);
         dev->clientConHead = clientCon;
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpAddClientConToDev: adding clientCon %p",
-                   clientCon));
+        LOG(LOG_LEVEL_INFO, "rdpAddClientConToDev: adding clientCon %p",
+                   clientCon);
         dev->clientConTail->next = clientCon;
     }
     dev->clientConTail = clientCon;
@@ -193,8 +193,8 @@ rdpAddClientConToDev(rdpPtr dev, rdpClientCon *clientCon)
 static void
 rdpRemoveClientConFromDev(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRemoveClientConFromDev: removing clientCon %p",
-               clientCon));
+    LOG(LOG_LEVEL_INFO, "rdpRemoveClientConFromDev: removing clientCon %p",
+               clientCon);
 
     if (clientCon->prev == NULL)
     {
@@ -224,7 +224,7 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     rdpClientCon *clientCon;
     int new_sck;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotConnection:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConGotConnection:");
     clientCon = g_new0(rdpClientCon, 1);
     clientCon->shmemstatus = SHM_UNINITIALIZED;
     clientCon->updateRetries = 0;
@@ -241,12 +241,12 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     new_sck = g_sck_accept(dev->listen_sck);
     if (new_sck == -1)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: g_sck_accept failed"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: g_sck_accept failed");
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: g_sck_accept ok new_sck %d",
-               new_sck));
+        LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: g_sck_accept ok new_sck %d",
+               new_sck);
         clientCon->sck = new_sck;
         g_sck_set_non_blocking(clientCon->sck);
         g_sck_tcp_set_no_delay(clientCon->sck); /* only works if TCP */
@@ -261,9 +261,9 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     if (dev->clientConTail != NULL)
     {
         /* Only allow one client at a time */
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
+        LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
                    "marking only clientCon %p for disconnect",
-                   dev->clientConTail));
+                   dev->clientConTail);
         dev->clientConTail->connected = FALSE;
     }
 #endif
@@ -271,15 +271,15 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
     /* set idle timer to disconnect */
     if (dev->idle_disconnect_timeout_s > 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
-                   "engaging idle timer, timeout [%d] sec", dev->idle_disconnect_timeout_s));
+        LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
+                   "engaging idle timer, timeout [%d] sec", dev->idle_disconnect_timeout_s);
         dev->idleDisconnectTimer = TimerSet(dev->idleDisconnectTimer, 0, dev->idle_disconnect_timeout_s * 1000,
                                             rdpDeferredIdleDisconnectCallback, dev);
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConGotConnection: "
-                   "idle_disconnect_timeout set to non-positive value, idle timer turned off"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConGotConnection: "
+                   "idle_disconnect_timeout set to non-positive value, idle timer turned off");
     }
 
     rdpAddClientConToDev(dev, clientCon);
@@ -297,14 +297,14 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
 
     dev = (rdpPtr) arg;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredDisconnectCallback"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredDisconnectCallback");
     if (dev->clientConHead != NULL)
     {
         /* this should not happen */
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: connected"));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: connected");
         if (dev->disconnectTimer != NULL)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: disengaging disconnect timer"));
+            LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: disengaging disconnect timer");
             TimerCancel(dev->disconnectTimer);
             TimerFree(dev->disconnectTimer);
             dev->disconnectTimer = NULL;
@@ -314,12 +314,12 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     }
     else
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredDisconnectCallback: not connected"));
+        LOG(LOG_LEVEL_TRACE, "rdpDeferredDisconnectCallback: not connected");
     }
     if (now - dev->disconnect_time_ms > dev->disconnect_timeout_s * 1000)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredDisconnectCallback: "
-                   "disconnect timeout exceeded, exiting"));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredDisconnectCallback: "
+                   "disconnect timeout exceeded, exiting");
         kill(getpid(), SIGTERM);
         return 0;
     }
@@ -332,7 +332,7 @@ rdpDeferredDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
 static CARD32
 rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredIdleDisconnectCallback:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredIdleDisconnectCallback:");
 
     rdpPtr dev;
 
@@ -346,8 +346,8 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     /* we MUST compare to equal otherwise we could restart the idle timer with 0! */
     if (millis_since_last_event >= (dev->idle_disconnect_timeout_s * 1000))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: session has been idle for %d seconds, disconnecting",
-                    dev->idle_disconnect_timeout_s));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: session has been idle for %d seconds, disconnecting",
+                    dev->idle_disconnect_timeout_s);
 
         /* disconnect all clients */
         while (dev->clientConHead != NULL)
@@ -355,12 +355,12 @@ rdpDeferredIdleDisconnectCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             rdpClientConDisconnect(dev, dev->clientConHead);
         }
 
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: disconnected idle session"));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: disconnected idle session");
 
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredIdleDisconnectCallback: idle timer disengaged"));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredIdleDisconnectCallback: idle timer disengaged");
         return 0;
     }
 
@@ -378,7 +378,7 @@ rdpShutdownAccelAssist(rdpPtr dev, rdpClientCon *clientCon) {
     int index;
     int exit_code = 0;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpShutdownAccelAssist:"));
+    LOG(LOG_LEVEL_TRACE, "rdpShutdownAccelAssist:");
     if (clientCon->accel_assist_pid <= 0)
     {
         return 0;
@@ -432,11 +432,11 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
 {
     int index;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDisconnect:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConDisconnect:");
 
     if (dev->idleDisconnectTimer != NULL && dev->idle_disconnect_timeout_s > 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDisconnect: disconnected, idle timer disengaged"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: disconnected, idle timer disengaged");
         TimerCancel(dev->idleDisconnectTimer);
         TimerFree(dev->idleDisconnectTimer);
         dev->idleDisconnectTimer = NULL;
@@ -446,8 +446,8 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
     {
         if (dev->disconnect_scheduled == FALSE)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDisconnect: engaging disconnect timer, "
-                       "exit after %d seconds", dev->disconnect_timeout_s));
+            LOG(LOG_LEVEL_INFO, "rdpClientConDisconnect: engaging disconnect timer, "
+                       "exit after %d seconds", dev->disconnect_timeout_s);
             dev->disconnectTimer = TimerSet(dev->disconnectTimer, 0, 1000 * 10,
                                             rdpDeferredDisconnectCallback, dev);
             dev->disconnect_scheduled = TRUE;
@@ -505,7 +505,7 @@ rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
     int sent;
     int retries = 0;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSend - sending %d bytes", len));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSend - sending %d bytes", len);
 
     if (!clientCon->connected)
     {
@@ -531,14 +531,14 @@ rdpClientConSend(rdpPtr dev, rdpClientCon *clientCon, const char *data, int len)
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSend: g_tcp_send failed(returned -1)"));
+                LOG(LOG_LEVEL_INFO, "rdpClientConSend: g_tcp_send failed(returned -1)");
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (sent == 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSend: g_tcp_send failed(returned zero)"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConSend: g_tcp_send failed(returned zero)");
             clientCon->connected = FALSE;
             return 1;
         }
@@ -568,9 +568,9 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
 
         if (len > s->size)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendMsg: overrun error len, %d "
+            LOG(LOG_LEVEL_INFO, "rdpClientConSendMsg: overrun error len, %d "
                        "stream size %d, client count %d",
-                       len, s->size, clientCon->count));
+                       len, s->size, clientCon->count);
         }
 
         s_pop_layer(s, iso_hdr);
@@ -582,7 +582,7 @@ rdpClientConSendMsg(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendMsg: error in rdpup_send_msg"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConSendMsg: error in rdpup_send_msg");
     }
 
     return rv;
@@ -603,7 +603,7 @@ rdpClientConSendPending(rdpPtr dev, rdpClientCon *clientCon)
         s_mark_end(clientCon->out_s);
         if (rdpClientConSendMsg(dev, clientCon) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendPending: rdpClientConSendMsg failed"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConSendPending: rdpClientConSendMsg failed");
             rv = 1;
         }
     }
@@ -636,14 +636,14 @@ rdpClientConRecv(rdpPtr dev, rdpClientCon *clientCon, char *data, int len)
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecv: g_sck_recv failed(returned -1)"));
+                LOG(LOG_LEVEL_INFO, "rdpClientConRecv: g_sck_recv failed(returned -1)");
                 clientCon->connected = FALSE;
                 return 1;
             }
         }
         else if (rcvd == 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecv: g_sck_recv failed(returned 0)"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConRecv: g_sck_recv failed(returned 0)");
             clientCon->connected = FALSE;
             return 1;
         }
@@ -692,7 +692,7 @@ rdpClientConRecvMsg(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConRecvMsg: error"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConRecvMsg: error");
     }
 
     return rv;
@@ -739,7 +739,7 @@ rdpClientConSendCaps(rdpPtr dev, rdpClientCon *clientCon)
 
     if (rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSendCaps: rdpup_send failed"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConSendCaps: rdpup_send failed");
     }
 
     free_stream(ls);
@@ -751,8 +751,8 @@ static int
 rdpClientConProcessMsgVersion(rdpPtr dev, rdpClientCon *clientCon,
                               int param1, int param2, int param3, int param4)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgVersion: version %d %d %d %d",
-           param1, param2, param3, param4));
+    LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgVersion: version %d %d %d %d",
+           param1, param2, param3, param4);
 
     if ((param1 > 0) || (param2 > 0) || (param3 > 0) || (param4 > 0))
     {
@@ -779,8 +779,8 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
 
     if (clientCon->shmemptr != NULL && clientCon->shmem_bytes == bytes)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: reusing shmemfd %d",
-               clientCon->shmemfd));
+        LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: reusing shmemfd %d",
+               clientCon->shmemfd);
         return;
     }
     if (clientCon->shmemptr != NULL)
@@ -794,16 +794,16 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
     }
     if (g_alloc_shm_map_fd(&shmemptr, &shmemfd, bytes) != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
-               "failed"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
+               "failed");
     }
     clientCon->shmemptr = shmemptr;
     clientCon->shmemfd = shmemfd;
     clientCon->shmem_bytes = bytes;
-    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
+    LOG(LOG_LEVEL_INFO, "rdpClientConAllocateSharedMemory: shmemfd %d shmemptr %p "
             "bytes %d",
             clientCon->shmemfd, clientCon->shmemptr,
-            clientCon->shmem_bytes));
+            clientCon->shmem_bytes);
 }
 
 /******************************************************************************/
@@ -845,7 +845,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
 
     enum shared_memory_status shmemstatus;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConResizeAllMemoryAreas:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConResizeAllMemoryAreas:");
 
     // Updare the rdp size from the client size
     clientCon->rdp_width = width;
@@ -856,12 +856,12 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
     {
         case CC_SUF_RFX: /* RFX */
         case CC_GFX_PRO:
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got RFX capture"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got RFX capture");
             /* RFX capture needs fixed-size rectangles */
             clientCon->cap_width = RDPALIGN(width, XRDP_RFX_ALIGN);
             clientCon->cap_height = RDPALIGN(height, XRDP_RFX_ALIGN);
-            LLOGLN(LOG_LEVEL_INFO, ("  cap_width %d cap_height %d",
-                   clientCon->cap_width, clientCon->cap_height));
+            LOG(LOG_LEVEL_INFO, "  cap_width %d cap_height %d",
+                   clientCon->cap_width, clientCon->cap_height);
 
             bytes = clientCon->cap_width * clientCon->cap_height *
                     clientCon->rdp_Bpp;
@@ -874,7 +874,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
         case CC_SUF_A2: /* H264 */
         case CC_GFX_A2:
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got H264 capture"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got H264 capture");
             clientCon->cap_width = width;
             clientCon->cap_height = height;
 
@@ -887,7 +887,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             dev->msFrameInterval = clientCon->client_info.h264_frame_interval;
             break;
         default:
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInfo: got normal capture"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInfo: got normal capture");
             clientCon->cap_width = width;
             clientCon->cap_width = width;
             clientCon->cap_height = height;
@@ -902,7 +902,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
     }
 
-    LLOGLN(LOG_LEVEL_INFO, ("    msFrameInterval %ld", (long)dev->msFrameInterval));
+    LOG(LOG_LEVEL_INFO, "    msFrameInterval %ld", (long)dev->msFrameInterval);
     rdpClientConAllocateSharedMemory(clientCon, bytes);
 
     if (clientCon->client_info.capture_format != 0)
@@ -961,7 +961,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
         dev->allow_screen_resize = 1;
         ok = RRScreenSizeSet(dev->pScreen, width, height, mmwidth, mmheight);
         dev->allow_screen_resize = 0;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok));
+        LOG(LOG_LEVEL_INFO, "rdpClientConResizeAllMemoryAreas: RRScreenSizeSet ok=[%d]", ok);
     }
 
     rdpCaptureResetState(clientCon);
@@ -981,8 +981,8 @@ rdpClientConProcessMonitorUpdateMsg(rdpPtr dev, rdpClientCon *clientCon,
                                     struct monitor_info monitors[])
 {
     int i;
-    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMonitorUpdateMsg: (%dx%d) #%d",
-           width, height, num_monitors));
+    LOG(LOG_LEVEL_INFO, "rdpClientConProcessMonitorUpdateMsg: (%dx%d) #%d",
+           width, height, num_monitors);
 
     // Update the client_info we have
     clientCon->client_info.display_sizes.monitorCount = num_monitors;
@@ -1031,8 +1031,8 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, param3);
     in_uint32_le(s, param4);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
-           "param3 %d param4 %d", msg, param1, param2, param3, param4));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientInput: msg %d param1 %d param2 %d "
+           "param3 %d param4 %d", msg, param1, param2, param3, param4);
 
     if (msg < 100)
     {
@@ -1048,13 +1048,13 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         y = param1 & 0xffff;
         cx = (param2 >> 16) & 0xffff;
         cy = param2 & 0xffff;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: invalidate x %d y %d "
-               "cx %d cy %d", x, y, cx, cy));
+        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: invalidate x %d y %d "
+               "cx %d cy %d", x, y, cx, cy);
         rdpClientConAddDirtyScreen(dev, clientCon, x, y, cx, cy);
     }
     else if (msg == 300) /* resize desktop */
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: obsolete msg %d", msg));
+        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: obsolete msg %d", msg);
     }
     else if (msg == 301) /* version */
     {
@@ -1074,12 +1074,12 @@ rdpClientConProcessMsgClientInput(rdpPtr dev, rdpClientCon *clientCon)
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: bad monitor count %d", param3));
+            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: bad monitor count %d", param3);
         }
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsgClientInput: unknown msg %d", msg));
+        LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsgClientInput: unknown msg %d", msg);
     }
 
     return 0;
@@ -1142,8 +1142,8 @@ rdpStartAccelAssist(rdpPtr dev, rdpClientCon *clientCon)
     else
     {
         /* parent */
-        LLOGLN(LOG_LEVEL_INFO, ("rdpStartAccelAssist: started accel assist pid %d",
-               clientCon->accel_assist_pid));
+        LOG(LOG_LEVEL_INFO, "rdpStartAccelAssist: started accel assist pid %d",
+               clientCon->accel_assist_pid);
         rdpClientConRemoveEnabledDevice(clientCon->sck);
         close(clientCon->sck);
         close(spair[0]);
@@ -1165,8 +1165,8 @@ rdpSendAccelAssistMonitors(rdpPtr dev, rdpClientCon *clientCon)
     int height;
     const int layer_size = 8;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpSendAccelAssistMonitors: monitorCount %d",
-           dev->monitorCount));
+    LOG(LOG_LEVEL_INFO, "rdpSendAccelAssistMonitors: monitorCount %d",
+           dev->monitorCount);
     rdpClientConSendPending(dev, clientCon);
     init_stream(clientCon->out_s, 0);
     s_push_layer(clientCon->out_s, iso_hdr, layer_size);
@@ -1276,8 +1276,8 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
     BoxRec box;
     if (clientCon->client_info.display_sizes.monitorCount > 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can do multimon"));
-        LLOGLN(LOG_LEVEL_INFO, ("  client monitor data, monitorCount=%d", clientCon->client_info.display_sizes.monitorCount));
+        LOG(LOG_LEVEL_INFO, "  client can do multimon");
+        LOG(LOG_LEVEL_INFO, "  client monitor data, monitorCount=%d", clientCon->client_info.display_sizes.monitorCount);
         clientCon->doMultimon = 1;
         dev->doMultimon = 1;
         memcpy(dev->minfo, clientCon->client_info.display_sizes.minfo, sizeof(dev->minfo));
@@ -1301,16 +1301,16 @@ rdpClientConProcessClientInfoMonitors(rdpPtr dev, rdpClientCon *clientCon)
             dev->minfo[index].top -= box.y1;
             dev->minfo[index].right -= box.x1;
             dev->minfo[index].bottom -= box.y1;
-            LLOGLN(LOG_LEVEL_INFO, ("    left %d top %d right %d bottom %d",
+            LOG(LOG_LEVEL_INFO, "    left %d top %d right %d bottom %d",
                    dev->minfo[index].left,
                    dev->minfo[index].top,
                    dev->minfo[index].right,
-                   dev->minfo[index].bottom));
+                   dev->minfo[index].bottom);
         }
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can not do multimon"));
+        LOG(LOG_LEVEL_INFO, "  client can not do multimon");
         clientCon->doMultimon = 0;
         dev->doMultimon = 0;
         dev->monitorCount = 0;
@@ -1350,7 +1350,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     int bytes;
     int i1;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientInfo:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientInfo:");
     s = clientCon->in_s;
     in_uint32_le(s, bytes);
     if (bytes > sizeof(clientCon->client_info))
@@ -1364,20 +1364,20 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     // before sending client info.
     if (clientCon->client_info.version != XUP_CLIENT_INFO_CURRENT_VERSION)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("expected xrdp client_info version %d, got %d",
+        LOG(LOG_LEVEL_INFO, "expected xrdp client_info version %d, got %d",
                    XUP_CLIENT_INFO_CURRENT_VERSION,
-                   clientCon->client_info.version));
+                   clientCon->client_info.version);
         FatalError("Incompatible xrdp version detected  - please recompile");
     }
 
-    LLOGLN(LOG_LEVEL_INFO, ("  got client info bytes %d", bytes));
-    LLOGLN(LOG_LEVEL_INFO, ("  jpeg support %d", clientCon->client_info.jpeg));
+    LOG(LOG_LEVEL_INFO, "  got client info bytes %d", bytes);
+    LOG(LOG_LEVEL_INFO, "  jpeg support %d", clientCon->client_info.jpeg);
     i1 = clientCon->client_info.offscreen_support_level;
-    LLOGLN(LOG_LEVEL_INFO, ("  offscreen support %d", i1));
+    LOG(LOG_LEVEL_INFO, "  offscreen support %d", i1);
     i1 = clientCon->client_info.offscreen_cache_size;
-    LLOGLN(LOG_LEVEL_INFO, ("  offscreen size %d", i1));
+    LOG(LOG_LEVEL_INFO, "  offscreen size %d", i1);
     i1 = clientCon->client_info.offscreen_cache_entries;
-    LLOGLN(LOG_LEVEL_INFO, ("  offscreen entries %d", i1));
+    LOG(LOG_LEVEL_INFO, "  offscreen entries %d", i1);
 
     /* Monitor info */
     int bpp = clientCon->client_info.bpp;
@@ -1418,7 +1418,7 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
 
     if (clientCon->client_info.orders[0x1b])   /* 27 NEG_GLYPH_INDEX_INDEX */
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client supports glyph cache but server disabled"));
+        LOG(LOG_LEVEL_INFO, "  client supports glyph cache but server disabled");
         //clientCon->doGlyphCache = 1;
     }
     if (clientCon->client_info.order_flags_ex & 0x100)
@@ -1427,30 +1427,30 @@ rdpClientConProcessMsgClientInfo(rdpPtr dev, rdpClientCon *clientCon)
     }
     if (clientCon->doGlyphCache)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  using glyph cache"));
+        LOG(LOG_LEVEL_INFO, "  using glyph cache");
     }
     if (clientCon->doComposite)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  using client composite"));
+        LOG(LOG_LEVEL_INFO, "  using client composite");
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("order_flags_ex 0x%x", clientCon->client_info.order_flags_ex));
+    LOG(LOG_LEVEL_TRACE, "order_flags_ex 0x%x", clientCon->client_info.order_flags_ex);
     if (clientCon->client_info.offscreen_cache_entries == 2000)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can do offscreen to offscreen blits"));
+        LOG(LOG_LEVEL_INFO, "  client can do offscreen to offscreen blits");
         clientCon->canDoPixToPix = 1;
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can not do offscreen to offscreen blits"));
+        LOG(LOG_LEVEL_INFO, "  client can not do offscreen to offscreen blits");
         clientCon->canDoPixToPix = 0;
     }
     if (clientCon->client_info.pointer_flags & 1)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can do new(color) cursor"));
+        LOG(LOG_LEVEL_INFO, "  client can do new(color) cursor");
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  client can not do new(color) cursor"));
+        LOG(LOG_LEVEL_INFO, "  client can not do new(color) cursor");
     }
 
     /* rdpLoadLayout */
@@ -1485,7 +1485,7 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     RegionRec reg;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion:");
     s = clientCon->in_s;
 
     in_uint32_le(s, flags);
@@ -1494,10 +1494,10 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, y);
     in_uint32_le(s, cx);
     in_uint32_le(s, cy);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
-           x, y, cx, cy, flags));
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
-           clientCon->rect_id, clientCon->rect_id_ack));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: %d %d %d %d flags 0x%8.8x",
+           x, y, cx, cy, flags);
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: rect_id %d rect_id_ack %d",
+           clientCon->rect_id, clientCon->rect_id_ack);
 
     box.x1 = x;
     box.y1 = y;
@@ -1505,8 +1505,8 @@ rdpClientConProcessMsgClientRegion(rdpPtr dev, rdpClientCon *clientCon)
     box.y2 = box.y1 + cy;
 
     rdpRegionInit(&reg, &box, 0);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegion: %d %d %d %d",
-           box.x1, box.y1, box.x2, box.y2));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegion: %d %d %d %d",
+           box.x1, box.y1, box.x2, box.y2);
     rdpRegionSubtract(clientCon->shmRegion, clientCon->shmRegion, &reg);
     rdpRegionUninit(&reg);
     rdpScheduleDeferredUpdate(clientCon);
@@ -1520,7 +1520,7 @@ rdpClientConProcessMsgClientRegionEx(rdpPtr dev, rdpClientCon *clientCon)
     struct stream *s;
     int flags;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegionEx:");
     s = clientCon->in_s;
 
     in_uint32_le(s, flags);
@@ -1530,9 +1530,9 @@ rdpClientConProcessMsgClientRegionEx(rdpPtr dev, rdpClientCon *clientCon)
         // Client just wishes to ack all in-flight frames
         clientCon->rect_id_ack = clientCon->rect_id;
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags));
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientRegionEx: rect_id %d "
-           "rect_id_ack %d", clientCon->rect_id, clientCon->rect_id_ack));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegionEx: flags 0x%8.8x", flags);
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientRegionEx: rect_id %d "
+           "rect_id_ack %d", clientCon->rect_id, clientCon->rect_id_ack);
     rdpScheduleDeferredUpdate(clientCon);
     return 0;
 }
@@ -1554,9 +1554,9 @@ rdpClientConProcessMsgClientSuppressOutput(rdpPtr dev, rdpClientCon *clientCon)
     in_uint32_le(s, top);
     in_uint32_le(s, right);
     in_uint32_le(s, bottom);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsgClientSuppressOutput: "
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsgClientSuppressOutput: "
            "suppress %d left %d top %d right %d bottom %d",
-           suppress, left, top, right, bottom));
+           suppress, left, top, right, bottom);
     clientCon->suppress_output = suppress;
     if (suppress == 0)
     {
@@ -1573,10 +1573,10 @@ rdpClientConProcessMsg(rdpPtr dev, rdpClientCon *clientCon)
     int msg_type;
     struct stream *s;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsg:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsg:");
     s = clientCon->in_s;
     in_uint16_le(s, msg_type);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConProcessMsg: msg_type %d", msg_type));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConProcessMsg: msg_type %d", msg_type);
     switch (msg_type)
     {
         case 103: /* client input */
@@ -1595,8 +1595,8 @@ rdpClientConProcessMsg(rdpPtr dev, rdpClientCon *clientCon)
             rdpClientConProcessMsgClientSuppressOutput(dev, clientCon);
             break;
         default:
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConProcessMsg: unknown msg_type %d",
-                   msg_type));
+            LOG(LOG_LEVEL_INFO, "rdpClientConProcessMsg: unknown msg_type %d",
+                   msg_type);
             break;
     }
 
@@ -1609,7 +1609,7 @@ rdpClientConGotData(ScreenPtr pScreen, rdpPtr dev, rdpClientCon *clientCon)
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotData:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConGotData:");
 
     rv = rdpClientConRecvMsg(dev, clientCon);
     if (rv == 0)
@@ -1625,7 +1625,7 @@ static int
 rdpClientConGotControlConnection(ScreenPtr pScreen, rdpPtr dev,
                                  rdpClientCon *clientCon)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotControlConnection:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConGotControlConnection:");
     return 0;
 }
 
@@ -1634,7 +1634,7 @@ static int
 rdpClientConGotControlData(ScreenPtr pScreen, rdpPtr dev,
                            rdpClientCon *clientCon)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConGotControlData:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConGotControlData:");
     return 0;
 }
 
@@ -1652,7 +1652,7 @@ rdpClientConCheck(ScreenPtr pScreen)
     int count;
     char buf[8];
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCheck:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConCheck:");
     dev = rdpGetDevFromScreen(pScreen);
     time.tv_sec = 0;
     time.tv_usec = 0;
@@ -1715,7 +1715,7 @@ rdpClientConCheck(ScreenPtr pScreen)
     }
     if (sel < 1)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCheck: no select"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConCheck: no select");
         return 0;
     }
 
@@ -1734,7 +1734,7 @@ rdpClientConCheck(ScreenPtr pScreen)
 
             if (g_sck_recv(dev->disconnect_sck, buf, sizeof(buf), 0))
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: got disconnection request"));
+                LOG(LOG_LEVEL_INFO, "rdpClientConCheck: got disconnection request");
 
                 /* disconnect all clients */
                 while (dev->clientConHead != NULL)
@@ -1755,7 +1755,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotData(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotData failed"));
+                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotData failed");
                     continue; /* skip other socket checks for this clientCon */
                 }
             }
@@ -1766,7 +1766,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlConnection(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotControlConnection failed"));
+                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotControlConnection failed");
                     continue;
                 }
             }
@@ -1777,7 +1777,7 @@ rdpClientConCheck(ScreenPtr pScreen)
             {
                 if (rdpClientConGotControlData(pScreen, dev, clientCon) != 0)
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConCheck: rdpClientConGotControlData failed"));
+                    LOG(LOG_LEVEL_INFO, "rdpClientConCheck: rdpClientConGotControlData failed");
                     continue;
                 }
             }
@@ -1840,7 +1840,7 @@ rdpClientConInit(rdpPtr dev)
         {
             if (!g_directory_exist(socket_dir))
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_create_dir(%s) failed", socket_dir));
+                LOG(LOG_LEVEL_INFO, "rdpClientConInit: g_create_dir(%s) failed", socket_dir);
                 return 0;
             }
         }
@@ -1874,7 +1874,7 @@ rdpClientConInit(rdpPtr dev)
         dev->listen_sck = g_sck_local_socket_stream();
         if (g_sck_local_bind(dev->listen_sck, dev->uds_data) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_tcp_local_bind failed"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConInit: g_tcp_local_bind failed");
             return 1;
         }
         g_sck_listen(dev->listen_sck);
@@ -1892,7 +1892,7 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_sck = g_sck_local_socket_dgram();
         if (g_sck_local_bind(dev->disconnect_sck, dev->disconnect_uds) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: g_tcp_local_bind failed at %s:%d", __FILE__, __LINE__));
+            LOG(LOG_LEVEL_INFO, "rdpClientConInit: g_tcp_local_bind failed at %s:%d", __FILE__, __LINE__);
             return 1;
         }
         g_sck_listen(dev->disconnect_sck);
@@ -1911,8 +1911,8 @@ rdpClientConInit(rdpPtr dev)
         }
 
     }
-    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: disconnect idle session after [%d] sec",
-               dev->idle_disconnect_timeout_s));
+    LOG(LOG_LEVEL_INFO, "rdpClientConInit: disconnect idle session after [%d] sec",
+               dev->idle_disconnect_timeout_s);
 
     /* kill disconnected */
     ptext = getenv("XRDP_SESMAN_MAX_DISC_TIME");
@@ -1943,8 +1943,8 @@ rdpClientConInit(rdpPtr dev)
         dev->disconnect_timeout_s = 60;
     }
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
-               dev->do_kill_disconnected, dev->disconnect_timeout_s));
+    LOG(LOG_LEVEL_INFO, "rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
+               dev->do_kill_disconnected, dev->disconnect_timeout_s);
 
 
     return 0;
@@ -1954,11 +1954,11 @@ rdpClientConInit(rdpPtr dev)
 int
 rdpClientConDeinit(rdpPtr dev)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeinit:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConDeinit:");
 
     while (dev->clientConTail != NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: disconnecting clientCon"));
+        LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: disconnecting clientCon");
         rdpClientConDisconnect(dev, dev->clientConTail);
     }
 
@@ -1966,11 +1966,11 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->listen_sck);
         g_sck_close(dev->listen_sck);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: deleting file %s", dev->uds_data));
+        LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: deleting file %s", dev->uds_data);
         if (unlink(dev->uds_data) < 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: failed to delete %s (%s)",
-                        dev->uds_data, strerror(errno)));
+            LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: failed to delete %s (%s)",
+                        dev->uds_data, strerror(errno));
         }
     }
 
@@ -1978,11 +1978,11 @@ rdpClientConDeinit(rdpPtr dev)
     {
         rdpClientConRemoveEnabledDevice(dev->disconnect_sck);
         g_sck_close(dev->disconnect_sck);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: deleting file %s", dev->disconnect_uds));
+        LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: deleting file %s", dev->disconnect_uds);
         if (unlink(dev->disconnect_uds) < 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConDeinit: failed to delete %s (%s)",
-                        dev->disconnect_uds, strerror(errno)));
+            LOG(LOG_LEVEL_INFO, "rdpClientConDeinit: failed to delete %s (%s)",
+                        dev->disconnect_uds, strerror(errno));
         }
     }
 
@@ -1993,7 +1993,7 @@ rdpClientConDeinit(rdpPtr dev)
 int
 rdpClientConBeginUpdate(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConBeginUpdate:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConBeginUpdate:");
 
     if (clientCon->begin)
     {
@@ -2013,7 +2013,7 @@ rdpClientConBeginUpdate(rdpPtr dev, rdpClientCon *clientCon)
 int
 rdpClientConEndUpdate(rdpPtr dev, rdpClientCon *clientCon)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConEndUpdate"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConEndUpdate");
 
     if (clientCon->connected && clientCon->begin)
     {
@@ -2049,7 +2049,7 @@ rdpClientConPreCheck(rdpPtr dev, rdpClientCon *clientCon, int in_size)
         s_mark_end(clientCon->out_s);
         if (rdpClientConSendMsg(dev, clientCon) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConPreCheck: rdpup_send_msg failed"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConPreCheck: rdpup_send_msg failed");
             rv = 1;
         }
         clientCon->count = 0;
@@ -2067,7 +2067,7 @@ rdpClientConFillRect(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConFillRect:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConFillRect:");
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 3); /* fill rect */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2088,9 +2088,9 @@ rdpClientConScreenBlt(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConScreenBlt: x %d y %d cx %d cy %d "
+        LOG(LOG_LEVEL_TRACE, "rdpClientConScreenBlt: x %d y %d cx %d cy %d "
                "srcx %d srcy %d",
-               x, y, cx, cy, srcx, srcy));
+               x, y, cx, cy, srcx, srcy);
         rdpClientConPreCheck(dev, clientCon, 16);
         out_uint16_le(clientCon->out_s, 4); /* screen blt */
         out_uint16_le(clientCon->out_s, 16); /* size */
@@ -2113,7 +2113,7 @@ rdpClientConSetClip(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetClip:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetClip:");
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 10); /* set clip */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2133,7 +2133,7 @@ rdpClientConResetClip(rdpPtr dev, rdpClientCon *clientCon)
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConResetClip:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConResetClip:");
         rdpClientConPreCheck(dev, clientCon, 4);
         out_uint16_le(clientCon->out_s, 11); /* reset clip */
         out_uint16_le(clientCon->out_s, 4); /* size */
@@ -2298,7 +2298,7 @@ rdpClientConSetFgcolor(rdpPtr dev, rdpClientCon *clientCon, int fgcolor)
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetFgcolor:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetFgcolor:");
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 12); /* set fgcolor */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2318,7 +2318,7 @@ rdpClientConSetBgcolor(rdpPtr dev, rdpClientCon *clientCon, int bgcolor)
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetBgcolor:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetBgcolor:");
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 13); /* set bg color */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2338,7 +2338,7 @@ rdpClientConSetOpcode(rdpPtr dev, rdpClientCon *clientCon, int opcode)
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetOpcode:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetOpcode:");
         rdpClientConPreCheck(dev, clientCon, 6);
         out_uint16_le(clientCon->out_s, 14); /* set opcode */
         out_uint16_le(clientCon->out_s, 6); /* size */
@@ -2355,7 +2355,7 @@ rdpClientConSetPen(rdpPtr dev, rdpClientCon *clientCon, int style, int width)
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetPen:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetPen:");
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 17); /* set pen */
         out_uint16_le(clientCon->out_s, 8); /* size */
@@ -2374,7 +2374,7 @@ rdpClientConDrawLine(rdpPtr dev, rdpClientCon *clientCon,
 {
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDrawLine:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConDrawLine:");
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 18); /* draw line */
         out_uint16_le(clientCon->out_s, 12); /* size */
@@ -2397,7 +2397,7 @@ rdpClientConSetCursorSystem(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursor:");
         size = 2 + 2 + 4;
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 65); /* set cursor system */
@@ -2417,7 +2417,7 @@ rdpClientConMoveCursor(rdpPtr dev, rdpClientCon *clientCon, int x, int y)
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursor:");
         size = 2 + 2 + 2 + 2;
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 66); /* move cursor */
@@ -2439,7 +2439,7 @@ rdpClientConSetCursor(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursor:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursor:");
         size = 8 + 32 * (32 * 3) + 32 * (32 / 8);
         rdpClientConPreCheck(dev, clientCon, size);
         out_uint16_le(clientCon->out_s, 19); /* set cursor */
@@ -2469,7 +2469,7 @@ rdpClientConSetCursorEx(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorEx:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursorEx:");
         Bpp = (bpp == 0) ? 3 : (bpp + 7) / 8;
         size = 10 + 32 * (32 * Bpp) + 32 * (32 / 8);
         rdpClientConPreCheck(dev, clientCon, size);
@@ -2507,12 +2507,12 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorShm:"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursorShm:");
         Bpp = (bpp == 0) ? 3 : (bpp + 7) / 8;
         shmsize = width * height * Bpp + width * height / 8;
         if (g_alloc_shm_map_fd(&addr, &fd, shmsize) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConSetCursorShmFd: rdpGetShmFd failed"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConSetCursorShmFd: rdpGetShmFd failed");
             return 0;
         }
         shmemptr = (uint8_t *)addr;
@@ -2534,7 +2534,7 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         memcpy(shmemptr + width * height * Bpp, cur_mask, width * height / 8);
         rdpClientConSendPending(clientCon->dev, clientCon);
         rv = g_sck_send_fd_set(clientCon->sck, "int", 4, &fd, 1);
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSetCursorShmFd: g_sck_send_fd_set rv %d", rv);
         g_free_unmap_fd(shmemptr, fd, shmsize);
     }
     return rv;
@@ -2545,11 +2545,11 @@ int
 rdpClientConCreateOsSurface(rdpPtr dev, rdpClientCon *clientCon,
                             int rdpindex, int width, int height)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurface:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurface:");
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurface: width %d height %d", width, height));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurface: width %d height %d", width, height);
         rdpClientConPreCheck(dev, clientCon, 12);
         out_uint16_le(clientCon->out_s, 20);
         out_uint16_le(clientCon->out_s, 12);
@@ -2567,11 +2567,11 @@ int
 rdpClientConCreateOsSurfaceBpp(rdpPtr dev, rdpClientCon *clientCon,
                                int rdpindex, int width, int height, int bpp)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurfaceBpp:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurfaceBpp:");
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConCreateOsSurfaceBpp: width %d height %d "
-               "bpp %d", width, height, bpp));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConCreateOsSurfaceBpp: width %d height %d "
+               "bpp %d", width, height, bpp);
         rdpClientConPreCheck(dev, clientCon, 13);
         out_uint16_le(clientCon->out_s, 31);
         out_uint16_le(clientCon->out_s, 13);
@@ -2588,7 +2588,7 @@ rdpClientConCreateOsSurfaceBpp(rdpPtr dev, rdpClientCon *clientCon,
 int
 rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSwitchOsSurface:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSwitchOsSurface:");
 
     if (clientCon->connected)
     {
@@ -2598,7 +2598,7 @@ rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         }
 
         clientCon->rdpIndex = rdpindex;
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSwitchOsSurface: rdpindex %d", rdpindex));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSwitchOsSurface: rdpindex %d", rdpindex);
         /* switch surface */
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 21);
@@ -2614,11 +2614,11 @@ rdpClientConSwitchOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 int
 rdpClientConDeleteOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConDeleteOsSurface: rdpindex %d", rdpindex);
 
     if (clientCon->connected)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeleteOsSurface: rdpindex %d", rdpindex));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConDeleteOsSurface: rdpindex %d", rdpindex);
         rdpClientConPreCheck(dev, clientCon, 8);
         out_uint16_le(clientCon->out_s, 22);
         out_uint16_le(clientCon->out_s, 8);
@@ -2641,25 +2641,25 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     int oldest_index;
     int this_bytes;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap:");
     if (clientCon->connected == FALSE)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 1"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: test error 1");
         return -1;
     }
 
     if (clientCon->osBitmaps == NULL)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 2"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: test error 2");
         return -1;
     }
 
     this_bytes = pixmap->devKind * pixmap->drawable.height;
     if (this_bytes > MAX_OS_BYTES)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: error, too big this_bytes %d "
+        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: error, too big this_bytes %d "
                "width %d height %d", this_bytes,
-               pixmap->drawable.height, pixmap->drawable.height));
+               pixmap->drawable.height, pixmap->drawable.height);
         return -1;
     }
 
@@ -2696,12 +2696,12 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
     {
         if (oldest_index == -1)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConAddOsBitmap: error");
         }
         else
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: too many pixmaps removing "
-                   "oldest_index %d", oldest_index));
+            LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: too many pixmaps removing "
+                   "oldest_index %d", oldest_index);
             rdpClientConRemoveOsBitmap(dev, clientCon, oldest_index);
             rdpClientConDeleteOsSurface(dev, clientCon, oldest_index);
             clientCon->osBitmaps[oldest_index].used = TRUE;
@@ -2716,20 +2716,20 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
 
     if (rv < 0)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: test error 3"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: test error 3");
         return rv;
     }
 
     clientCon->osBitmapAllocSize += this_bytes;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: this_bytes %d "
+    LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: this_bytes %d "
            "clientCon->osBitmapAllocSize %d",
-           this_bytes, clientCon->osBitmapAllocSize));
+           this_bytes, clientCon->osBitmapAllocSize);
 #if USE_MAX_OS_BYTES
     while (clientCon->osBitmapAllocSize > MAX_OS_BYTES)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: must delete "
+        LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: must delete "
                "clientCon->osBitmapNumUsed %d",
-               clientCon->osBitmapNumUsed));
+               clientCon->osBitmapNumUsed);
         /* find oldest */
         oldest = INT_MAX;
         oldest_index = -1;
@@ -2746,22 +2746,22 @@ rdpClientConAddOsBitmap(rdpPtr dev, rdpClientCon *clientCon,
         }
         if (oldest_index == -1)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error 1"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConAddOsBitmap: error 1");
             break;
         }
         if (oldest_index == rv)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpClientConAddOsBitmap: error 2"));
+            LOG(LOG_LEVEL_INFO, "rdpClientConAddOsBitmap: error 2");
             break;
         }
         rdpClientConRemoveOsBitmap(dev, clientCon, oldest_index);
         rdpClientConDeleteOsSurface(dev, clientCon, oldest_index);
     }
 #endif
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: new bitmap index %d", rv));
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
+    LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: new bitmap index %d", rv);
+    LOG(LOG_LEVEL_TRACE, "rdpClientConAddOsBitmap: clientCon->osBitmapNumUsed %d "
            "clientCon->osBitmapStamp 0x%8.8x",
-           clientCon->osBitmapNumUsed, clientCon->osBitmapStamp));
+           clientCon->osBitmapNumUsed, clientCon->osBitmapStamp);
     return rv;
 }
 
@@ -2775,16 +2775,16 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
 
     if (clientCon->osBitmaps == NULL)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: test error 1"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: test error 1");
         return 1;
     }
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: index %d stamp %d",
+           rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: test error 2"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: test error 2");
         return 1;
     }
 
@@ -2795,9 +2795,9 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         rdpDrawItemRemoveAll(dev, priv);
         this_bytes = pixmap->devKind * pixmap->drawable.height;
         clientCon->osBitmapAllocSize -= this_bytes;
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConRemoveOsBitmap: this_bytes %d "
+        LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: this_bytes %d "
                "clientCon->osBitmapAllocSize %d", this_bytes,
-               clientCon->osBitmapAllocSize));
+               clientCon->osBitmapAllocSize);
         clientCon->osBitmaps[rdpindex].used = 0;
         clientCon->osBitmaps[rdpindex].pixmap = 0;
         clientCon->osBitmaps[rdpindex].priv = 0;
@@ -2808,11 +2808,11 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpup_remove_os_bitmap: error"));
+        LOG(LOG_LEVEL_INFO, "rdpup_remove_os_bitmap: error");
     }
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpup_remove_os_bitmap: clientCon->osBitmapNumUsed %d",
-           clientCon->osBitmapNumUsed));
+    LOG(LOG_LEVEL_TRACE, "rdpup_remove_os_bitmap: clientCon->osBitmapNumUsed %d",
+           clientCon->osBitmapNumUsed);
     return 0;
 }
 
@@ -2825,8 +2825,8 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConUpdateOsUse: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConUpdateOsUse: index %d stamp %d",
+           rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
     {
@@ -2840,7 +2840,7 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpClientConUpdateOsUse: error rdpindex %d", rdpindex));
+        LOG(LOG_LEVEL_INFO, "rdpClientConUpdateOsUse: error rdpindex %d", rdpindex);
     }
 
     return 0;
@@ -2853,7 +2853,7 @@ rdpClientConDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
     rdpClientCon *clientCon;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConDeferredUpdateCallback"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConDeferredUpdateCallback");
 
     dev = (rdpPtr) arg;
     clientCon = dev->clientConHead;
@@ -2918,8 +2918,8 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LLOGLN(LOG_LEVEL_TRACE, ("out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
-               index, x, y, cx, cy));
+        LOG(LOG_LEVEL_TRACE, "out_rects_dr: rects_d index %d x %d y %d cx %d cy %d",
+               index, x, y, cx, cy);
     }
     out_uint16_le(s, num_rects_c);
     for (index = 0; index < num_rects_c; index++)
@@ -2933,8 +2933,8 @@ out_rects_dr(struct stream *s,
         out_uint16_le(s, y);
         out_uint16_le(s, cx);
         out_uint16_le(s, cy);
-        LLOGLN(LOG_LEVEL_TRACE, ("out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
-               index, x, y, cx, cy));
+        LOG(LOG_LEVEL_TRACE, "out_rects_dr: rects_c index %d x %d y %d cx %d cy %d",
+               index, x, y, cx, cy);
     }
     return 0;
 }
@@ -2957,24 +2957,24 @@ rdpClientConSendPaintRectShmFd(rdpPtr dev, rdpClientCon *clientCon,
     int end_frame_bytes;
     int surface_id;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd:"));
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd:");
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: cap_left %d cap_top %d "
            "cap_width %d cap_height %d",
            clientCon->cap_left, clientCon->cap_top,
-           clientCon->cap_width, clientCon->cap_height));
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
+           clientCon->cap_width, clientCon->cap_height);
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: id->flags 0x%8.8X "
            "id->left %d id->top %d id->width %d id->height %d",
-           id->flags, id->left, id->top, id->width, id->height));
+           id->flags, id->left, id->top, id->width, id->height);
 
     capture_code = clientCon->client_info.capture_code;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: capture_code %d",
-           capture_code));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: capture_code %d",
+           capture_code);
 
     num_rects_d = REGION_NUM_RECTS(dirtyReg);
     num_rects_c = numCopyRects;
     if ((num_rects_c < 1) || (num_rects_d < 1))
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConSendPaintRectShmFd: nothing to send"));
+        LOG(LOG_LEVEL_TRACE, "rdpClientConSendPaintRectShmFd: nothing to send");
         return 0;
     }
 
@@ -3182,8 +3182,8 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
     int num_rects;
 
     cap_dirty = rdpRegionCreate(cap_rect, 0);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
-               cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2));
+    LOG(LOG_LEVEL_TRACE, "rdpCapRect: cap_rect x1 %d y1 %d x2 %d y2 %d",
+               cap_rect->x1, cap_rect->y1, cap_rect->x2, cap_rect->y2);
     rdpRegionIntersect(cap_dirty, cap_dirty, clientCon->dirtyRegion);
     num_rects = REGION_NUM_RECTS(cap_dirty);
     if (num_rects > MAX_CAPTURE_RECTS)
@@ -3202,11 +3202,11 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
     {
         rects = 0;
         num_rects = 0;
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: capture_code %d",
-                    clientCon->client_info.capture_code));
+        LOG(LOG_LEVEL_TRACE, "rdpCapRect: capture_code %d",
+                    clientCon->client_info.capture_code);
         if (rdpCapture(clientCon, cap_dirty, &rects, &num_rects, id))
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpCapRect: num_rects %d", num_rects));
+            LOG(LOG_LEVEL_TRACE, "rdpCapRect: num_rects %d", num_rects);
             if (clientCon->send_key_frame[mon])
             {
                 clientCon->send_key_frame[mon] = 0;
@@ -3219,7 +3219,7 @@ rdpCapRect(rdpClientCon *clientCon, BoxPtr cap_rect, int mon,
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpCapRect: rdpCapture failed"));
+            LOG(LOG_LEVEL_INFO, "rdpCapRect: rdpCapture failed");
         }
     }
     rdpRegionSubtract(clientCon->dirtyRegion, clientCon->dirtyRegion,
@@ -3240,18 +3240,18 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     int monitor_count;
     BoxRec cap_rect;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback:");
     clientCon->updateScheduled = FALSE;
     if (clientCon->suppress_output)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: suppress_output set"));
+        LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: suppress_output set");
         return 0;
     }
     if (clientCon->shmemstatus == SHM_UNINITIALIZED || clientCon->shmemstatus == SHM_RESIZING) {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: clientCon->shmemstatus "
+        LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: clientCon->shmemstatus "
                "is not valid for capture operations: %d"
                " reschedule rect_id %d rect_id_ack %d",
-               clientCon->shmemstatus, clientCon->rect_id, clientCon->rect_id_ack));
+               clientCon->shmemstatus, clientCon->rect_id, clientCon->rect_id_ack);
         return 0;
     }
     if ((clientCon->rect_id > clientCon->rect_id_ack) ||
@@ -3261,7 +3261,7 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
         return 0;
     }
     clientCon->lastUpdateTime = now;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: sending"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: sending");
     clientCon->updateRetries = 0;
     if (clientCon->dev->monitorCount < 1)
     {
@@ -3285,9 +3285,9 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
             // Did we get anything from the last monitor?
             if (clientCon->rect_id > clientCon->rect_id_ack)
             {
-                LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredUpdateCallback: reschedule rect_id %d "
+                LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: reschedule rect_id %d "
                        "rect_id_ack %d",
-                       clientCon->rect_id, clientCon->rect_id_ack));
+                       clientCon->rect_id, clientCon->rect_id_ack);
                 break;
             }
             // Offset the monitor index by the rectangle ID so we start
@@ -3361,7 +3361,7 @@ int
 rdpClientConAddDirtyScreenReg(rdpPtr dev, rdpClientCon *clientCon,
                               RegionPtr reg)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpClientConAddDirtyScreenReg:"));
+    LOG(LOG_LEVEL_TRACE, "rdpClientConAddDirtyScreenReg:");
     rdpRegionUnion(clientCon->dirtyRegion, clientCon->dirtyRegion, reg);
     rdpScheduleDeferredUpdate(clientCon);
     return 0;

--- a/module/rdpComposite.c
+++ b/module/rdpComposite.c
@@ -72,7 +72,7 @@ rdpComposite(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpComposite:"));
+    LOG(LOG_LEVEL_TRACE, "rdpComposite:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCompositeCallCount++;

--- a/module/rdpComposite.c
+++ b/module/rdpComposite.c
@@ -72,7 +72,7 @@ rdpComposite(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpComposite:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpComposite:"));
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCompositeCallCount++;

--- a/module/rdpCompositeRects.c
+++ b/module/rdpCompositeRects.c
@@ -66,7 +66,7 @@ rdpCompositeRects(CARD8 op, PicturePtr dst, xRenderColor * color,
     PictureScreenPtr ps;
     RegionPtr reg;
 
-    LLOGLN(10, ("rdpCompositeRects:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCompositeRects:"));
     pScreen = dst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCompositeRectsCallCount++;

--- a/module/rdpCompositeRects.c
+++ b/module/rdpCompositeRects.c
@@ -66,7 +66,7 @@ rdpCompositeRects(CARD8 op, PicturePtr dst, xRenderColor * color,
     PictureScreenPtr ps;
     RegionPtr reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCompositeRects:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCompositeRects:");
     pScreen = dst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCompositeRectsCallCount++;

--- a/module/rdpCopyArea.c
+++ b/module/rdpCopyArea.c
@@ -68,7 +68,7 @@ rdpCopyArea(DrawablePtr pSrc, DrawablePtr pDst, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyArea:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyArea:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpCopyAreaCallCount++;
     box.x1 = dstx + pDst->x;
@@ -78,7 +78,7 @@ rdpCopyArea(DrawablePtr pSrc, DrawablePtr pDst, GCPtr pGC,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyArea: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyArea: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpCopyArea.c
+++ b/module/rdpCopyArea.c
@@ -68,7 +68,7 @@ rdpCopyArea(DrawablePtr pSrc, DrawablePtr pDst, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpCopyArea:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyArea:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpCopyAreaCallCount++;
     box.x1 = dstx + pDst->x;
@@ -78,7 +78,7 @@ rdpCopyArea(DrawablePtr pSrc, DrawablePtr pDst, GCPtr pGC,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(10, ("rdpCopyArea: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyArea: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpCopyPlane.c
+++ b/module/rdpCopyPlane.c
@@ -71,7 +71,7 @@ rdpCopyPlane(DrawablePtr pSrc, DrawablePtr pDst,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpCopyPlane:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyPlane:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpCopyPlaneCallCount++;
     box.x1 = pDst->x + dstx;
@@ -81,7 +81,7 @@ rdpCopyPlane(DrawablePtr pSrc, DrawablePtr pDst,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(10, ("rdpCopyPlane: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyPlane: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpCopyPlane.c
+++ b/module/rdpCopyPlane.c
@@ -71,7 +71,7 @@ rdpCopyPlane(DrawablePtr pSrc, DrawablePtr pDst,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyPlane:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyPlane:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpCopyPlaneCallCount++;
     box.x1 = pDst->x + dstx;
@@ -81,7 +81,7 @@ rdpCopyPlane(DrawablePtr pSrc, DrawablePtr pDst,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyPlane: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyPlane: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -276,7 +276,7 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         /* None cursor */
         cursor_id = 0; /* SYSPTR_NULL */
         LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon: sending cursor system "
-                "pointer 0x%8.8X", cursor_id);
+            "pointer 0x%8.8X", cursor_id);
         rdpClientConBeginUpdate(clientCon->dev, clientCon);
         rdpClientConSetCursorSystem(clientCon->dev, clientCon, cursor_id);
         rdpClientConEndUpdate(clientCon->dev, clientCon);
@@ -304,9 +304,9 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         sending_width = server_width > 32 ? client_max_width : 32;
         sending_height = server_height > 32 ? client_max_height : 32;
         LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon: sending_width %d "
-               "sending_height %d server_width %d server_height %d "
-               "sending_bpp %d", sending_width, sending_height,
-               server_width, server_height, sending_bpp);
+            "sending_height %d server_width %d server_height %d "
+            "sending_bpp %d", sending_width, sending_height,
+            server_width, server_height, sending_bpp);
         if (sending_bpp == 32)
         {
             paddedRowBytes = PixmapBytePad(server_width, 32);
@@ -399,10 +399,12 @@ rdpSpriteSetCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
 
     LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor:");
     dev = rdpGetDevFromScreen(pScr);
-    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
-           x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
+        x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move);
     clientCon = dev->clientConHead;
     while (clientCon != NULL)
     {
@@ -432,10 +434,12 @@ rdpSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
 
     LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor:");
     dev = rdpGetDevFromScreen(pScr);
-    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
-      x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
+        x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move);
     if (!do_move)
     {
         return;

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -101,7 +101,7 @@ static uint8_t g_reverse_byte[0x100] =
 Bool
 rdpSpriteRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 {
-    LLOGLN(10, ("rdpSpriteRealizeCursor:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteRealizeCursor:"));
     return TRUE;
 }
 
@@ -109,7 +109,7 @@ rdpSpriteRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 Bool
 rdpSpriteUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 {
-    LLOGLN(10, ("rdpSpriteUnrealizeCursor:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteUnrealizeCursor:"));
     return TRUE;
 }
 
@@ -249,10 +249,10 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
     int can_do_large;
     int cursor_id;
 
-    LLOGLN(10, ("rdpSpriteSetCursorCon:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon:"));
     if (clientCon->suppress_output)
     {
-        LLOGLN(10, ("rdpSpriteSetCursorCon: suppress_output set"));
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: suppress_output set"));
         return;
     }
     if (clientCon->client_info.size == 0)
@@ -275,7 +275,7 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
     {
         /* None cursor */
         cursor_id = 0; /* SYSPTR_NULL */
-        LLOGLN(10, ("rdpSpriteSetCursorCon: sending cursor system "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: sending cursor system "
                 "pointer 0x%8.8X", cursor_id));
         rdpClientConBeginUpdate(clientCon->dev, clientCon);
         rdpClientConSetCursorSystem(clientCon->dev, clientCon, cursor_id);
@@ -303,7 +303,7 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         }
         sending_width = server_width > 32 ? client_max_width : 32;
         sending_height = server_height > 32 ? client_max_height : 32;
-        LLOGLN(10, ("rdpSpriteSetCursorCon: sending_width %d "
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: sending_width %d "
                "sending_height %d server_width %d server_height %d "
                "sending_bpp %d", sending_width, sending_height,
                server_width, server_height, sending_bpp));
@@ -397,12 +397,12 @@ rdpSpriteSetCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
     rdpClientCon *clientCon;
     int do_move;
 
-    LLOGLN(10, ("rdpSpriteSetCursor:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor:"));
     dev = rdpGetDevFromScreen(pScr);
-    LLOGLN(10, ("rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
            x, y, dev->pointer.cursor_x, dev->pointer.cursor_y));
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LLOGLN(10, ("rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move));
     clientCon = dev->clientConHead;
     while (clientCon != NULL)
     {
@@ -416,7 +416,7 @@ static void
 rdpSpriteMoveCursorCon(rdpClientCon *clientCon,
                       DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
 {
-    LLOGLN(10, ("rdpSpriteMoveCursorCon:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursorCon:"));
     rdpClientConBeginUpdate(clientCon->dev, clientCon);
     rdpClientConMoveCursor(clientCon->dev, clientCon, x, y);
     rdpClientConEndUpdate(clientCon->dev, clientCon);
@@ -430,12 +430,12 @@ rdpSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
     rdpClientCon *clientCon;
     int do_move;
 
-    LLOGLN(10, ("rdpSpriteMoveCursor:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor:"));
     dev = rdpGetDevFromScreen(pScr);
-    LLOGLN(10, ("rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
       x, y, dev->pointer.cursor_x, dev->pointer.cursor_y));
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LLOGLN(10, ("rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move));
     if (!do_move)
     {
         return;
@@ -452,7 +452,7 @@ rdpSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
 Bool
 rdpSpriteDeviceCursorInitialize(DeviceIntPtr pDev, ScreenPtr pScr)
 {
-    LLOGLN(10, ("rdpSpriteDeviceCursorInitialize:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteDeviceCursorInitialize:"));
     return TRUE;
 }
 
@@ -460,5 +460,5 @@ rdpSpriteDeviceCursorInitialize(DeviceIntPtr pDev, ScreenPtr pScr)
 void
 rdpSpriteDeviceCursorCleanup(DeviceIntPtr pDev, ScreenPtr pScr)
 {
-    LLOGLN(10, ("rdpSpriteDeviceCursorCleanup:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteDeviceCursorCleanup:"));
 }

--- a/module/rdpCursor.c
+++ b/module/rdpCursor.c
@@ -101,7 +101,7 @@ static uint8_t g_reverse_byte[0x100] =
 Bool
 rdpSpriteRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteRealizeCursor:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteRealizeCursor:");
     return TRUE;
 }
 
@@ -109,7 +109,7 @@ rdpSpriteRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 Bool
 rdpSpriteUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteUnrealizeCursor:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteUnrealizeCursor:");
     return TRUE;
 }
 
@@ -249,10 +249,10 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
     int can_do_large;
     int cursor_id;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon:");
     if (clientCon->suppress_output)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: suppress_output set"));
+        LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon: suppress_output set");
         return;
     }
     if (clientCon->client_info.size == 0)
@@ -275,8 +275,8 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
     {
         /* None cursor */
         cursor_id = 0; /* SYSPTR_NULL */
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: sending cursor system "
-                "pointer 0x%8.8X", cursor_id));
+        LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon: sending cursor system "
+                "pointer 0x%8.8X", cursor_id);
         rdpClientConBeginUpdate(clientCon->dev, clientCon);
         rdpClientConSetCursorSystem(clientCon->dev, clientCon, cursor_id);
         rdpClientConEndUpdate(clientCon->dev, clientCon);
@@ -303,10 +303,10 @@ rdpSpriteSetCursorCon(rdpClientCon *clientCon,
         }
         sending_width = server_width > 32 ? client_max_width : 32;
         sending_height = server_height > 32 ? client_max_height : 32;
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursorCon: sending_width %d "
+        LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursorCon: sending_width %d "
                "sending_height %d server_width %d server_height %d "
                "sending_bpp %d", sending_width, sending_height,
-               server_width, server_height, sending_bpp));
+               server_width, server_height, sending_bpp);
         if (sending_bpp == 32)
         {
             paddedRowBytes = PixmapBytePad(server_width, 32);
@@ -397,12 +397,12 @@ rdpSpriteSetCursor(DeviceIntPtr pDev, ScreenPtr pScr, CursorPtr pCurs,
     rdpClientCon *clientCon;
     int do_move;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor:");
     dev = rdpGetDevFromScreen(pScr);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
-           x, y, dev->pointer.cursor_x, dev->pointer.cursor_y));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor: x %d y %d cursor_x %d cursor_y %d",
+           x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteSetCursor: x %d y %d do_move %d", x, y, do_move);
     clientCon = dev->clientConHead;
     while (clientCon != NULL)
     {
@@ -416,7 +416,7 @@ static void
 rdpSpriteMoveCursorCon(rdpClientCon *clientCon,
                       DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursorCon:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursorCon:");
     rdpClientConBeginUpdate(clientCon->dev, clientCon);
     rdpClientConMoveCursor(clientCon->dev, clientCon, x, y);
     rdpClientConEndUpdate(clientCon->dev, clientCon);
@@ -430,12 +430,12 @@ rdpSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
     rdpClientCon *clientCon;
     int do_move;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor:");
     dev = rdpGetDevFromScreen(pScr);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
-      x, y, dev->pointer.cursor_x, dev->pointer.cursor_y));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor: x %d y %d cursor_x %d cursor_y %d",
+      x, y, dev->pointer.cursor_x, dev->pointer.cursor_y);
     do_move = (dev->pointer.cursor_x != x) || (dev->pointer.cursor_y != y);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteMoveCursor: x %d y %d do_move %d", x, y, do_move);
     if (!do_move)
     {
         return;
@@ -452,7 +452,7 @@ rdpSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScr, int x, int y)
 Bool
 rdpSpriteDeviceCursorInitialize(DeviceIntPtr pDev, ScreenPtr pScr)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteDeviceCursorInitialize:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteDeviceCursorInitialize:");
     return TRUE;
 }
 
@@ -460,5 +460,5 @@ rdpSpriteDeviceCursorInitialize(DeviceIntPtr pDev, ScreenPtr pScr)
 void
 rdpSpriteDeviceCursorCleanup(DeviceIntPtr pDev, ScreenPtr pScr)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSpriteDeviceCursorCleanup:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSpriteDeviceCursorCleanup:");
 }

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -305,7 +305,7 @@ rdpCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr pOldRegion)
     BoxPtr box;
     BoxRec box1;
 
-    LLOGLN(10, ("rdpCopyWindow:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyWindow:"));
     pScreen = pWin->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCopyWindowCallCount++;
@@ -331,7 +331,7 @@ rdpCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr pOldRegion)
     {
         if ((num_clip_rects > 16) || (num_reg_rects > 16))
         {
-            LLOGLN(10, ("rdpCopyWindow: big list"));
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyWindow: big list"));
             box = rdpRegionExtents(&reg);
             box1 = *box;
             box1.x1 += dx;
@@ -360,7 +360,7 @@ rdpCloseScreen(int index, ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(10, ("rdpCloseScreen:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCloseScreen:"));
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(index, pScreen);
@@ -378,7 +378,7 @@ rdpCloseScreen(ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(10, ("rdpCloseScreen:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCloseScreen:"));
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(pScreen);

--- a/module/rdpDraw.c
+++ b/module/rdpDraw.c
@@ -305,7 +305,7 @@ rdpCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr pOldRegion)
     BoxPtr box;
     BoxRec box1;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyWindow:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyWindow:");
     pScreen = pWin->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpCopyWindowCallCount++;
@@ -331,7 +331,7 @@ rdpCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr pOldRegion)
     {
         if ((num_clip_rects > 16) || (num_reg_rects > 16))
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyWindow: big list"));
+            LOG(LOG_LEVEL_TRACE, "rdpCopyWindow: big list");
             box = rdpRegionExtents(&reg);
             box1 = *box;
             box1.x1 += dx;
@@ -360,7 +360,7 @@ rdpCloseScreen(int index, ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCloseScreen:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCloseScreen:");
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(index, pScreen);
@@ -378,7 +378,7 @@ rdpCloseScreen(ScreenPtr pScreen)
     rdpPtr dev;
     Bool rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCloseScreen:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCloseScreen:");
     dev = rdpGetDevFromScreen(pScreen);
     dev->pScreen->CloseScreen = dev->CloseScreen;
     rv = dev->pScreen->CloseScreen(pScreen);

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -334,7 +334,7 @@ rdpEglCreate(ScreenPtr screen)
     egl->tex_loc[0] = glGetUniformLocation(egl->program[0], "tex");
     egl->tex_size_loc[0] = glGetUniformLocation(egl->program[0], "tex_size");
     LOG(LOG_LEVEL_INFO, "rdpEglCreate: copy_tex_loc %d copy_tex_size_loc %d",
-           egl->tex_loc[0], egl->tex_size_loc[0]);
+        egl->tex_loc[0], egl->tex_size_loc[0]);
     /* create yuv shader */
     vsource = g_vs;
     fsource = g_fs_rfx_rgb_to_yuv;
@@ -359,7 +359,7 @@ rdpEglCreate(ScreenPtr screen)
     egl->tex_loc[1] = glGetUniformLocation(egl->program[1], "tex");
     egl->tex_size_loc[1] = glGetUniformLocation(egl->program[1], "tex_size");
     LOG(LOG_LEVEL_INFO, "rdpEglCreate: yuv_tex_loc %d yuv_tex_size_loc %d",
-           egl->tex_loc[1], egl->tex_size_loc[1]);
+        egl->tex_loc[1], egl->tex_size_loc[1]);
     /* create yuvlp shader */
     vsource = g_vs;
     fsource = g_fs_rfx_yuv_to_yuvlp;
@@ -384,7 +384,7 @@ rdpEglCreate(ScreenPtr screen)
     egl->tex_loc[2] = glGetUniformLocation(egl->program[2], "tex");
     egl->tex_size_loc[2] = glGetUniformLocation(egl->program[2], "tex_size");
     LOG(LOG_LEVEL_INFO, "rdpEglCreate: yuvlp_tex_loc %d yuvlp_tex_size_loc %d",
-           egl->tex_loc[2], egl->tex_size_loc[2]);
+        egl->tex_loc[2], egl->tex_size_loc[2]);
     /* create crc shader */
     vsource = g_vs;
     fsource = g_fs_rfx_crc;
@@ -409,7 +409,7 @@ rdpEglCreate(ScreenPtr screen)
     egl->tex_loc[3] = glGetUniformLocation(egl->program[3], "tex");
     egl->tex_size_loc[3] = glGetUniformLocation(egl->program[3], "tex_size");
     LOG(LOG_LEVEL_INFO, "rdpEglCreate: crc_tex_loc %d crc_tex_size_loc %d",
-           egl->tex_loc[3], egl->tex_size_loc[3]);
+        egl->tex_loc[3], egl->tex_size_loc[3]);
     return egl;
 }
 
@@ -568,7 +568,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
         LOG(LOG_LEVEL_INFO, "rdpEglOut: resize the crc list was %d now %d",
-               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
+            clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
         free(clientCon->rfx_crcs[mon_index]);
@@ -587,7 +587,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
             rect.x2 = rect.x1 + 64;
             rect.y2 = rect.y1 + 64;
             LOG(LOG_LEVEL_TRACE, "rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
-                   rect.x1, rect.y1, rect.x2, rect.y2);
+                rect.x1, rect.y1, rect.x2, rect.y2);
             rcode = rdpRegionContainsRect(in_reg, &rect);
             if (rcode == rgnOUT)
             {
@@ -611,9 +611,9 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 if (crc != crcs[(ly / 64) * tile_extents_stride + (lx / 64)])
                 {
                     LOG(LOG_LEVEL_INFO, "rdpEglOut: error crc no match "
-                           "0x%" PRIx64 " 0x%" PRIx64,
-                           crc,
-                           crcs[(ly / 64) * tile_extents_stride + (lx / 64)]);
+                        "0x%" PRIx64 " 0x%" PRIx64,
+                        crc,
+                        crcs[(ly / 64) * tile_extents_stride + (lx / 64)]);
                 }
 #endif
                 crc = crcs[(ly / 64) * tile_extents_stride + (lx / 64)];
@@ -638,7 +638,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                     else
                     {
                         LOG(LOG_LEVEL_INFO, "rdpEglOut: too many out rects %d",
-                               out_rect_index);
+                            out_rect_index);
                     }
                 }
 

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -321,19 +321,19 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[0], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[0]);
     glGetShaderiv(egl->vertex_shader[0], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
     glCompileShader(egl->fragment_shader[0]);
     glGetShaderiv(egl->fragment_shader[0], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
     egl->program[0] = glCreateProgram();
     glAttachShader(egl->program[0], egl->vertex_shader[0]);
     glAttachShader(egl->program[0], egl->fragment_shader[0]);
     glLinkProgram(egl->program[0]);
     glGetProgramiv(egl->program[0], GL_LINK_STATUS, &linked);
-    LLOGLN(0, ("rdpEglCreate: linked %d", linked));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
     egl->tex_loc[0] = glGetUniformLocation(egl->program[0], "tex");
     egl->tex_size_loc[0] = glGetUniformLocation(egl->program[0], "tex_size");
-    LLOGLN(0, ("rdpEglCreate: copy_tex_loc %d copy_tex_size_loc %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: copy_tex_loc %d copy_tex_size_loc %d",
            egl->tex_loc[0], egl->tex_size_loc[0]));
     /* create yuv shader */
     vsource = g_vs;
@@ -346,19 +346,19 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[1], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[1]);
     glGetShaderiv(egl->vertex_shader[1], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
     glCompileShader(egl->fragment_shader[1]);
     glGetShaderiv(egl->fragment_shader[1], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
     egl->program[1] = glCreateProgram();
     glAttachShader(egl->program[1], egl->vertex_shader[1]);
     glAttachShader(egl->program[1], egl->fragment_shader[1]);
     glLinkProgram(egl->program[1]);
     glGetProgramiv(egl->program[1], GL_LINK_STATUS, &linked);
-    LLOGLN(0, ("rdpEglCreate: linked %d", linked));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
     egl->tex_loc[1] = glGetUniformLocation(egl->program[1], "tex");
     egl->tex_size_loc[1] = glGetUniformLocation(egl->program[1], "tex_size");
-    LLOGLN(0, ("rdpEglCreate: yuv_tex_loc %d yuv_tex_size_loc %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: yuv_tex_loc %d yuv_tex_size_loc %d",
            egl->tex_loc[1], egl->tex_size_loc[1]));
     /* create yuvlp shader */
     vsource = g_vs;
@@ -371,19 +371,19 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[2], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[2]);
     glGetShaderiv(egl->vertex_shader[2], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
     glCompileShader(egl->fragment_shader[2]);
     glGetShaderiv(egl->fragment_shader[2], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
     egl->program[2] = glCreateProgram();
     glAttachShader(egl->program[2], egl->vertex_shader[2]);
     glAttachShader(egl->program[2], egl->fragment_shader[2]);
     glLinkProgram(egl->program[2]);
     glGetProgramiv(egl->program[2], GL_LINK_STATUS, &linked);
-    LLOGLN(0, ("rdpEglCreate: linked %d", linked));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
     egl->tex_loc[2] = glGetUniformLocation(egl->program[2], "tex");
     egl->tex_size_loc[2] = glGetUniformLocation(egl->program[2], "tex_size");
-    LLOGLN(0, ("rdpEglCreate: yuvlp_tex_loc %d yuvlp_tex_size_loc %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: yuvlp_tex_loc %d yuvlp_tex_size_loc %d",
            egl->tex_loc[2], egl->tex_size_loc[2]));
     /* create crc shader */
     vsource = g_vs;
@@ -396,19 +396,19 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[3], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[3]);
     glGetShaderiv(egl->vertex_shader[3], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
     glCompileShader(egl->fragment_shader[3]);
     glGetShaderiv(egl->fragment_shader[3], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(0, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
     egl->program[3] = glCreateProgram();
     glAttachShader(egl->program[3], egl->vertex_shader[3]);
     glAttachShader(egl->program[3], egl->fragment_shader[3]);
     glLinkProgram(egl->program[3]);
     glGetProgramiv(egl->program[3], GL_LINK_STATUS, &linked);
-    LLOGLN(0, ("rdpEglCreate: linked %d", linked));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
     egl->tex_loc[3] = glGetUniformLocation(egl->program[3], "tex");
     egl->tex_size_loc[3] = glGetUniformLocation(egl->program[3], "tex_size");
-    LLOGLN(0, ("rdpEglCreate: crc_tex_loc %d crc_tex_size_loc %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: crc_tex_loc %d crc_tex_size_loc %d",
            egl->tex_loc[3], egl->tex_size_loc[3]));
     return egl;
 }
@@ -444,7 +444,7 @@ rdpEglRfxRgbToYuv(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(0, ("rdpEglRfxRgbToYuv: glCheckFramebufferStatus error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxRgbToYuv: glCheckFramebufferStatus error"));
     }
     glViewport(0, 0, width, height);
     glUseProgram(egl->program[1]);
@@ -475,7 +475,7 @@ rdpEglRfxYuvToYuvlp(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(0, ("rdpEglRfxYuvToYuvlp: glCheckFramebufferStatus error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxYuvToYuvlp: glCheckFramebufferStatus error"));
     }
     glViewport(0, 0, width, height);
     glUseProgram(egl->program[2]);
@@ -510,7 +510,7 @@ rdpEglRfxCrc(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(0, ("rdpEglRfxCrc: glCheckFramebufferStatus error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxCrc: glCheckFramebufferStatus error"));
     }
     glViewport(0, 0, w_div_64, h_div_64);
     glUseProgram(egl->program[3]);
@@ -558,7 +558,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(0, ("rdpEglOut: glCheckFramebufferStatus error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: glCheckFramebufferStatus error"));
     }
     dst = id->shmem_pixels;
     dst_stride = ((id->width + 63) & ~63) * 4;
@@ -567,7 +567,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     num_crcs = crc_stride * ((id->height + 63) / 64);
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
-        LLOGLN(0, ("rdpEglOut: resize the crc list was %d now %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: resize the crc list was %d now %d",
                clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
@@ -586,12 +586,12 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
             rect.y1 = y;
             rect.x2 = rect.x1 + 64;
             rect.y2 = rect.y1 + 64;
-            LLOGLN(10, ("rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
                    rect.x1, rect.y1, rect.x2, rect.y2));
             rcode = rdpRegionContainsRect(in_reg, &rect);
             if (rcode == rgnOUT)
             {
-                LLOGLN(10, ("rdpEglOut: rgnOUT"));
+                LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: rgnOUT"));
                 rdpRegionInit(&tile_reg, &rect, 0);
                 rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                 rdpRegionUninit(&tile_reg);
@@ -610,7 +610,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 crc = crc_end(crc);
                 if (crc != crcs[(ly / 64) * tile_extents_stride + (lx / 64)])
                 {
-                    LLOGLN(0, ("rdpEglOut: error crc no match "
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: error crc no match "
                            "0x%" PRIx64 " 0x%" PRIx64,
                            crc,
                            crcs[(ly / 64) * tile_extents_stride + (lx / 64)]));
@@ -620,7 +620,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 crc_offset = (y / 64) * crc_stride + (x / 64);
                 if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
-                    LLOGLN(10, ("rdpEglOut: crc skip at x %d y %d", x, y));
+                    LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: crc skip at x %d y %d", x, y));
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                     rdpRegionUninit(&tile_reg);
@@ -637,7 +637,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                     }
                     else
                     {
-                        LLOGLN(0, ("rdpEglOut: too many out rects %d",
+                        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: too many out rects %d",
                                out_rect_index));
                     }
                 }
@@ -719,7 +719,7 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     tile_extents_rect.y2 = (extents_rect.y2 + 63) & ~63;
     width = tile_extents_rect.x2 - tile_extents_rect.x1;
     height = tile_extents_rect.y2 - tile_extents_rect.y1;
-    LLOGLN(10, ("rdpEglCaptureRfx: width %d height %d", width, height));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpEglCaptureRfx: width %d height %d", width, height));
     crcs = g_new(int, (width / 64) * (height / 64));
     if (crcs == NULL)
     {
@@ -769,25 +769,25 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 else
                 {
-                    LLOGLN(0, ("rdpEglCaptureRfx: CreatePixmap failed"));
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
                 }
                 pScreen->DestroyPixmap(crc_pixmap);
             }
             else
             {
-                LLOGLN(0, ("rdpEglCaptureRfx: CreatePixmap failed"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
             }
             pScreen->DestroyPixmap(pixmap);
         }
         else
         {
-            LLOGLN(0, ("rdpEglCaptureRfx: CreatePixmap failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
         }
         FreeScratchGC(rfxGC);
     }
     else
     {
-        LLOGLN(0, ("rdpEglCaptureRfx: GetScratchGC failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: GetScratchGC failed"));
     }
     free(crcs);
     return TRUE;

--- a/module/rdpEgl.c
+++ b/module/rdpEgl.c
@@ -321,20 +321,20 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[0], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[0]);
     glGetShaderiv(egl->vertex_shader[0], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: vertex_shader compiled %d", compiled);
     glCompileShader(egl->fragment_shader[0]);
     glGetShaderiv(egl->fragment_shader[0], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: fragment_shader compiled %d", compiled);
     egl->program[0] = glCreateProgram();
     glAttachShader(egl->program[0], egl->vertex_shader[0]);
     glAttachShader(egl->program[0], egl->fragment_shader[0]);
     glLinkProgram(egl->program[0]);
     glGetProgramiv(egl->program[0], GL_LINK_STATUS, &linked);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: linked %d", linked);
     egl->tex_loc[0] = glGetUniformLocation(egl->program[0], "tex");
     egl->tex_size_loc[0] = glGetUniformLocation(egl->program[0], "tex_size");
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: copy_tex_loc %d copy_tex_size_loc %d",
-           egl->tex_loc[0], egl->tex_size_loc[0]));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: copy_tex_loc %d copy_tex_size_loc %d",
+           egl->tex_loc[0], egl->tex_size_loc[0]);
     /* create yuv shader */
     vsource = g_vs;
     fsource = g_fs_rfx_rgb_to_yuv;
@@ -346,20 +346,20 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[1], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[1]);
     glGetShaderiv(egl->vertex_shader[1], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: vertex_shader compiled %d", compiled);
     glCompileShader(egl->fragment_shader[1]);
     glGetShaderiv(egl->fragment_shader[1], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: fragment_shader compiled %d", compiled);
     egl->program[1] = glCreateProgram();
     glAttachShader(egl->program[1], egl->vertex_shader[1]);
     glAttachShader(egl->program[1], egl->fragment_shader[1]);
     glLinkProgram(egl->program[1]);
     glGetProgramiv(egl->program[1], GL_LINK_STATUS, &linked);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: linked %d", linked);
     egl->tex_loc[1] = glGetUniformLocation(egl->program[1], "tex");
     egl->tex_size_loc[1] = glGetUniformLocation(egl->program[1], "tex_size");
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: yuv_tex_loc %d yuv_tex_size_loc %d",
-           egl->tex_loc[1], egl->tex_size_loc[1]));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: yuv_tex_loc %d yuv_tex_size_loc %d",
+           egl->tex_loc[1], egl->tex_size_loc[1]);
     /* create yuvlp shader */
     vsource = g_vs;
     fsource = g_fs_rfx_yuv_to_yuvlp;
@@ -371,20 +371,20 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[2], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[2]);
     glGetShaderiv(egl->vertex_shader[2], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: vertex_shader compiled %d", compiled);
     glCompileShader(egl->fragment_shader[2]);
     glGetShaderiv(egl->fragment_shader[2], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: fragment_shader compiled %d", compiled);
     egl->program[2] = glCreateProgram();
     glAttachShader(egl->program[2], egl->vertex_shader[2]);
     glAttachShader(egl->program[2], egl->fragment_shader[2]);
     glLinkProgram(egl->program[2]);
     glGetProgramiv(egl->program[2], GL_LINK_STATUS, &linked);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: linked %d", linked);
     egl->tex_loc[2] = glGetUniformLocation(egl->program[2], "tex");
     egl->tex_size_loc[2] = glGetUniformLocation(egl->program[2], "tex_size");
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: yuvlp_tex_loc %d yuvlp_tex_size_loc %d",
-           egl->tex_loc[2], egl->tex_size_loc[2]));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: yuvlp_tex_loc %d yuvlp_tex_size_loc %d",
+           egl->tex_loc[2], egl->tex_size_loc[2]);
     /* create crc shader */
     vsource = g_vs;
     fsource = g_fs_rfx_crc;
@@ -396,20 +396,20 @@ rdpEglCreate(ScreenPtr screen)
     glShaderSource(egl->fragment_shader[3], 1, &fsource, &flength);
     glCompileShader(egl->vertex_shader[3]);
     glGetShaderiv(egl->vertex_shader[3], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: vertex_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: vertex_shader compiled %d", compiled);
     glCompileShader(egl->fragment_shader[3]);
     glGetShaderiv(egl->fragment_shader[3], GL_COMPILE_STATUS, &compiled);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: fragment_shader compiled %d", compiled));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: fragment_shader compiled %d", compiled);
     egl->program[3] = glCreateProgram();
     glAttachShader(egl->program[3], egl->vertex_shader[3]);
     glAttachShader(egl->program[3], egl->fragment_shader[3]);
     glLinkProgram(egl->program[3]);
     glGetProgramiv(egl->program[3], GL_LINK_STATUS, &linked);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: linked %d", linked));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: linked %d", linked);
     egl->tex_loc[3] = glGetUniformLocation(egl->program[3], "tex");
     egl->tex_size_loc[3] = glGetUniformLocation(egl->program[3], "tex_size");
-    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCreate: crc_tex_loc %d crc_tex_size_loc %d",
-           egl->tex_loc[3], egl->tex_size_loc[3]));
+    LOG(LOG_LEVEL_INFO, "rdpEglCreate: crc_tex_loc %d crc_tex_size_loc %d",
+           egl->tex_loc[3], egl->tex_size_loc[3]);
     return egl;
 }
 
@@ -444,7 +444,7 @@ rdpEglRfxRgbToYuv(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxRgbToYuv: glCheckFramebufferStatus error"));
+        LOG(LOG_LEVEL_INFO, "rdpEglRfxRgbToYuv: glCheckFramebufferStatus error");
     }
     glViewport(0, 0, width, height);
     glUseProgram(egl->program[1]);
@@ -475,7 +475,7 @@ rdpEglRfxYuvToYuvlp(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxYuvToYuvlp: glCheckFramebufferStatus error"));
+        LOG(LOG_LEVEL_INFO, "rdpEglRfxYuvToYuvlp: glCheckFramebufferStatus error");
     }
     glViewport(0, 0, width, height);
     glUseProgram(egl->program[2]);
@@ -510,7 +510,7 @@ rdpEglRfxCrc(struct rdp_egl *egl, GLuint src_tex, GLuint dst_tex,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglRfxCrc: glCheckFramebufferStatus error"));
+        LOG(LOG_LEVEL_INFO, "rdpEglRfxCrc: glCheckFramebufferStatus error");
     }
     glViewport(0, 0, w_div_64, h_div_64);
     glUseProgram(egl->program[3]);
@@ -558,7 +558,7 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: glCheckFramebufferStatus error"));
+        LOG(LOG_LEVEL_INFO, "rdpEglOut: glCheckFramebufferStatus error");
     }
     dst = id->shmem_pixels;
     dst_stride = ((id->width + 63) & ~63) * 4;
@@ -567,8 +567,8 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
     num_crcs = crc_stride * ((id->height + 63) / 64);
     if (num_crcs != clientCon->num_rfx_crcs_alloc[mon_index])
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: resize the crc list was %d now %d",
-               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs));
+        LOG(LOG_LEVEL_INFO, "rdpEglOut: resize the crc list was %d now %d",
+               clientCon->num_rfx_crcs_alloc[mon_index], num_crcs);
         /* resize the crc list */
         clientCon->num_rfx_crcs_alloc[mon_index] = num_crcs;
         free(clientCon->rfx_crcs[mon_index]);
@@ -586,12 +586,12 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
             rect.y1 = y;
             rect.x2 = rect.x1 + 64;
             rect.y2 = rect.y1 + 64;
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
-                   rect.x1, rect.y1, rect.x2, rect.y2));
+            LOG(LOG_LEVEL_TRACE, "rdpEglOut: x1 %d y1 %d x2 %d y2 %d",
+                   rect.x1, rect.y1, rect.x2, rect.y2);
             rcode = rdpRegionContainsRect(in_reg, &rect);
             if (rcode == rgnOUT)
             {
-                LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: rgnOUT"));
+                LOG(LOG_LEVEL_TRACE, "rdpEglOut: rgnOUT");
                 rdpRegionInit(&tile_reg, &rect, 0);
                 rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                 rdpRegionUninit(&tile_reg);
@@ -610,17 +610,17 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                 crc = crc_end(crc);
                 if (crc != crcs[(ly / 64) * tile_extents_stride + (lx / 64)])
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: error crc no match "
+                    LOG(LOG_LEVEL_INFO, "rdpEglOut: error crc no match "
                            "0x%" PRIx64 " 0x%" PRIx64,
                            crc,
-                           crcs[(ly / 64) * tile_extents_stride + (lx / 64)]));
+                           crcs[(ly / 64) * tile_extents_stride + (lx / 64)]);
                 }
 #endif
                 crc = crcs[(ly / 64) * tile_extents_stride + (lx / 64)];
                 crc_offset = (y / 64) * crc_stride + (x / 64);
                 if (crc == clientCon->rfx_crcs[mon_index][crc_offset])
                 {
-                    LLOGLN(LOG_LEVEL_TRACE, ("rdpEglOut: crc skip at x %d y %d", x, y));
+                    LOG(LOG_LEVEL_TRACE, "rdpEglOut: crc skip at x %d y %d", x, y);
                     rdpRegionInit(&tile_reg, &rect, 0);
                     rdpRegionSubtract(in_reg, in_reg, &tile_reg);
                     rdpRegionUninit(&tile_reg);
@@ -637,8 +637,8 @@ rdpEglOut(rdpClientCon *clientCon, struct rdp_egl *egl, RegionPtr in_reg,
                     }
                     else
                     {
-                        LLOGLN(LOG_LEVEL_INFO, ("rdpEglOut: too many out rects %d",
-                               out_rect_index));
+                        LOG(LOG_LEVEL_INFO, "rdpEglOut: too many out rects %d",
+                               out_rect_index);
                     }
                 }
 
@@ -719,7 +719,7 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     tile_extents_rect.y2 = (extents_rect.y2 + 63) & ~63;
     width = tile_extents_rect.x2 - tile_extents_rect.x1;
     height = tile_extents_rect.y2 - tile_extents_rect.y1;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpEglCaptureRfx: width %d height %d", width, height));
+    LOG(LOG_LEVEL_TRACE, "rdpEglCaptureRfx: width %d height %d", width, height);
     crcs = g_new(int, (width / 64) * (height / 64));
     if (crcs == NULL)
     {
@@ -769,25 +769,25 @@ rdpEglCaptureRfx(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
                 }
                 else
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
+                    LOG(LOG_LEVEL_INFO, "rdpEglCaptureRfx: CreatePixmap failed");
                 }
                 pScreen->DestroyPixmap(crc_pixmap);
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
+                LOG(LOG_LEVEL_INFO, "rdpEglCaptureRfx: CreatePixmap failed");
             }
             pScreen->DestroyPixmap(pixmap);
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: CreatePixmap failed"));
+            LOG(LOG_LEVEL_INFO, "rdpEglCaptureRfx: CreatePixmap failed");
         }
         FreeScratchGC(rfxGC);
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpEglCaptureRfx: GetScratchGC failed"));
+        LOG(LOG_LEVEL_INFO, "rdpEglCaptureRfx: GetScratchGC failed");
     }
     free(crcs);
     return TRUE;

--- a/module/rdpFillPolygon.c
+++ b/module/rdpFillPolygon.c
@@ -74,7 +74,7 @@ rdpFillPolygon(DrawablePtr pDrawable, GCPtr pGC,
     int y;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillPolygon:"));
+    LOG(LOG_LEVEL_TRACE, "rdpFillPolygon:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpFillPolygonCallCount++;
     box.x1 = 0;
@@ -104,7 +104,7 @@ rdpFillPolygon(DrawablePtr pDrawable, GCPtr pGC,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillPolygon: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpFillPolygon: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpFillPolygon.c
+++ b/module/rdpFillPolygon.c
@@ -74,7 +74,7 @@ rdpFillPolygon(DrawablePtr pDrawable, GCPtr pGC,
     int y;
     BoxRec box;
 
-    LLOGLN(10, ("rdpFillPolygon:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillPolygon:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpFillPolygonCallCount++;
     box.x1 = 0;
@@ -104,7 +104,7 @@ rdpFillPolygon(DrawablePtr pDrawable, GCPtr pGC,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpFillPolygon: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillPolygon: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpFillSpans.c
+++ b/module/rdpFillSpans.c
@@ -57,7 +57,7 @@ void
 rdpFillSpans(DrawablePtr pDrawable, GCPtr pGC, int nInit,
              DDXPointPtr pptInit, int *pwidthInit, int fSorted)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillSpans:"));
+    LOG(LOG_LEVEL_TRACE, "rdpFillSpans:");
     /* do original call */
     rdpFillSpansOrg(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted);
 }

--- a/module/rdpFillSpans.c
+++ b/module/rdpFillSpans.c
@@ -57,7 +57,7 @@ void
 rdpFillSpans(DrawablePtr pDrawable, GCPtr pGC, int nInit,
              DDXPointPtr pptInit, int *pwidthInit, int fSorted)
 {
-    LLOGLN(10, ("rdpFillSpans:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpFillSpans:"));
     /* do original call */
     rdpFillSpansOrg(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted);
 }

--- a/module/rdpGC.c
+++ b/module/rdpGC.c
@@ -130,7 +130,7 @@ rdpValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr d)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpValidateGC:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpValidateGC:"));
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ValidateGC(pGC, changes, d);
     priv->ops = pGC->ops;
@@ -143,7 +143,7 @@ rdpChangeGC(GCPtr pGC, unsigned long mask)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpChangeGC:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpChangeGC:"));
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ChangeGC(pGC, mask);
     GC_FUNC_EPILOGUE(pGC);
@@ -155,7 +155,7 @@ rdpCopyGC(GCPtr src, unsigned long mask, GCPtr dst)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpCopyGC:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyGC:"));
     GC_FUNC_PROLOGUE(dst);
     dst->funcs->CopyGC(src, mask, dst);
     GC_FUNC_EPILOGUE(dst);
@@ -167,7 +167,7 @@ rdpDestroyGC(GCPtr pGC)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpDestroyGC:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyGC:"));
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->DestroyGC(pGC);
     GC_FUNC_EPILOGUE(pGC);
@@ -179,7 +179,7 @@ rdpChangeClip(GCPtr pGC, int type, pointer pValue, int nrects)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpChangeClip:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpChangeClip:"));
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ChangeClip(pGC, type, pValue, nrects);
     GC_FUNC_EPILOGUE(pGC);
@@ -191,7 +191,7 @@ rdpDestroyClip(GCPtr pGC)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpDestroyClip:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyClip:"));
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->DestroyClip(pGC);
     GC_FUNC_EPILOGUE(pGC);
@@ -203,7 +203,7 @@ rdpCopyClip(GCPtr dst, GCPtr src)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(10, ("rdpCopyClip:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyClip:"));
     GC_FUNC_PROLOGUE(dst);
     dst->funcs->CopyClip(dst, src);
     GC_FUNC_EPILOGUE(dst);
@@ -218,7 +218,7 @@ rdpCreateGC(GCPtr pGC)
     ScreenPtr pScreen;
     rdpGCPtr priv;
 
-    LLOGLN(10, ("rdpCreateGC:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateGC:"));
     pScreen = pGC->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     priv = (rdpGCPtr)rdpGetGCPrivate(pGC, dev->privateKeyRecGC);

--- a/module/rdpGC.c
+++ b/module/rdpGC.c
@@ -130,7 +130,7 @@ rdpValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr d)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpValidateGC:"));
+    LOG(LOG_LEVEL_TRACE, "rdpValidateGC:");
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ValidateGC(pGC, changes, d);
     priv->ops = pGC->ops;
@@ -143,7 +143,7 @@ rdpChangeGC(GCPtr pGC, unsigned long mask)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpChangeGC:"));
+    LOG(LOG_LEVEL_TRACE, "rdpChangeGC:");
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ChangeGC(pGC, mask);
     GC_FUNC_EPILOGUE(pGC);
@@ -155,7 +155,7 @@ rdpCopyGC(GCPtr src, unsigned long mask, GCPtr dst)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyGC:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyGC:");
     GC_FUNC_PROLOGUE(dst);
     dst->funcs->CopyGC(src, mask, dst);
     GC_FUNC_EPILOGUE(dst);
@@ -167,7 +167,7 @@ rdpDestroyGC(GCPtr pGC)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyGC:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDestroyGC:");
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->DestroyGC(pGC);
     GC_FUNC_EPILOGUE(pGC);
@@ -179,7 +179,7 @@ rdpChangeClip(GCPtr pGC, int type, pointer pValue, int nrects)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpChangeClip:"));
+    LOG(LOG_LEVEL_TRACE, "rdpChangeClip:");
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->ChangeClip(pGC, type, pValue, nrects);
     GC_FUNC_EPILOGUE(pGC);
@@ -191,7 +191,7 @@ rdpDestroyClip(GCPtr pGC)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyClip:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDestroyClip:");
     GC_FUNC_PROLOGUE(pGC);
     pGC->funcs->DestroyClip(pGC);
     GC_FUNC_EPILOGUE(pGC);
@@ -203,7 +203,7 @@ rdpCopyClip(GCPtr dst, GCPtr src)
 {
     GC_FUNC_VARS;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCopyClip:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCopyClip:");
     GC_FUNC_PROLOGUE(dst);
     dst->funcs->CopyClip(dst, src);
     GC_FUNC_EPILOGUE(dst);
@@ -218,7 +218,7 @@ rdpCreateGC(GCPtr pGC)
     ScreenPtr pScreen;
     rdpGCPtr priv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateGC:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCreateGC:");
     pScreen = pGC->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     priv = (rdpGCPtr)rdpGetGCPrivate(pGC, dev->privateKeyRecGC);

--- a/module/rdpGlyphs.c
+++ b/module/rdpGlyphs.c
@@ -95,7 +95,7 @@ rdpGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     rdpPtr dev;
     PictureScreenPtr ps;
 
-    LLOGLN(10, ("rdpGlyphs:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpGlyphs:"));
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     ps = GetPictureScreen(pScreen);

--- a/module/rdpGlyphs.c
+++ b/module/rdpGlyphs.c
@@ -95,7 +95,7 @@ rdpGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     rdpPtr dev;
     PictureScreenPtr ps;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpGlyphs:"));
+    LOG(LOG_LEVEL_TRACE, "rdpGlyphs:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     ps = GetPictureScreen(pScreen);

--- a/module/rdpImageGlyphBlt.c
+++ b/module/rdpImageGlyphBlt.c
@@ -67,14 +67,14 @@ rdpImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpImageGlyphBlt:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageGlyphBlt:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpImageGlyphBlt: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageGlyphBlt: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpImageGlyphBlt.c
+++ b/module/rdpImageGlyphBlt.c
@@ -67,14 +67,14 @@ rdpImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageGlyphBlt:"));
+    LOG(LOG_LEVEL_TRACE, "rdpImageGlyphBlt:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageGlyphBlt: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpImageGlyphBlt: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpImageText16.c
+++ b/module/rdpImageText16.c
@@ -65,14 +65,14 @@ rdpImageText16(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpImageText16:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText16:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageText16CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpImageText16: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText16: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpImageText16.c
+++ b/module/rdpImageText16.c
@@ -65,14 +65,14 @@ rdpImageText16(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText16:"));
+    LOG(LOG_LEVEL_TRACE, "rdpImageText16:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageText16CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText16: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpImageText16: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpImageText8.c
+++ b/module/rdpImageText8.c
@@ -65,14 +65,14 @@ rdpImageText8(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpImageText8:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText8:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageText8CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpImageText8: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText8: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpImageText8.c
+++ b/module/rdpImageText8.c
@@ -65,14 +65,14 @@ rdpImageText8(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText8:"));
+    LOG(LOG_LEVEL_TRACE, "rdpImageText8:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpImageText8CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpImageText8: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpImageText8: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -54,7 +54,7 @@ static struct input_proc_list g_input_proc[MAX_INPUT_PROC];
 int
 rdpRegisterInputCallback(int type, rdpInputEventProcPtr proc)
 {
-    LLOGLN(0, ("rdpRegisterInputCallback: type %d proc %p", type, proc));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRegisterInputCallback: type %d proc %p", type, proc));
     if (type == 0)
     {
         g_input_proc[0].proc = proc;
@@ -76,7 +76,7 @@ rdpUnregisterInputCallback(rdpInputEventProcPtr proc)
 {
     int index;
 
-    LLOGLN(0, ("rdpUnregisterInputCallback: proc %p", proc));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpUnregisterInputCallback: proc %p", proc));
     for (index = 0; index < MAX_INPUT_PROC; index++)
     {
         if (g_input_proc[index].proc == proc)

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -54,7 +54,7 @@ static struct input_proc_list g_input_proc[MAX_INPUT_PROC];
 int
 rdpRegisterInputCallback(int type, rdpInputEventProcPtr proc)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRegisterInputCallback: type %d proc %p", type, proc));
+    LOG(LOG_LEVEL_INFO, "rdpRegisterInputCallback: type %d proc %p", type, proc);
     if (type == 0)
     {
         g_input_proc[0].proc = proc;
@@ -76,7 +76,7 @@ rdpUnregisterInputCallback(rdpInputEventProcPtr proc)
 {
     int index;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpUnregisterInputCallback: proc %p", proc));
+    LOG(LOG_LEVEL_INFO, "rdpUnregisterInputCallback: proc %p", proc);
     for (index = 0; index < MAX_INPUT_PROC; index++)
     {
         if (g_input_proc[index].proc == proc)

--- a/module/rdpLRandR.c
+++ b/module/rdpLRandR.c
@@ -115,7 +115,7 @@ remove_client(ClientPtr pClient)
     {
         if (iterator->pClient == pClient)
         {
-            LLOGLN(10, ("remove_client:                      client %p found "
+            LLOGLN(LOG_LEVEL_TRACE, ("remove_client:                      client %p found "
                    "pClient, removing", pClient));
             xorg_list_del(&(iterator->entry));
             free(iterator);
@@ -132,7 +132,7 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     WindowPtr pRoot;
     WindowPtr pWin;
 
-    LLOGLN(10, ("LRRDeliverScreenEvent:              client %p", ic->pClient));
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverScreenEvent:              client %p", ic->pClient));
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -140,7 +140,7 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     }
     memset(&se, 0, sizeof(se));
     pRoot = pScreen->root;
-    LLOGLN(10, ("LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
            "width %d height %d",
            pRoot->drawable.id, ic->window,
            pScreen->width, pScreen->height));
@@ -166,13 +166,13 @@ LRRDeliverCrtcEvent(interestedClientRec *ic, LRRCrtcRec *pCrtc)
     xRRCrtcChangeNotifyEvent ce;
     WindowPtr pWin;
 
-    LLOGLN(10, ("LRRDeliverCrtcEvent:                client %p", ic->pClient));
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverCrtcEvent:                client %p", ic->pClient));
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
         return 1;
     }
-    LLOGLN(10, ("LRRDeliverCrtcEvent: x %d y %d width %d height %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverCrtcEvent: x %d y %d width %d height %d",
            pCrtc->x, pCrtc->y, pCrtc->width, pCrtc->height));
     memset(&ce, 0, sizeof(ce));
     ce.type = RRNotify + LRREventBase;
@@ -197,7 +197,7 @@ LRRDeliverOutputEvent(interestedClientRec *ic, LRROutputRec *pOutput)
     xRROutputChangeNotifyEvent oe;
     WindowPtr pWin;
 
-    LLOGLN(10, ("LRRDeliverOutputEvent:              client %p", ic->pClient));
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverOutputEvent:              client %p", ic->pClient));
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -233,7 +233,7 @@ ProcLRRQueryVersion(ClientPtr client)
     REQUEST(xRRQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRRQueryVersionReq);
-    LLOGLN(10, ("ProcLRRQueryVersion:                client %p version %d %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRQueryVersion:                client %p version %d %d",
            client, stuff->majorVersion, stuff->minorVersion));
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -253,13 +253,13 @@ ProcLRRQueryVersion(ClientPtr client)
     /* require 1.1 or greater randr client */
     if (version_compare(rep.majorVersion, rep.minorVersion, 1, 1) < 0)
     {
-        LLOGLN(0, ("ProcLRRQueryVersion: bad version"));
+        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRQueryVersion: bad version"));
         return BadValue;
     }
     /* don't allow swapping */
     if (client->swapped)
     {
-        LLOGLN(0, ("ProcLRRQueryVersion: no swap support"));
+        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRQueryVersion: no swap support"));
         return BadValue;
     }
     WriteToClient(client, sizeof(rep), &rep);
@@ -279,7 +279,7 @@ ProcLRRSelectInput(ClientPtr client)
     interestedClientRec* ic;
     REQUEST(xRRSelectInputReq);
 
-    LLOGLN(10, ("ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
            stuff->enable));
     REQUEST_SIZE_MATCH(xRRSelectInputReq);
 
@@ -303,7 +303,7 @@ ProcLRRSelectInput(ClientPtr client)
         ic->pClient = client;
         ic->mask = stuff->enable;
         ic->window = stuff->window;
-        LLOGLN(10, ("ProcLRRSelectInput:                 client %p adding "
+        LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSelectInput:                 client %p adding "
                "pClient to list", client));
         xorg_list_add(&(ic->entry), &g_interestedClients);
     }
@@ -314,7 +314,7 @@ ProcLRRSelectInput(ClientPtr client)
     }
     else
     {
-        LLOGLN(0, ("ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable));
+        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable));
         client->errorValue = stuff->enable;
         return BadValue;
     }
@@ -347,7 +347,7 @@ ProcLRRGetScreenInfo(ClientPtr client)
     CARD16 *rates;
     REQUEST(xRRGetScreenInfoReq);
 
-    LLOGLN(10, ("ProcLRRGetScreenInfo:               client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenInfo:               client %p", client));
     REQUEST_SIZE_MATCH(xRRGetScreenInfoReq);
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
@@ -408,7 +408,7 @@ ProcLRRGetScreenSizeRange(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetScreenSizeRange:          client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenSizeRange:          client %p", client));
     REQUEST_SIZE_MATCH(xRRGetScreenSizeRangeReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -446,7 +446,7 @@ ProcLRRGetScreenResources(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetScreenResources:          client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources:          client %p", client));
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -460,12 +460,12 @@ ProcLRRGetScreenResources(ClientPtr client)
     {
         rep.nbytesNames += g_modes[index].nameLength;
     }
-    LLOGLN(10, ("ProcLRRGetScreenResources: rep.nbytesNames %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: rep.nbytesNames %d",
            rep.nbytesNames));
     rep.length = (g_numCrtcs + g_numOutputs +
                   g_numModes * bytes_to_int32(SIZEOF(xRRModeInfo)) +
                   bytes_to_int32(rep.nbytesNames));
-    LLOGLN(10, ("ProcLRRGetScreenResources: rep.length %d", rep.length));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: rep.length %d", rep.length));
     extraLen = rep.length << 2;
     if (extraLen != 0)
     {
@@ -479,7 +479,7 @@ ProcLRRGetScreenResources(ClientPtr client)
     {
         extra = NULL;
     }
-    LLOGLN(10, ("ProcLRRGetScreenResources: extraLen %d", (int) extraLen));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: extraLen %d", (int) extraLen));
     crtcs = (RRCrtc *) extra;
     outputs = (RROutput *) (crtcs + g_numCrtcs);
     modeinfos = (xRRModeInfo *) (outputs + g_numOutputs);
@@ -539,7 +539,7 @@ ProcLRRGetOutputInfo(ClientPtr client)
     xRRGetOutputInfoReply rep;
     REQUEST(xRRGetOutputInfoReq);
 
-    LLOGLN(10, ("ProcLRRGetOutputInfo:               client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputInfo:               client %p", client));
     REQUEST_SIZE_MATCH(xRRGetOutputInfoReq);
 
     if ((stuff->output < LRROutputStart) ||
@@ -550,7 +550,7 @@ ProcLRRGetOutputInfo(ClientPtr client)
     output = g_outputs + (stuff->output - LRROutputStart);
 
     memset(&rep, 0, sizeof(rep));
-    LLOGLN(10, ("ProcLRRGetOutputInfo: stuff->output %d", stuff->output));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputInfo: stuff->output %d", stuff->output));
     rep.type = X_Reply;
     rep.status = RRSetConfigSuccess;
     rep.sequenceNumber = client->sequence;
@@ -616,7 +616,7 @@ ProcLRRListOutputProperties(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRListOutputProperties:        client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRListOutputProperties:        client %p", client));
     REQUEST_SIZE_MATCH(xRRListOutputPropertiesReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -640,7 +640,7 @@ ProcLRRQueryOutputProperty(ClientPtr client)
 {
     xRRQueryOutputPropertyReply rep;
 
-    LLOGLN(10, ("ProcLRRQueryOutputProperty:         client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRQueryOutputProperty:         client %p", client));
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;
@@ -670,7 +670,7 @@ ProcLRRGetOutputProperty(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetOutputProperty:           client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputProperty:           client %p", client));
     REQUEST_SIZE_MATCH(xRRGetOutputPropertyReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -702,7 +702,7 @@ ProcLRRGetCrtcInfo(ClientPtr client)
     xRRGetCrtcInfoReply rep;
     REQUEST(xRRGetCrtcInfoReq);
 
-    LLOGLN(10, ("ProcLRRGetCrtcInfo:                 client %p crtc %d", client, stuff->crtc));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcInfo:                 client %p crtc %d", client, stuff->crtc));
     REQUEST_SIZE_MATCH(xRRGetCrtcInfoReq);
 
     if ((stuff->crtc < LRRCrtcStart) ||
@@ -755,7 +755,7 @@ ProcLRRSetCrtcConfig(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRSetCrtcConfig:               client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSetCrtcConfig:               client %p", client));
     REQUEST_SIZE_MATCH(xRRSetCrtcConfigReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -782,7 +782,7 @@ ProcLRRGetCrtcGammaSize(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetCrtcGammaSize:            client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcGammaSize:            client %p", client));
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaSizeReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -813,7 +813,7 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetCrtcGamma:                client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcGamma:                client %p", client));
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaReq);
     len = 256 * 3 * 2;
     extra = (char *) malloc(len);
@@ -866,7 +866,7 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 int
 ProcLRRGetScreenResourcesCurrent(ClientPtr client)
 {
-    LLOGLN(10, ("ProcLRRGetScreenResourcesCurrent:   client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResourcesCurrent:   client %p", client));
     return ProcLRRGetScreenResources(client);
 }
 
@@ -892,7 +892,7 @@ ProcLRRGetCrtcTransform(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetCrtcTransform:            client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcTransform:            client %p", client));
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -923,7 +923,7 @@ ProcLRRGetPanning(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetPanning:                  client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetPanning:                  client %p", client));
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -949,7 +949,7 @@ ProcLRRGetOutputPrimary(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(10, ("ProcLRRGetOutputPrimary:            client %p", client));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputPrimary:            client %p", client));
     REQUEST_SIZE_MATCH(xRRGetOutputPrimaryReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -965,16 +965,16 @@ ProcLRRDispatch(ClientPtr client)
 {
     REQUEST(xReq);
 
-    LLOGLN(10, ("ProcLRRDispatch: data %d", stuff->data));
+    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRDispatch: data %d", stuff->data));
     if (stuff->data >= LRRNumberRequests)
     {
-        LLOGLN(0, ("ProcLRRDispatch: returning BadRequest, data %d",
+        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRDispatch: returning BadRequest, data %d",
                stuff->data));
         return BadRequest;
     }
     if (g_procLRandrVector[stuff->data] == NULL)
     {
-        LLOGLN(0, ("ProcLRRDispatch: returning Success, data %d",
+        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRDispatch: returning Success, data %d",
                stuff->data));
         return Success;
     }
@@ -985,7 +985,7 @@ ProcLRRDispatch(ClientPtr client)
 static int
 SProcLRRDispatch(ClientPtr client)
 {
-    LLOGLN(10, ("SProcLRRDispatch:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("SProcLRRDispatch:"));
     return 0;
 }
 
@@ -996,7 +996,7 @@ LRRClientCallback(CallbackListPtr *list, void *closure, void *data)
     NewClientInfoRec *clientinfo;
     ClientPtr pClient;
 
-    LLOGLN(10, ("LRRClientCallback: list %p closure %p data %p",
+    LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: list %p closure %p data %p",
            list, closure, data));
     if (data != NULL)
     {
@@ -1004,13 +1004,13 @@ LRRClientCallback(CallbackListPtr *list, void *closure, void *data)
         if (clientinfo->client != NULL)
         {
             pClient = clientinfo->client;
-            LLOGLN(10, ("LRRClientCallback: clientState %d clientGone %d",
+            LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: clientState %d clientGone %d",
                    pClient->clientState, pClient->clientGone));
             if (pClient->clientGone ||
                 (pClient->clientState == ClientStateRetained) ||
                 (pClient->clientState == ClientStateGone))
             {
-                LLOGLN(10, ("LRRClientCallback: client gone"));
+                LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: client gone"));
                 remove_client(pClient);
             }
         }
@@ -1024,13 +1024,13 @@ rdpLRRInit(rdpPtr dev)
     ExtensionEntry *extEntry;
     int index;
 
-    LLOGLN(10, ("rdpLRRInit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRInit:"));
     if (!AddCallback(&ClientStateCallback, LRRClientCallback, 0))
     {
-        LLOGLN(0, ("rdpLRRInit: AddCallback failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddCallback failed"));
         return 1;
     }
-    LLOGLN(0, ("rdpLRRInit: AddCallback ok"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddCallback ok"));
 
     extEntry = AddExtension(LRANDR_NAME,
                             LRRNumberEvents, LRRNumberErrors,
@@ -1038,10 +1038,10 @@ rdpLRRInit(rdpPtr dev)
                             NULL, StandardMinorOpcode);
     if (extEntry == NULL)
     {
-        LLOGLN(0, ("rdpLRRInit: AddExtension failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddExtension failed"));
         return 1;
     }
-    LLOGLN(0, ("rdpLRRInit: AddExtension ok"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddExtension ok"));
 
     LRRErrorBase = extEntry->errorBase;
     LRREventBase = extEntry->eventBase;
@@ -1133,14 +1133,14 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     int count;
     int cont;
 
-    LLOGLN(10, ("rdpLRRSetRdpOutputs: numCrtcs %d numOutputs %d "
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs: numCrtcs %d numOutputs %d "
            "monitorCount %d",
            g_numCrtcs, g_numOutputs, dev->monitorCount));
     LRRSendConfigNotify(dev->pScreen);
     g_primaryOutput = None;
     width = dev->width;
     height = dev->height;
-    LLOGLN(10, ("rdpLRRSetRdpOutputs: width %d height %d", width, height));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs: width %d height %d", width, height));
     if (dev->monitorCount <= 0)
     {
         g_numCrtcs = 1;
@@ -1195,13 +1195,13 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     xorg_list_for_each_entry_safe(iterator, next, &g_interestedClients, entry)
     {
         cont = 0;
-        LLOGLN(10, ("rdpLRRSetRdpOutputs:                client %p",
+        LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs:                client %p",
                iterator->pClient));
         if (iterator->mask & RRScreenChangeNotifyMask)
         {
             if (LRRDeliverScreenEvent(iterator, dev->pScreen) != 0)
             {
-                LLOGLN(0, ("rdpLRRSetRdpOutputs: error removing from "
+                LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
                        "interested list"));
                 xorg_list_del(&(iterator->entry));
                 free(iterator);
@@ -1214,7 +1214,7 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverCrtcEvent(iterator, g_crtcs + index) != 0)
                 {
-                    LLOGLN(0, ("rdpLRRSetRdpOutputs: error removing from "
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
                            "interested list"));
                     xorg_list_del(&(iterator->entry));
                     free(iterator);
@@ -1233,7 +1233,7 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverOutputEvent(iterator, g_outputs + index) != 0)
                 {
-                    LLOGLN(0, ("rdpLRRSetRdpOutputs: error removing from "
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
                            "interested list"));
                     xorg_list_del(&(iterator->entry));
                     free(iterator);

--- a/module/rdpLRandR.c
+++ b/module/rdpLRandR.c
@@ -115,8 +115,9 @@ remove_client(ClientPtr pClient)
     {
         if (iterator->pClient == pClient)
         {
-            LOG(LOG_LEVEL_TRACE, "remove_client:                      client %p found "
-                   "pClient, removing", pClient);
+            LOG(LOG_LEVEL_TRACE,
+                "remove_client:                      client %p found "
+                "pClient, removing", pClient);
             xorg_list_del(&(iterator->entry));
             free(iterator);
         }
@@ -132,7 +133,8 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     WindowPtr pRoot;
     WindowPtr pWin;
 
-    LOG(LOG_LEVEL_TRACE, "LRRDeliverScreenEvent:              client %p", ic->pClient);
+    LOG(LOG_LEVEL_TRACE,
+        "LRRDeliverScreenEvent:              client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -140,10 +142,11 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     }
     memset(&se, 0, sizeof(se));
     pRoot = pScreen->root;
-    LOG(LOG_LEVEL_TRACE, "LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
-           "width %d height %d",
-           pRoot->drawable.id, ic->window,
-           pScreen->width, pScreen->height);
+    LOG(LOG_LEVEL_TRACE,
+        "LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
+        "width %d height %d",
+        pRoot->drawable.id, ic->window,
+        pScreen->width, pScreen->height);
     se.type = RRScreenChangeNotify + LRREventBase;
     se.rotation = RR_Rotate_0;
     se.timestamp = g_updateTime;
@@ -166,14 +169,15 @@ LRRDeliverCrtcEvent(interestedClientRec *ic, LRRCrtcRec *pCrtc)
     xRRCrtcChangeNotifyEvent ce;
     WindowPtr pWin;
 
-    LOG(LOG_LEVEL_TRACE, "LRRDeliverCrtcEvent:                client %p", ic->pClient);
+    LOG(LOG_LEVEL_TRACE,
+        "LRRDeliverCrtcEvent:                client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
         return 1;
     }
     LOG(LOG_LEVEL_TRACE, "LRRDeliverCrtcEvent: x %d y %d width %d height %d",
-           pCrtc->x, pCrtc->y, pCrtc->width, pCrtc->height);
+        pCrtc->x, pCrtc->y, pCrtc->width, pCrtc->height);
     memset(&ce, 0, sizeof(ce));
     ce.type = RRNotify + LRREventBase;
     ce.subCode = RRNotify_CrtcChange;
@@ -197,7 +201,8 @@ LRRDeliverOutputEvent(interestedClientRec *ic, LRROutputRec *pOutput)
     xRROutputChangeNotifyEvent oe;
     WindowPtr pWin;
 
-    LOG(LOG_LEVEL_TRACE, "LRRDeliverOutputEvent:              client %p", ic->pClient);
+    LOG(LOG_LEVEL_TRACE,
+        "LRRDeliverOutputEvent:              client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -233,8 +238,9 @@ ProcLRRQueryVersion(ClientPtr client)
     REQUEST(xRRQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRRQueryVersionReq);
-    LOG(LOG_LEVEL_TRACE, "ProcLRRQueryVersion:                client %p version %d %d",
-           client, stuff->majorVersion, stuff->minorVersion);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRQueryVersion:                client %p version %d %d",
+        client, stuff->majorVersion, stuff->minorVersion);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;
@@ -279,8 +285,9 @@ ProcLRRSelectInput(ClientPtr client)
     interestedClientRec* ic;
     REQUEST(xRRSelectInputReq);
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
-           stuff->enable);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
+        stuff->enable);
     REQUEST_SIZE_MATCH(xRRSelectInputReq);
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -303,8 +310,9 @@ ProcLRRSelectInput(ClientPtr client)
         ic->pClient = client;
         ic->mask = stuff->enable;
         ic->window = stuff->window;
-        LOG(LOG_LEVEL_TRACE, "ProcLRRSelectInput:                 client %p adding "
-               "pClient to list", client);
+        LOG(LOG_LEVEL_TRACE,
+            "ProcLRRSelectInput:                 client %p adding "
+            "pClient to list", client);
         xorg_list_add(&(ic->entry), &g_interestedClients);
     }
     else if (stuff->enable == 0)
@@ -314,7 +322,8 @@ ProcLRRSelectInput(ClientPtr client)
     }
     else
     {
-        LOG(LOG_LEVEL_INFO, "ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable);
+        LOG(LOG_LEVEL_INFO,
+            "ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable);
         client->errorValue = stuff->enable;
         return BadValue;
     }
@@ -461,7 +470,7 @@ ProcLRRGetScreenResources(ClientPtr client)
         rep.nbytesNames += g_modes[index].nameLength;
     }
     LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResources: rep.nbytesNames %d",
-           rep.nbytesNames);
+        rep.nbytesNames);
     rep.length = (g_numCrtcs + g_numOutputs +
                   g_numModes * bytes_to_int32(SIZEOF(xRRModeInfo)) +
                   bytes_to_int32(rep.nbytesNames));
@@ -702,7 +711,9 @@ ProcLRRGetCrtcInfo(ClientPtr client)
     xRRGetCrtcInfoReply rep;
     REQUEST(xRRGetCrtcInfoReq);
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcInfo:                 client %p crtc %d", client, stuff->crtc);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetCrtcInfo:                 client %p crtc %d",
+        client, stuff->crtc);
     REQUEST_SIZE_MATCH(xRRGetCrtcInfoReq);
 
     if ((stuff->crtc < LRRCrtcStart) ||
@@ -755,7 +766,8 @@ ProcLRRSetCrtcConfig(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRSetCrtcConfig:               client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRSetCrtcConfig:               client %p", client);
     REQUEST_SIZE_MATCH(xRRSetCrtcConfigReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -782,7 +794,8 @@ ProcLRRGetCrtcGammaSize(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcGammaSize:            client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetCrtcGammaSize:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaSizeReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -813,7 +826,8 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcGamma:                client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetCrtcGamma:                client %p", client);
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaReq);
     len = 256 * 3 * 2;
     extra = (char *) malloc(len);
@@ -866,7 +880,8 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 int
 ProcLRRGetScreenResourcesCurrent(ClientPtr client)
 {
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResourcesCurrent:   client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetScreenResourcesCurrent:   client %p", client);
     return ProcLRRGetScreenResources(client);
 }
 
@@ -892,7 +907,8 @@ ProcLRRGetCrtcTransform(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcTransform:            client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetCrtcTransform:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -923,7 +939,8 @@ ProcLRRGetPanning(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetPanning:                  client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetPanning:                  client %p", client);
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -949,7 +966,8 @@ ProcLRRGetOutputPrimary(ClientPtr client)
 
     (void) stuff;
 
-    LOG(LOG_LEVEL_TRACE, "ProcLRRGetOutputPrimary:            client %p", client);
+    LOG(LOG_LEVEL_TRACE,
+        "ProcLRRGetOutputPrimary:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetOutputPrimaryReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -969,13 +987,13 @@ ProcLRRDispatch(ClientPtr client)
     if (stuff->data >= LRRNumberRequests)
     {
         LOG(LOG_LEVEL_INFO, "ProcLRRDispatch: returning BadRequest, data %d",
-               stuff->data);
+            stuff->data);
         return BadRequest;
     }
     if (g_procLRandrVector[stuff->data] == NULL)
     {
         LOG(LOG_LEVEL_INFO, "ProcLRRDispatch: returning Success, data %d",
-               stuff->data);
+            stuff->data);
         return Success;
     }
     return g_procLRandrVector[stuff->data](client);
@@ -997,7 +1015,7 @@ LRRClientCallback(CallbackListPtr *list, void *closure, void *data)
     ClientPtr pClient;
 
     LOG(LOG_LEVEL_TRACE, "LRRClientCallback: list %p closure %p data %p",
-           list, closure, data);
+        list, closure, data);
     if (data != NULL)
     {
         clientinfo = (NewClientInfoRec *) data;
@@ -1005,7 +1023,7 @@ LRRClientCallback(CallbackListPtr *list, void *closure, void *data)
         {
             pClient = clientinfo->client;
             LOG(LOG_LEVEL_TRACE, "LRRClientCallback: clientState %d clientGone %d",
-                   pClient->clientState, pClient->clientGone);
+                pClient->clientState, pClient->clientGone);
             if (pClient->clientGone ||
                 (pClient->clientState == ClientStateRetained) ||
                 (pClient->clientState == ClientStateGone))
@@ -1134,13 +1152,14 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     int cont;
 
     LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs: numCrtcs %d numOutputs %d "
-           "monitorCount %d",
-           g_numCrtcs, g_numOutputs, dev->monitorCount);
+        "monitorCount %d",
+        g_numCrtcs, g_numOutputs, dev->monitorCount);
     LRRSendConfigNotify(dev->pScreen);
     g_primaryOutput = None;
     width = dev->width;
     height = dev->height;
-    LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs: width %d height %d", width, height);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpLRRSetRdpOutputs: width %d height %d", width, height);
     if (dev->monitorCount <= 0)
     {
         g_numCrtcs = 1;
@@ -1196,13 +1215,13 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     {
         cont = 0;
         LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs:                client %p",
-               iterator->pClient);
+            iterator->pClient);
         if (iterator->mask & RRScreenChangeNotifyMask)
         {
             if (LRRDeliverScreenEvent(iterator, dev->pScreen) != 0)
             {
                 LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
-                       "interested list");
+                    "interested list");
                 xorg_list_del(&(iterator->entry));
                 free(iterator);
                 continue;
@@ -1214,8 +1233,9 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverCrtcEvent(iterator, g_crtcs + index) != 0)
                 {
-                    LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
-                           "interested list");
+                    LOG(LOG_LEVEL_INFO,
+                        "rdpLRRSetRdpOutputs: error removing from "
+                        "interested list");
                     xorg_list_del(&(iterator->entry));
                     free(iterator);
                     cont = 1;
@@ -1233,8 +1253,9 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverOutputEvent(iterator, g_outputs + index) != 0)
                 {
-                    LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
-                           "interested list");
+                    LOG(LOG_LEVEL_INFO,
+                        "rdpLRRSetRdpOutputs: error removing from "
+                        "interested list");
                     xorg_list_del(&(iterator->entry));
                     free(iterator);
                     cont = 1;

--- a/module/rdpLRandR.c
+++ b/module/rdpLRandR.c
@@ -115,8 +115,8 @@ remove_client(ClientPtr pClient)
     {
         if (iterator->pClient == pClient)
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("remove_client:                      client %p found "
-                   "pClient, removing", pClient));
+            LOG(LOG_LEVEL_TRACE, "remove_client:                      client %p found "
+                   "pClient, removing", pClient);
             xorg_list_del(&(iterator->entry));
             free(iterator);
         }
@@ -132,7 +132,7 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     WindowPtr pRoot;
     WindowPtr pWin;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverScreenEvent:              client %p", ic->pClient));
+    LOG(LOG_LEVEL_TRACE, "LRRDeliverScreenEvent:              client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -140,10 +140,10 @@ LRRDeliverScreenEvent(interestedClientRec *ic, ScreenPtr pScreen)
     }
     memset(&se, 0, sizeof(se));
     pRoot = pScreen->root;
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
+    LOG(LOG_LEVEL_TRACE, "LRRDeliverScreenEvent: root id 0x%8.8x win id 0x%8.8x "
            "width %d height %d",
            pRoot->drawable.id, ic->window,
-           pScreen->width, pScreen->height));
+           pScreen->width, pScreen->height);
     se.type = RRScreenChangeNotify + LRREventBase;
     se.rotation = RR_Rotate_0;
     se.timestamp = g_updateTime;
@@ -166,14 +166,14 @@ LRRDeliverCrtcEvent(interestedClientRec *ic, LRRCrtcRec *pCrtc)
     xRRCrtcChangeNotifyEvent ce;
     WindowPtr pWin;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverCrtcEvent:                client %p", ic->pClient));
+    LOG(LOG_LEVEL_TRACE, "LRRDeliverCrtcEvent:                client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
         return 1;
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverCrtcEvent: x %d y %d width %d height %d",
-           pCrtc->x, pCrtc->y, pCrtc->width, pCrtc->height));
+    LOG(LOG_LEVEL_TRACE, "LRRDeliverCrtcEvent: x %d y %d width %d height %d",
+           pCrtc->x, pCrtc->y, pCrtc->width, pCrtc->height);
     memset(&ce, 0, sizeof(ce));
     ce.type = RRNotify + LRREventBase;
     ce.subCode = RRNotify_CrtcChange;
@@ -197,7 +197,7 @@ LRRDeliverOutputEvent(interestedClientRec *ic, LRROutputRec *pOutput)
     xRROutputChangeNotifyEvent oe;
     WindowPtr pWin;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRDeliverOutputEvent:              client %p", ic->pClient));
+    LOG(LOG_LEVEL_TRACE, "LRRDeliverOutputEvent:              client %p", ic->pClient);
     if (dixLookupWindow(&pWin, ic->window, ic->pClient,
                         DixGetAttrAccess) != Success)
     {
@@ -233,8 +233,8 @@ ProcLRRQueryVersion(ClientPtr client)
     REQUEST(xRRQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRRQueryVersionReq);
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRQueryVersion:                client %p version %d %d",
-           client, stuff->majorVersion, stuff->minorVersion));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRQueryVersion:                client %p version %d %d",
+           client, stuff->majorVersion, stuff->minorVersion);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;
@@ -253,13 +253,13 @@ ProcLRRQueryVersion(ClientPtr client)
     /* require 1.1 or greater randr client */
     if (version_compare(rep.majorVersion, rep.minorVersion, 1, 1) < 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRQueryVersion: bad version"));
+        LOG(LOG_LEVEL_INFO, "ProcLRRQueryVersion: bad version");
         return BadValue;
     }
     /* don't allow swapping */
     if (client->swapped)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRQueryVersion: no swap support"));
+        LOG(LOG_LEVEL_INFO, "ProcLRRQueryVersion: no swap support");
         return BadValue;
     }
     WriteToClient(client, sizeof(rep), &rep);
@@ -279,8 +279,8 @@ ProcLRRSelectInput(ClientPtr client)
     interestedClientRec* ic;
     REQUEST(xRRSelectInputReq);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
-           stuff->enable));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRSelectInput:                 client %p enable 0x%8.8x", client,
+           stuff->enable);
     REQUEST_SIZE_MATCH(xRRSelectInputReq);
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -303,8 +303,8 @@ ProcLRRSelectInput(ClientPtr client)
         ic->pClient = client;
         ic->mask = stuff->enable;
         ic->window = stuff->window;
-        LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSelectInput:                 client %p adding "
-               "pClient to list", client));
+        LOG(LOG_LEVEL_TRACE, "ProcLRRSelectInput:                 client %p adding "
+               "pClient to list", client);
         xorg_list_add(&(ic->entry), &g_interestedClients);
     }
     else if (stuff->enable == 0)
@@ -314,7 +314,7 @@ ProcLRRSelectInput(ClientPtr client)
     }
     else
     {
-        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable));
+        LOG(LOG_LEVEL_INFO, "ProcLRRSelectInput: bad enable 0x%8.8x", stuff->enable);
         client->errorValue = stuff->enable;
         return BadValue;
     }
@@ -347,7 +347,7 @@ ProcLRRGetScreenInfo(ClientPtr client)
     CARD16 *rates;
     REQUEST(xRRGetScreenInfoReq);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenInfo:               client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenInfo:               client %p", client);
     REQUEST_SIZE_MATCH(xRRGetScreenInfoReq);
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
@@ -408,7 +408,7 @@ ProcLRRGetScreenSizeRange(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenSizeRange:          client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenSizeRange:          client %p", client);
     REQUEST_SIZE_MATCH(xRRGetScreenSizeRangeReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -446,7 +446,7 @@ ProcLRRGetScreenResources(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources:          client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResources:          client %p", client);
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -460,12 +460,12 @@ ProcLRRGetScreenResources(ClientPtr client)
     {
         rep.nbytesNames += g_modes[index].nameLength;
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: rep.nbytesNames %d",
-           rep.nbytesNames));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResources: rep.nbytesNames %d",
+           rep.nbytesNames);
     rep.length = (g_numCrtcs + g_numOutputs +
                   g_numModes * bytes_to_int32(SIZEOF(xRRModeInfo)) +
                   bytes_to_int32(rep.nbytesNames));
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: rep.length %d", rep.length));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResources: rep.length %d", rep.length);
     extraLen = rep.length << 2;
     if (extraLen != 0)
     {
@@ -479,7 +479,7 @@ ProcLRRGetScreenResources(ClientPtr client)
     {
         extra = NULL;
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResources: extraLen %d", (int) extraLen));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResources: extraLen %d", (int) extraLen);
     crtcs = (RRCrtc *) extra;
     outputs = (RROutput *) (crtcs + g_numCrtcs);
     modeinfos = (xRRModeInfo *) (outputs + g_numOutputs);
@@ -539,7 +539,7 @@ ProcLRRGetOutputInfo(ClientPtr client)
     xRRGetOutputInfoReply rep;
     REQUEST(xRRGetOutputInfoReq);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputInfo:               client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetOutputInfo:               client %p", client);
     REQUEST_SIZE_MATCH(xRRGetOutputInfoReq);
 
     if ((stuff->output < LRROutputStart) ||
@@ -550,7 +550,7 @@ ProcLRRGetOutputInfo(ClientPtr client)
     output = g_outputs + (stuff->output - LRROutputStart);
 
     memset(&rep, 0, sizeof(rep));
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputInfo: stuff->output %d", stuff->output));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetOutputInfo: stuff->output %d", stuff->output);
     rep.type = X_Reply;
     rep.status = RRSetConfigSuccess;
     rep.sequenceNumber = client->sequence;
@@ -616,7 +616,7 @@ ProcLRRListOutputProperties(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRListOutputProperties:        client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRListOutputProperties:        client %p", client);
     REQUEST_SIZE_MATCH(xRRListOutputPropertiesReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -640,7 +640,7 @@ ProcLRRQueryOutputProperty(ClientPtr client)
 {
     xRRQueryOutputPropertyReply rep;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRQueryOutputProperty:         client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRQueryOutputProperty:         client %p", client);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;
@@ -670,7 +670,7 @@ ProcLRRGetOutputProperty(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputProperty:           client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetOutputProperty:           client %p", client);
     REQUEST_SIZE_MATCH(xRRGetOutputPropertyReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -702,7 +702,7 @@ ProcLRRGetCrtcInfo(ClientPtr client)
     xRRGetCrtcInfoReply rep;
     REQUEST(xRRGetCrtcInfoReq);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcInfo:                 client %p crtc %d", client, stuff->crtc));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcInfo:                 client %p crtc %d", client, stuff->crtc);
     REQUEST_SIZE_MATCH(xRRGetCrtcInfoReq);
 
     if ((stuff->crtc < LRRCrtcStart) ||
@@ -755,7 +755,7 @@ ProcLRRSetCrtcConfig(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRSetCrtcConfig:               client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRSetCrtcConfig:               client %p", client);
     REQUEST_SIZE_MATCH(xRRSetCrtcConfigReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -782,7 +782,7 @@ ProcLRRGetCrtcGammaSize(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcGammaSize:            client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcGammaSize:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaSizeReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -813,7 +813,7 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcGamma:                client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcGamma:                client %p", client);
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaReq);
     len = 256 * 3 * 2;
     extra = (char *) malloc(len);
@@ -866,7 +866,7 @@ ProcLRRGetCrtcGamma(ClientPtr client)
 int
 ProcLRRGetScreenResourcesCurrent(ClientPtr client)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetScreenResourcesCurrent:   client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetScreenResourcesCurrent:   client %p", client);
     return ProcLRRGetScreenResources(client);
 }
 
@@ -892,7 +892,7 @@ ProcLRRGetCrtcTransform(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetCrtcTransform:            client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetCrtcTransform:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -923,7 +923,7 @@ ProcLRRGetPanning(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetPanning:                  client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetPanning:                  client %p", client);
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -949,7 +949,7 @@ ProcLRRGetOutputPrimary(ClientPtr client)
 
     (void) stuff;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRGetOutputPrimary:            client %p", client));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRGetOutputPrimary:            client %p", client);
     REQUEST_SIZE_MATCH(xRRGetOutputPrimaryReq);
     memset(&rep, 0, sizeof(rep));
     rep.type = X_Reply;
@@ -965,17 +965,17 @@ ProcLRRDispatch(ClientPtr client)
 {
     REQUEST(xReq);
 
-    LLOGLN(LOG_LEVEL_TRACE, ("ProcLRRDispatch: data %d", stuff->data));
+    LOG(LOG_LEVEL_TRACE, "ProcLRRDispatch: data %d", stuff->data);
     if (stuff->data >= LRRNumberRequests)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRDispatch: returning BadRequest, data %d",
-               stuff->data));
+        LOG(LOG_LEVEL_INFO, "ProcLRRDispatch: returning BadRequest, data %d",
+               stuff->data);
         return BadRequest;
     }
     if (g_procLRandrVector[stuff->data] == NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("ProcLRRDispatch: returning Success, data %d",
-               stuff->data));
+        LOG(LOG_LEVEL_INFO, "ProcLRRDispatch: returning Success, data %d",
+               stuff->data);
         return Success;
     }
     return g_procLRandrVector[stuff->data](client);
@@ -985,7 +985,7 @@ ProcLRRDispatch(ClientPtr client)
 static int
 SProcLRRDispatch(ClientPtr client)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("SProcLRRDispatch:"));
+    LOG(LOG_LEVEL_TRACE, "SProcLRRDispatch:");
     return 0;
 }
 
@@ -996,21 +996,21 @@ LRRClientCallback(CallbackListPtr *list, void *closure, void *data)
     NewClientInfoRec *clientinfo;
     ClientPtr pClient;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: list %p closure %p data %p",
-           list, closure, data));
+    LOG(LOG_LEVEL_TRACE, "LRRClientCallback: list %p closure %p data %p",
+           list, closure, data);
     if (data != NULL)
     {
         clientinfo = (NewClientInfoRec *) data;
         if (clientinfo->client != NULL)
         {
             pClient = clientinfo->client;
-            LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: clientState %d clientGone %d",
-                   pClient->clientState, pClient->clientGone));
+            LOG(LOG_LEVEL_TRACE, "LRRClientCallback: clientState %d clientGone %d",
+                   pClient->clientState, pClient->clientGone);
             if (pClient->clientGone ||
                 (pClient->clientState == ClientStateRetained) ||
                 (pClient->clientState == ClientStateGone))
             {
-                LLOGLN(LOG_LEVEL_TRACE, ("LRRClientCallback: client gone"));
+                LOG(LOG_LEVEL_TRACE, "LRRClientCallback: client gone");
                 remove_client(pClient);
             }
         }
@@ -1024,13 +1024,13 @@ rdpLRRInit(rdpPtr dev)
     ExtensionEntry *extEntry;
     int index;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRInit:"));
+    LOG(LOG_LEVEL_TRACE, "rdpLRRInit:");
     if (!AddCallback(&ClientStateCallback, LRRClientCallback, 0))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddCallback failed"));
+        LOG(LOG_LEVEL_INFO, "rdpLRRInit: AddCallback failed");
         return 1;
     }
-    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddCallback ok"));
+    LOG(LOG_LEVEL_INFO, "rdpLRRInit: AddCallback ok");
 
     extEntry = AddExtension(LRANDR_NAME,
                             LRRNumberEvents, LRRNumberErrors,
@@ -1038,10 +1038,10 @@ rdpLRRInit(rdpPtr dev)
                             NULL, StandardMinorOpcode);
     if (extEntry == NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddExtension failed"));
+        LOG(LOG_LEVEL_INFO, "rdpLRRInit: AddExtension failed");
         return 1;
     }
-    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRInit: AddExtension ok"));
+    LOG(LOG_LEVEL_INFO, "rdpLRRInit: AddExtension ok");
 
     LRRErrorBase = extEntry->errorBase;
     LRREventBase = extEntry->eventBase;
@@ -1133,14 +1133,14 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     int count;
     int cont;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs: numCrtcs %d numOutputs %d "
+    LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs: numCrtcs %d numOutputs %d "
            "monitorCount %d",
-           g_numCrtcs, g_numOutputs, dev->monitorCount));
+           g_numCrtcs, g_numOutputs, dev->monitorCount);
     LRRSendConfigNotify(dev->pScreen);
     g_primaryOutput = None;
     width = dev->width;
     height = dev->height;
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs: width %d height %d", width, height));
+    LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs: width %d height %d", width, height);
     if (dev->monitorCount <= 0)
     {
         g_numCrtcs = 1;
@@ -1195,14 +1195,14 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
     xorg_list_for_each_entry_safe(iterator, next, &g_interestedClients, entry)
     {
         cont = 0;
-        LLOGLN(LOG_LEVEL_TRACE, ("rdpLRRSetRdpOutputs:                client %p",
-               iterator->pClient));
+        LOG(LOG_LEVEL_TRACE, "rdpLRRSetRdpOutputs:                client %p",
+               iterator->pClient);
         if (iterator->mask & RRScreenChangeNotifyMask)
         {
             if (LRRDeliverScreenEvent(iterator, dev->pScreen) != 0)
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
-                       "interested list"));
+                LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
+                       "interested list");
                 xorg_list_del(&(iterator->entry));
                 free(iterator);
                 continue;
@@ -1214,8 +1214,8 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverCrtcEvent(iterator, g_crtcs + index) != 0)
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
-                           "interested list"));
+                    LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
+                           "interested list");
                     xorg_list_del(&(iterator->entry));
                     free(iterator);
                     cont = 1;
@@ -1233,8 +1233,8 @@ rdpLRRSetRdpOutputs(rdpPtr dev)
             {
                 if (LRRDeliverOutputEvent(iterator, g_outputs + index) != 0)
                 {
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpLRRSetRdpOutputs: error removing from "
-                           "interested list"));
+                    LOG(LOG_LEVEL_INFO, "rdpLRRSetRdpOutputs: error removing from "
+                           "interested list");
                     xorg_list_del(&(iterator->entry));
                     free(iterator);
                     cont = 1;

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -100,7 +100,7 @@ xorgxrdpPreInit(ScrnInfoPtr pScrn, int flags)
     Bool rv;
     const char *env;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPreInit:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpPreInit:");
     env = getenv("XRDP_NVIDIA_GRID");
     if (env != NULL)
     {
@@ -160,7 +160,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateScreenResources:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCreateScreenResources:");
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -188,7 +188,7 @@ xorgxrdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     rdpPtr dev;
     rrScrPrivPtr pRRScrPriv;
 
-    LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpRRScreenSetSize: width %d height %d", width, height));
+    LOG(LOG_LEVEL_INFO, "xorgxrdpRRScreenSetSize: width %d height %d", width, height);
     dev = rdpGetDevFromScreen(pScreen);
 
     pRRScrPriv = rrGetScrPriv(pScreen);
@@ -208,9 +208,9 @@ xorgxrdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     dev->paddedWidthInBytes = dev->screenSwPixmap->devKind;
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
-    LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpRRScreenSetSize: screenInfo x %d y %d "
+    LOG(LOG_LEVEL_INFO, "xorgxrdpRRScreenSetSize: screenInfo x %d y %d "
            "width %d height %d", screenInfo.x, screenInfo.y,
-           screenInfo.width, screenInfo.height));
+           screenInfo.width, screenInfo.height);
 
     return rv;
 }
@@ -222,7 +222,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageReport:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDamageReport:");
     pScreen = (ScreenPtr)closure;
     dev = rdpGetDevFromScreen(pScreen);
     rdpClientConAddAllReg(dev, pRegion, &(pScreen->root->drawable));
@@ -232,7 +232,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageDestroy:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDamageDestroy:");
 }
 
 #ifdef XACE_DISABLE_DRI3_PRESENT
@@ -241,16 +241,16 @@ static void
 xorgxrdpExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
     XaceExtAccessRec *rec = calldata;
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpExtension:"));
-    LLOGLN(LOG_LEVEL_TRACE, ("  name %s", rec->ext->name));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpExtension:");
+    LOG(LOG_LEVEL_TRACE, "  name %s", rec->ext->name);
     if (strcmp(rec->ext->name, "DRI3") == 0)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("  disabling name %s", rec->ext->name));
+        LOG(LOG_LEVEL_TRACE, "  disabling name %s", rec->ext->name);
         rec->status = BadValue;
     }
     if (strcmp(rec->ext->name, "Present") == 0)
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("  disabling name %s", rec->ext->name));
+        LOG(LOG_LEVEL_TRACE, "  disabling name %s", rec->ext->name);
         rec->status = BadValue;
     }
 }
@@ -264,7 +264,7 @@ xorgxrdpDeferredStartup(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDeferredStartup:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDeferredStartup:");
     pScreen = (ScreenPtr)arg;
     if (pScreen->root != NULL)
     {
@@ -282,7 +282,7 @@ xorgxrdpDeferredStartup(OsTimerPtr timer, CARD32 now, pointer arg)
         {
             DamageSetReportAfterOp(dev->damage, TRUE);
             DamageRegister(&(pScreen->root->drawable), dev->damage);
-            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpSetupDamage: DamageRegister ok"));
+            LOG(LOG_LEVEL_INFO, "xorgxrdpSetupDamage: DamageRegister ok");
             TimerFree(g_timer);
             g_timer = NULL;
 #ifdef XACE_DISABLE_DRI3_PRESENT
@@ -309,7 +309,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
     miPointerScreenPtr PointPriv;
     rrScrPrivPtr pRRScrPriv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpScreenInit:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpScreenInit:");
     rv = g_orgScreenInit(pScreen, argc, argv);
     if (rv)
     {
@@ -317,7 +317,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev = XRDPPTR(pScrn);
         dev->nvidia = TRUE;
         dev->nvidia_grid = g_nvidia_grid;
-        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: nvidia_grid %d", dev->nvidia_grid));
+        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: nvidia_grid %d", dev->nvidia_grid);
         dev->pScreen = pScreen;
         dev->depth = pScrn->depth;
         dev->width = pScrn->virtualX;
@@ -326,7 +326,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
         dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
-        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: width %d height %d", dev->width, dev->height));
+        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: width %d height %d", dev->width, dev->height);
 
         PointPriv = dixLookupPrivate(&pScreen->devPrivates, miPointerScreenKey);
         PointPriv->spriteFuncs = &g_rdpSpritePointerFuncs;
@@ -379,7 +379,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
 
         if (rdpClientConInit(dev) != 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: rdpClientConInit failed"));
+            LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: rdpClientConInit failed");
         }
 
         dev->Bpp_mask = 0x00FFFFFF;
@@ -427,12 +427,12 @@ xorgxrdpWrapPreIntScreenInit(Bool ok)
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpWrapPreIntScreenInit: error"));
+                LOG(LOG_LEVEL_INFO, "xorgxrdpWrapPreIntScreenInit: error");
             }
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpWrapPreIntScreenInit: error"));
+            LOG(LOG_LEVEL_INFO, "xorgxrdpWrapPreIntScreenInit: error");
         }
     }
     return ok;
@@ -445,7 +445,7 @@ xorgxrdpPciProbe(struct _DriverRec * drv, int entity_num,
 {
     Bool rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPciProbe:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpPciProbe:");
     rv = g_saved_driver.PciProbe(drv, entity_num, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -457,7 +457,7 @@ xorgxrdpPlatformProbe(struct _DriverRec * drv, int entity_num, int flags,
 {
     Bool rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPlatformProbe:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpPlatformProbe:");
     rv = g_saved_driver.platformProbe(drv, entity_num, flags, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -469,7 +469,7 @@ xorgxrdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
     xorgHWFlags *flags;
     Bool rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDriverFunc:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDriverFunc:");
     rv = g_saved_driver.driverFunc(pScrn, op, ptr);
     if (op == GET_REQUIRED_HW_INTERFACES)
     {
@@ -501,7 +501,7 @@ xorgxrdpCheckWrap(void)
     {
         g_saved_driver = *(xf86DriverList[0]);
         g_nvidia_wrap_done = TRUE;
-        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpCheckWrap: NVIDIA driver found"));
+        LOG(LOG_LEVEL_INFO, "xorgxrdpCheckWrap: NVIDIA driver found");
         xf86DriverList[0]->PciProbe = xorgxrdpPciProbe;
         xf86DriverList[0]->platformProbe = xorgxrdpPlatformProbe;
         xf86DriverList[0]->driverFunc = xorgxrdpDriverFunc;
@@ -514,7 +514,7 @@ static pointer
 xorgxrdpSetup(pointer Module, pointer Options,
               int *ErrorMajor, int *ErrorMinor)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpSetup:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpSetup:");
     if (!g_initialised)
     {
         g_initialised = TRUE;
@@ -528,18 +528,18 @@ xorgxrdpSetup(pointer Module, pointer Options,
 static void
 xorgxrdpTearDown(pointer Module)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpTearDown:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpTearDown:");
 }
 
 /*****************************************************************************/
 void
 xorgxrdpDownDown(ScreenPtr pScreen)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDownDown:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDownDown:");
     if (g_initialised)
     {
         g_initialised = FALSE;
-        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpDownDown: 1"));
+        LOG(LOG_LEVEL_INFO, "xorgxrdpDownDown: 1");
         rdpClientConDeinit(rdpGetDevFromScreen(pScreen));
     }
 }

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -100,7 +100,7 @@ xorgxrdpPreInit(ScrnInfoPtr pScrn, int flags)
     Bool rv;
     const char *env;
 
-    LLOGLN(10, ("xorgxrdpPreInit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPreInit:"));
     env = getenv("XRDP_NVIDIA_GRID");
     if (env != NULL)
     {
@@ -160,7 +160,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpCreateScreenResources:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateScreenResources:"));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -188,7 +188,7 @@ xorgxrdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     rdpPtr dev;
     rrScrPrivPtr pRRScrPriv;
 
-    LLOGLN(0, ("xorgxrdpRRScreenSetSize: width %d height %d", width, height));
+    LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpRRScreenSetSize: width %d height %d", width, height));
     dev = rdpGetDevFromScreen(pScreen);
 
     pRRScrPriv = rrGetScrPriv(pScreen);
@@ -208,7 +208,7 @@ xorgxrdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     dev->paddedWidthInBytes = dev->screenSwPixmap->devKind;
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
-    LLOGLN(0, ("xorgxrdpRRScreenSetSize: screenInfo x %d y %d "
+    LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpRRScreenSetSize: screenInfo x %d y %d "
            "width %d height %d", screenInfo.x, screenInfo.y,
            screenInfo.width, screenInfo.height));
 
@@ -222,7 +222,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(10, ("xorgxrdpDamageReport:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageReport:"));
     pScreen = (ScreenPtr)closure;
     dev = rdpGetDevFromScreen(pScreen);
     rdpClientConAddAllReg(dev, pRegion, &(pScreen->root->drawable));
@@ -232,7 +232,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(10, ("xorgxrdpDamageDestroy:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageDestroy:"));
 }
 
 #ifdef XACE_DISABLE_DRI3_PRESENT
@@ -241,16 +241,16 @@ static void
 xorgxrdpExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
     XaceExtAccessRec *rec = calldata;
-    LLOGLN(10, ("xorgxrdpExtension:"));
-    LLOGLN(10, ("  name %s", rec->ext->name));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpExtension:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("  name %s", rec->ext->name));
     if (strcmp(rec->ext->name, "DRI3") == 0)
     {
-        LLOGLN(10, ("  disabling name %s", rec->ext->name));
+        LLOGLN(LOG_LEVEL_TRACE, ("  disabling name %s", rec->ext->name));
         rec->status = BadValue;
     }
     if (strcmp(rec->ext->name, "Present") == 0)
     {
-        LLOGLN(10, ("  disabling name %s", rec->ext->name));
+        LLOGLN(LOG_LEVEL_TRACE, ("  disabling name %s", rec->ext->name));
         rec->status = BadValue;
     }
 }
@@ -264,7 +264,7 @@ xorgxrdpDeferredStartup(OsTimerPtr timer, CARD32 now, pointer arg)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(10, ("xorgxrdpDeferredStartup:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDeferredStartup:"));
     pScreen = (ScreenPtr)arg;
     if (pScreen->root != NULL)
     {
@@ -282,7 +282,7 @@ xorgxrdpDeferredStartup(OsTimerPtr timer, CARD32 now, pointer arg)
         {
             DamageSetReportAfterOp(dev->damage, TRUE);
             DamageRegister(&(pScreen->root->drawable), dev->damage);
-            LLOGLN(0, ("xorgxrdpSetupDamage: DamageRegister ok"));
+            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpSetupDamage: DamageRegister ok"));
             TimerFree(g_timer);
             g_timer = NULL;
 #ifdef XACE_DISABLE_DRI3_PRESENT
@@ -309,7 +309,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
     miPointerScreenPtr PointPriv;
     rrScrPrivPtr pRRScrPriv;
 
-    LLOGLN(10, ("xorgxrdpScreenInit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpScreenInit:"));
     rv = g_orgScreenInit(pScreen, argc, argv);
     if (rv)
     {
@@ -317,7 +317,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev = XRDPPTR(pScrn);
         dev->nvidia = TRUE;
         dev->nvidia_grid = g_nvidia_grid;
-        LLOGLN(0, ("xorgxrdpScreenInit: nvidia_grid %d", dev->nvidia_grid));
+        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: nvidia_grid %d", dev->nvidia_grid));
         dev->pScreen = pScreen;
         dev->depth = pScrn->depth;
         dev->width = pScrn->virtualX;
@@ -326,7 +326,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
         dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
-        LLOGLN(0, ("xorgxrdpScreenInit: width %d height %d", dev->width, dev->height));
+        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: width %d height %d", dev->width, dev->height));
 
         PointPriv = dixLookupPrivate(&pScreen->devPrivates, miPointerScreenKey);
         PointPriv->spriteFuncs = &g_rdpSpritePointerFuncs;
@@ -379,7 +379,7 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
 
         if (rdpClientConInit(dev) != 0)
         {
-            LLOGLN(0, ("xorgxrdpScreenInit: rdpClientConInit failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpScreenInit: rdpClientConInit failed"));
         }
 
         dev->Bpp_mask = 0x00FFFFFF;
@@ -427,12 +427,12 @@ xorgxrdpWrapPreIntScreenInit(Bool ok)
             }
             else
             {
-                LLOGLN(0, ("xorgxrdpWrapPreIntScreenInit: error"));
+                LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpWrapPreIntScreenInit: error"));
             }
         }
         else
         {
-            LLOGLN(0, ("xorgxrdpWrapPreIntScreenInit: error"));
+            LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpWrapPreIntScreenInit: error"));
         }
     }
     return ok;
@@ -445,7 +445,7 @@ xorgxrdpPciProbe(struct _DriverRec * drv, int entity_num,
 {
     Bool rv;
 
-    LLOGLN(10, ("xorgxrdpPciProbe:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPciProbe:"));
     rv = g_saved_driver.PciProbe(drv, entity_num, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -457,7 +457,7 @@ xorgxrdpPlatformProbe(struct _DriverRec * drv, int entity_num, int flags,
 {
     Bool rv;
 
-    LLOGLN(10, ("xorgxrdpPlatformProbe:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpPlatformProbe:"));
     rv = g_saved_driver.platformProbe(drv, entity_num, flags, dev, match_data);
     return xorgxrdpWrapPreIntScreenInit(rv);
 }
@@ -469,7 +469,7 @@ xorgxrdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
     xorgHWFlags *flags;
     Bool rv;
 
-    LLOGLN(10, ("xorgxrdpDriverFunc:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDriverFunc:"));
     rv = g_saved_driver.driverFunc(pScrn, op, ptr);
     if (op == GET_REQUIRED_HW_INTERFACES)
     {
@@ -501,7 +501,7 @@ xorgxrdpCheckWrap(void)
     {
         g_saved_driver = *(xf86DriverList[0]);
         g_nvidia_wrap_done = TRUE;
-        LLOGLN(0, ("xorgxrdpCheckWrap: NVIDIA driver found"));
+        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpCheckWrap: NVIDIA driver found"));
         xf86DriverList[0]->PciProbe = xorgxrdpPciProbe;
         xf86DriverList[0]->platformProbe = xorgxrdpPlatformProbe;
         xf86DriverList[0]->driverFunc = xorgxrdpDriverFunc;
@@ -514,7 +514,7 @@ static pointer
 xorgxrdpSetup(pointer Module, pointer Options,
               int *ErrorMajor, int *ErrorMinor)
 {
-    LLOGLN(10, ("xorgxrdpSetup:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpSetup:"));
     if (!g_initialised)
     {
         g_initialised = TRUE;
@@ -528,18 +528,18 @@ xorgxrdpSetup(pointer Module, pointer Options,
 static void
 xorgxrdpTearDown(pointer Module)
 {
-    LLOGLN(10, ("xorgxrdpTearDown:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpTearDown:"));
 }
 
 /*****************************************************************************/
 void
 xorgxrdpDownDown(ScreenPtr pScreen)
 {
-    LLOGLN(10, ("xorgxrdpDownDown:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDownDown:"));
     if (g_initialised)
     {
         g_initialised = FALSE;
-        LLOGLN(0, ("xorgxrdpDownDown: 1"));
+        LLOGLN(LOG_LEVEL_INFO, ("xorgxrdpDownDown: 1"));
         rdpClientConDeinit(rdpGetDevFromScreen(pScreen));
     }
 }

--- a/module/rdpMain.c
+++ b/module/rdpMain.c
@@ -209,8 +209,8 @@ xorgxrdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
     LOG(LOG_LEVEL_INFO, "xorgxrdpRRScreenSetSize: screenInfo x %d y %d "
-           "width %d height %d", screenInfo.x, screenInfo.y,
-           screenInfo.width, screenInfo.height);
+        "width %d height %d", screenInfo.x, screenInfo.y,
+        screenInfo.width, screenInfo.height);
 
     return rv;
 }
@@ -317,7 +317,8 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev = XRDPPTR(pScrn);
         dev->nvidia = TRUE;
         dev->nvidia_grid = g_nvidia_grid;
-        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: nvidia_grid %d", dev->nvidia_grid);
+        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: nvidia_grid %d",
+            dev->nvidia_grid);
         dev->pScreen = pScreen;
         dev->depth = pScrn->depth;
         dev->width = pScrn->virtualX;
@@ -326,7 +327,8 @@ xorgxrdpScreenInit(ScreenPtr pScreen, int argc, char** argv)
         dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
         dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
 
-        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: width %d height %d", dev->width, dev->height);
+        LOG(LOG_LEVEL_INFO, "xorgxrdpScreenInit: width %d height %d",
+            dev->width, dev->height);
 
         PointPriv = dixLookupPrivate(&pScreen->devPrivates, miPointerScreenKey);
         PointPriv->spriteFuncs = &g_rdpSpritePointerFuncs;

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -690,3 +690,47 @@ g_log_trace(const char *format, ...)
     LogVMessageVerb(X_NONE, 5, "\n", ap);
     va_end(ap);
 }
+
+/******************************************************************************/
+void
+g_log_msg(enum logLevels log_level, const char *format, ...)
+{
+    va_list ap;
+    MessageType type;
+    int verb = 0;
+
+    switch (log_level)
+    {
+        case LOG_LEVEL_ERROR:
+            type = X_ERROR;
+            break;
+
+        case LOG_LEVEL_WARNING:
+            type = X_WARNING;
+            break;
+
+        case LOG_LEVEL_INFO:
+            type = X_INFO;
+            break;
+
+        case LOG_LEVEL_DEBUG:
+            type = X_DEBUG;
+            verb = 4;
+            break;
+
+        case LOG_LEVEL_TRACE:
+            type = X_DEBUG;
+            verb = 5;
+            break;
+
+        default:
+            type = X_UNKNOWN;
+    }
+    va_start(ap, format);
+    LogVMessageVerb(type, verb, format, ap);
+    va_end(ap);
+    // Also need to terminate message. This seems the simplest way.
+    va_start(ap, format);
+    LogVMessageVerb(X_NONE, verb, "\n", ap);
+    va_end(ap);
+}

--- a/module/rdpMisc.c
+++ b/module/rdpMisc.c
@@ -650,49 +650,6 @@ g_free_unmap_fd(void *addr, int fd, size_t size)
 
 /******************************************************************************/
 void
-g_log_info(const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    LogVMessageVerb(X_INFO, 0, format, ap);
-    va_end(ap);
-    // Also need to terminate message. This seems the simplest way.
-    va_start(ap, format);
-    LogVMessageVerb(X_NONE, 0, "\n", ap);
-    va_end(ap);
-}
-
-/******************************************************************************/
-void
-g_log_debug(const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    LogVMessageVerb(X_DEBUG, 4, format, ap);
-    va_end(ap);
-    va_start(ap, format);
-    LogVMessageVerb(X_NONE, 4, "\n", ap);
-    va_end(ap);
-}
-
-/******************************************************************************/
-void
-g_log_trace(const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    LogVMessageVerb(X_DEBUG, 5, format, ap);
-    va_end(ap);
-    va_start(ap, format);
-    LogVMessageVerb(X_NONE, 5, "\n", ap);
-    va_end(ap);
-}
-
-/******************************************************************************/
-void
 g_log_msg(enum logLevels log_level, const char *format, ...)
 {
     va_list ap;

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -109,7 +109,7 @@ g_alloc_map_fd(void **addr, int *fd, size_t size);
 extern _X_EXPORT void
 g_free_unmap_fd(void *addr, int fd, size_t size);
 
-/* Logging. Use these for new code */
+/* Legacy Logging functions */
 extern _X_EXPORT void
 g_log_info(const char *format, ...) PRINTFLIKE(1,2);
 extern _X_EXPORT void
@@ -130,10 +130,24 @@ g_log_trace(const char *format, ...) PRINTFLIKE(1,2);
      (_level == LOG_LEVEL_DEBUG) ? g_log_debug : g_log_info) _args; \
 }
 
+/* Logging */
 /* Logging levels */
-#define LOG_LEVEL_INFO 0
-#define LOG_LEVEL_DEBUG 1
-#define LOG_LEVEL_TRACE 2
+enum logLevels
+{
+    LOG_LEVEL_ERROR,
+    LOG_LEVEL_WARNING,
+    LOG_LEVEL_INFO,
+    LOG_LEVEL_DEBUG,
+    LOG_LEVEL_TRACE
+};
+
+extern _X_EXPORT void
+g_log_msg(enum logLevels log_level, const char *format, ...) PRINTFLIKE(2,3);
+
+/* Logging macro, for compatibility with xrdp
+ */
+#define LOG(log_level,...) \
+    g_log_msg(log_level, __VA_ARGS__)
 
 /* glib-style memory allocation macros */
 #define g_new(struct_type, n_structs) \

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -126,9 +126,14 @@ g_log_trace(const char *format, ...) PRINTFLIKE(1,2);
  */
 #define LLOGLN(_level, _args) \
 { \
-    ((_level > 1) ? g_log_trace : \
-     (_level == 1) ? g_log_debug : g_log_info) _args; \
+    ((_level > LOG_LEVEL_DEBUG) ? g_log_trace : \
+     (_level == LOG_LEVEL_DEBUG) ? g_log_debug : g_log_info) _args; \
 }
+
+/* Logging levels */
+#define LOG_LEVEL_INFO 0
+#define LOG_LEVEL_DEBUG 1
+#define LOG_LEVEL_TRACE 2
 
 /* glib-style memory allocation macros */
 #define g_new(struct_type, n_structs) \

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -64,7 +64,8 @@ g_sck_send(int sck, const void *ptr, int len, int flags);
 extern _X_EXPORT void
 g_sprintf(char *dest, const char *format, ...) PRINTFLIKE(2,3);
 extern _X_EXPORT int
-g_snprintf(char *dest, unsigned int dest_size, const char *format, ...);
+g_snprintf(char *dest, unsigned int dest_size, const char *format, ...)
+    PRINTFLIKE(3,4);
 extern _X_EXPORT int
 g_sck_tcp_socket(void);
 extern _X_EXPORT int

--- a/module/rdpMisc.h
+++ b/module/rdpMisc.h
@@ -109,27 +109,6 @@ g_alloc_map_fd(void **addr, int *fd, size_t size);
 extern _X_EXPORT void
 g_free_unmap_fd(void *addr, int fd, size_t size);
 
-/* Legacy Logging functions */
-extern _X_EXPORT void
-g_log_info(const char *format, ...) PRINTFLIKE(1,2);
-extern _X_EXPORT void
-g_log_debug(const char *format, ...) PRINTFLIKE(1,2);
-extern _X_EXPORT void
-g_log_trace(const char *format, ...) PRINTFLIKE(1,2);
-
-/* Legacy logging macro
- *
- * Remove when unused
- *
- * _level : 0=Info, 1=Debug, 10=Trace
- * _args : Argument to logging function
- */
-#define LLOGLN(_level, _args) \
-{ \
-    ((_level > LOG_LEVEL_DEBUG) ? g_log_trace : \
-     (_level == LOG_LEVEL_DEBUG) ? g_log_debug : g_log_info) _args; \
-}
-
 /* Logging */
 /* Logging levels */
 enum logLevels

--- a/module/rdpPixmap.c
+++ b/module/rdpPixmap.c
@@ -57,7 +57,7 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     rdpPtr dev;
     PixmapPtr rv;
 
-    LLOGLN(10, ("rdpCreatePixmap: width %d height %d depth %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreatePixmap: width %d height %d depth %d",
            width, height, depth));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
@@ -75,7 +75,7 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth)
     rdpPtr dev;
     PixmapPtr rv;
 
-    LLOGLN(10, ("rdpCreatePixmap: width %d height %d depth %d",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreatePixmap: width %d height %d depth %d",
            width, height, depth));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
@@ -94,7 +94,7 @@ rdpDestroyPixmap(PixmapPtr pPixmap)
     ScreenPtr pScreen;
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpDestroyPixmap: refcnt %d", pPixmap->refcnt));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyPixmap: refcnt %d", pPixmap->refcnt));
     pScreen = pPixmap->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->DestroyPixmap = dev->DestroyPixmap;
@@ -112,7 +112,7 @@ rdpModifyPixmapHeader(PixmapPtr pPixmap, int width, int height, int depth,
     ScreenPtr pScreen;
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpModifyPixmapHeader:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpModifyPixmapHeader:"));
     pScreen = pPixmap->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->ModifyPixmapHeader = dev->ModifyPixmapHeader;

--- a/module/rdpPixmap.c
+++ b/module/rdpPixmap.c
@@ -58,7 +58,7 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     PixmapPtr rv;
 
     LOG(LOG_LEVEL_TRACE, "rdpCreatePixmap: width %d height %d depth %d",
-           width, height, depth);
+        width, height, depth);
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
     rv = pScreen->CreatePixmap(pScreen, width, height, depth, usage_hint);
@@ -76,7 +76,7 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth)
     PixmapPtr rv;
 
     LOG(LOG_LEVEL_TRACE, "rdpCreatePixmap: width %d height %d depth %d",
-           width, height, depth);
+        width, height, depth);
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
     rv = pScreen->CreatePixmap(pScreen, width, height, depth);

--- a/module/rdpPixmap.c
+++ b/module/rdpPixmap.c
@@ -57,8 +57,8 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     rdpPtr dev;
     PixmapPtr rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreatePixmap: width %d height %d depth %d",
-           width, height, depth));
+    LOG(LOG_LEVEL_TRACE, "rdpCreatePixmap: width %d height %d depth %d",
+           width, height, depth);
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
     rv = pScreen->CreatePixmap(pScreen, width, height, depth, usage_hint);
@@ -75,8 +75,8 @@ rdpCreatePixmap(ScreenPtr pScreen, int width, int height, int depth)
     rdpPtr dev;
     PixmapPtr rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreatePixmap: width %d height %d depth %d",
-           width, height, depth));
+    LOG(LOG_LEVEL_TRACE, "rdpCreatePixmap: width %d height %d depth %d",
+           width, height, depth);
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreatePixmap = dev->CreatePixmap;
     rv = pScreen->CreatePixmap(pScreen, width, height, depth);
@@ -94,7 +94,7 @@ rdpDestroyPixmap(PixmapPtr pPixmap)
     ScreenPtr pScreen;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDestroyPixmap: refcnt %d", pPixmap->refcnt));
+    LOG(LOG_LEVEL_TRACE, "rdpDestroyPixmap: refcnt %d", pPixmap->refcnt);
     pScreen = pPixmap->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->DestroyPixmap = dev->DestroyPixmap;
@@ -112,7 +112,7 @@ rdpModifyPixmapHeader(PixmapPtr pPixmap, int width, int height, int depth,
     ScreenPtr pScreen;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpModifyPixmapHeader:"));
+    LOG(LOG_LEVEL_TRACE, "rdpModifyPixmapHeader:");
     pScreen = pPixmap->drawable.pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->ModifyPixmapHeader = dev->ModifyPixmapHeader;

--- a/module/rdpPolyArc.c
+++ b/module/rdpPolyArc.c
@@ -66,7 +66,7 @@ rdpPolyArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyArc:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyArc:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyArcCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -89,7 +89,7 @@ rdpPolyArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyArc: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyArc: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyArc.c
+++ b/module/rdpPolyArc.c
@@ -66,7 +66,7 @@ rdpPolyArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpPolyArc:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyArc:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyArcCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -89,7 +89,7 @@ rdpPolyArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyArc: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyArc: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyFillArc.c
+++ b/module/rdpPolyFillArc.c
@@ -66,7 +66,7 @@ rdpPolyFillArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillArc:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyFillArc:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyFillArcCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -89,7 +89,7 @@ rdpPolyFillArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillArc: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyFillArc: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyFillArc.c
+++ b/module/rdpPolyFillArc.c
@@ -66,7 +66,7 @@ rdpPolyFillArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpPolyFillArc:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillArc:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyFillArcCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -89,7 +89,7 @@ rdpPolyFillArc(DrawablePtr pDrawable, GCPtr pGC, int narcs, xArc *parcs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyFillArc: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillArc: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyFillRect.c
+++ b/module/rdpPolyFillRect.c
@@ -64,7 +64,7 @@ rdpPolyFillRect(DrawablePtr pDrawable, GCPtr pGC, int nrectFill,
     RegionPtr reg;
     int cd;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillRect:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyFillRect:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyFillRectCallCount++;
     /* make a copy of rects */
@@ -72,7 +72,7 @@ rdpPolyFillRect(DrawablePtr pDrawable, GCPtr pGC, int nrectFill,
     rdpRegionTranslate(reg, pDrawable->x, pDrawable->y);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillRect: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyFillRect: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(reg, &clip_reg, reg);

--- a/module/rdpPolyFillRect.c
+++ b/module/rdpPolyFillRect.c
@@ -64,7 +64,7 @@ rdpPolyFillRect(DrawablePtr pDrawable, GCPtr pGC, int nrectFill,
     RegionPtr reg;
     int cd;
 
-    LLOGLN(10, ("rdpPolyFillRect:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillRect:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyFillRectCallCount++;
     /* make a copy of rects */
@@ -72,7 +72,7 @@ rdpPolyFillRect(DrawablePtr pDrawable, GCPtr pGC, int nrectFill,
     rdpRegionTranslate(reg, pDrawable->x, pDrawable->y);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyFillRect: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyFillRect: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(reg, &clip_reg, reg);

--- a/module/rdpPolyGlyphBlt.c
+++ b/module/rdpPolyGlyphBlt.c
@@ -67,14 +67,14 @@ rdpPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolyGlyphBlt:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyGlyphBlt:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyGlyphBlt: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyGlyphBlt: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyGlyphBlt.c
+++ b/module/rdpPolyGlyphBlt.c
@@ -67,14 +67,14 @@ rdpPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyGlyphBlt:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyGlyphBlt:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyGlyphBltCallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, nglyph, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyGlyphBlt: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyGlyphBlt: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyPoint.c
+++ b/module/rdpPolyPoint.c
@@ -66,7 +66,7 @@ rdpPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
     int index;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyPoint:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyPoint:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyPointCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -80,7 +80,7 @@ rdpPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyPoint: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyPoint: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyPoint.c
+++ b/module/rdpPolyPoint.c
@@ -66,7 +66,7 @@ rdpPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
     int index;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolyPoint:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyPoint:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyPointCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -80,7 +80,7 @@ rdpPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyPoint: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyPoint: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyRectangle.c
+++ b/module/rdpPolyRectangle.c
@@ -73,7 +73,7 @@ rdpPolyRectangle(DrawablePtr pDrawable, GCPtr pGC, int nrects,
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyRectangle:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyRectangle:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyRectangleCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -119,7 +119,7 @@ rdpPolyRectangle(DrawablePtr pDrawable, GCPtr pGC, int nrects,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyRectangle: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyRectangle: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyRectangle.c
+++ b/module/rdpPolyRectangle.c
@@ -73,7 +73,7 @@ rdpPolyRectangle(DrawablePtr pDrawable, GCPtr pGC, int nrects,
     RegionRec clip_reg;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpPolyRectangle:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyRectangle:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyRectangleCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -119,7 +119,7 @@ rdpPolyRectangle(DrawablePtr pDrawable, GCPtr pGC, int nrects,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyRectangle: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyRectangle: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolySegment.c
+++ b/module/rdpPolySegment.c
@@ -68,7 +68,7 @@ rdpPolySegment(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment *pSegs)
     int y2;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolySegment:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolySegment:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolySegmentCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -86,7 +86,7 @@ rdpPolySegment(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment *pSegs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolySegment: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolySegment: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolySegment.c
+++ b/module/rdpPolySegment.c
@@ -68,7 +68,7 @@ rdpPolySegment(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment *pSegs)
     int y2;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolySegment:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolySegment:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolySegmentCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -86,7 +86,7 @@ rdpPolySegment(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment *pSegs)
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolySegment: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolySegment: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyText16.c
+++ b/module/rdpPolyText16.c
@@ -68,14 +68,14 @@ rdpPolyText16(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolyText16:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText16:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyText16CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyText16: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText16: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyText16.c
+++ b/module/rdpPolyText16.c
@@ -68,14 +68,14 @@ rdpPolyText16(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText16:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyText16:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyText16CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText16: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyText16: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyText8.c
+++ b/module/rdpPolyText8.c
@@ -68,14 +68,14 @@ rdpPolyText8(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolyText8:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText8:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyText8CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolyText8: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText8: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolyText8.c
+++ b/module/rdpPolyText8.c
@@ -68,14 +68,14 @@ rdpPolyText8(DrawablePtr pDrawable, GCPtr pGC,
     int cd;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText8:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyText8:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolyText8CallCount++;
     GetTextBoundingBox(pDrawable, pGC->font, x, y, count, &box);
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolyText8: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolyText8: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolylines.c
+++ b/module/rdpPolylines.c
@@ -70,7 +70,7 @@ rdpPolylines(DrawablePtr pDrawable, GCPtr pGC, int mode,
     int y2;
     BoxRec box;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolylines:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPolylines:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolylinesCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -88,7 +88,7 @@ rdpPolylines(DrawablePtr pDrawable, GCPtr pGC, int mode,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolylines: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPolylines: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPolylines.c
+++ b/module/rdpPolylines.c
@@ -70,7 +70,7 @@ rdpPolylines(DrawablePtr pDrawable, GCPtr pGC, int mode,
     int y2;
     BoxRec box;
 
-    LLOGLN(10, ("rdpPolylines:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolylines:"));
     dev = rdpGetDevFromScreen(pGC->pScreen);
     dev->counts.rdpPolylinesCallCount++;
     rdpRegionInit(&reg, NullBox, 0);
@@ -88,7 +88,7 @@ rdpPolylines(DrawablePtr pDrawable, GCPtr pGC, int mode,
     }
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDrawable, pGC);
-    LLOGLN(10, ("rdpPolylines: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPolylines: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPushPixels.c
+++ b/module/rdpPushPixels.c
@@ -57,7 +57,7 @@ void
 rdpPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDst,
               int w, int h, int x, int y)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPushPixels:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPushPixels:");
     /* do original call */
     rdpPushPixelsOrg(pGC, pBitMap, pDst, w, h, x, y);
 }

--- a/module/rdpPushPixels.c
+++ b/module/rdpPushPixels.c
@@ -57,7 +57,7 @@ void
 rdpPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDst,
               int w, int h, int x, int y)
 {
-    LLOGLN(10, ("rdpPushPixels:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPushPixels:"));
     /* do original call */
     rdpPushPixelsOrg(pGC, pBitMap, pDst, w, h, x, y);
 }

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -93,8 +93,9 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                     }
                     /* set new */
                     pixmap = (PixmapPtr) pDst;
-                    LOG(LOG_LEVEL_INFO, "rdpPutImage: setting conNumber %d, monitor num %d "
-                           "to pixmap %p", pBits32[1], monitor_index, pixmap);
+                    LOG(LOG_LEVEL_INFO,
+                        "rdpPutImage: setting conNumber %d, monitor num %d "
+                        "to pixmap %p", pBits32[1], monitor_index, pixmap);
                     clientCon->accelAssistPixmaps[monitor_index] = pixmap;
                     /* so it can not get freed early */
                     pixmap->refcnt++;
@@ -102,8 +103,8 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                     if (dev->monitorCount < 1)
                     {
                         LOG(LOG_LEVEL_INFO, "rdpPutImage: monitor_index %d "
-                               "invalidating 0 0 %d %d",
-                               monitor_index, dev->width, dev->height);
+                            "invalidating 0 0 %d %d",
+                            monitor_index, dev->width, dev->height);
                         rdpClientConAddDirtyScreen(dev, clientCon, 0, 0,
                                                    dev->width, dev->height);
                     }
@@ -116,8 +117,8 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                         int height = dev->minfo[monitor_index].bottom -
                                      dev->minfo[monitor_index].top + 1;
                         LOG(LOG_LEVEL_INFO, "rdpPutImage: monitor_index %d "
-                               "invalidating %d %d %d %d",
-                               monitor_index, left, top, width, height);
+                            "invalidating %d %d %d %d",
+                            monitor_index, left, top, width, height);
                         rdpClientConAddDirtyScreen(dev, clientCon,
                                                    left, top , width, height);
                     }

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -70,7 +70,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     rdpClientCon *clientCon;
     ScreenPtr pScreen;
 
-    LLOGLN(10, ("rdpPutImage:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPutImage:"));
     pScreen = pGC->pScreen;
     dev = rdpGetDevFromScreen(pGC->pScreen);
     if ((x == 0) && (y == 0) && (w == 4) && (h == 4) && (depth >= 24) &&
@@ -93,7 +93,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                     }
                     /* set new */
                     pixmap = (PixmapPtr) pDst;
-                    LLOGLN(0, ("rdpPutImage: setting conNumber %d, monitor num %d "
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: setting conNumber %d, monitor num %d "
                            "to pixmap %p", pBits32[1], monitor_index, pixmap));
                     clientCon->accelAssistPixmaps[monitor_index] = pixmap;
                     /* so it can not get freed early */
@@ -101,7 +101,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                     /* invalidate */
                     if (dev->monitorCount < 1)
                     {
-                        LLOGLN(0, ("rdpPutImage: monitor_index %d "
+                        LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: monitor_index %d "
                                "invalidating 0 0 %d %d",
                                monitor_index, dev->width, dev->height));
                         rdpClientConAddDirtyScreen(dev, clientCon, 0, 0,
@@ -115,7 +115,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                                     dev->minfo[monitor_index].left + 1;
                         int height = dev->minfo[monitor_index].bottom -
                                      dev->minfo[monitor_index].top + 1;
-                        LLOGLN(0, ("rdpPutImage: monitor_index %d "
+                        LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: monitor_index %d "
                                "invalidating %d %d %d %d",
                                monitor_index, left, top, width, height));
                         rdpClientConAddDirtyScreen(dev, clientCon,
@@ -136,7 +136,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(10, ("rdpPutImage: cd %d", cd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPutImage: cd %d", cd));
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -70,7 +70,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     rdpClientCon *clientCon;
     ScreenPtr pScreen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPutImage:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPutImage:");
     pScreen = pGC->pScreen;
     dev = rdpGetDevFromScreen(pGC->pScreen);
     if ((x == 0) && (y == 0) && (w == 4) && (h == 4) && (depth >= 24) &&
@@ -93,17 +93,17 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                     }
                     /* set new */
                     pixmap = (PixmapPtr) pDst;
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: setting conNumber %d, monitor num %d "
-                           "to pixmap %p", pBits32[1], monitor_index, pixmap));
+                    LOG(LOG_LEVEL_INFO, "rdpPutImage: setting conNumber %d, monitor num %d "
+                           "to pixmap %p", pBits32[1], monitor_index, pixmap);
                     clientCon->accelAssistPixmaps[monitor_index] = pixmap;
                     /* so it can not get freed early */
                     pixmap->refcnt++;
                     /* invalidate */
                     if (dev->monitorCount < 1)
                     {
-                        LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: monitor_index %d "
+                        LOG(LOG_LEVEL_INFO, "rdpPutImage: monitor_index %d "
                                "invalidating 0 0 %d %d",
-                               monitor_index, dev->width, dev->height));
+                               monitor_index, dev->width, dev->height);
                         rdpClientConAddDirtyScreen(dev, clientCon, 0, 0,
                                                    dev->width, dev->height);
                     }
@@ -115,9 +115,9 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
                                     dev->minfo[monitor_index].left + 1;
                         int height = dev->minfo[monitor_index].bottom -
                                      dev->minfo[monitor_index].top + 1;
-                        LLOGLN(LOG_LEVEL_INFO, ("rdpPutImage: monitor_index %d "
+                        LOG(LOG_LEVEL_INFO, "rdpPutImage: monitor_index %d "
                                "invalidating %d %d %d %d",
-                               monitor_index, left, top, width, height));
+                               monitor_index, left, top, width, height);
                         rdpClientConAddDirtyScreen(dev, clientCon,
                                                    left, top , width, height);
                     }
@@ -136,7 +136,7 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     rdpRegionInit(&reg, &box, 0);
     rdpRegionInit(&clip_reg, NullBox, 0);
     cd = rdpDrawGetClip(dev, &clip_reg, pDst, pGC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPutImage: cd %d", cd));
+    LOG(LOG_LEVEL_TRACE, "rdpPutImage: cd %d", cd);
     if (cd == XRDP_CD_CLIP)
     {
         rdpRegionIntersect(&reg, &clip_reg, &reg);

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -63,7 +63,7 @@ rdpRRRegisterSize(ScreenPtr pScreen, int width, int height)
     RRScreenSizePtr pSize;
     ScrnInfoPtr pScrn;
 
-    LLOGLN(0, ("rdpRRRegisterSize: width %d height %d", width, height));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRRRegisterSize: width %d height %d", width, height));
     pScrn = xf86Screens[pScreen->myNum];
     mmwidth = PixelToMM(width, pScrn->xDpi);
     mmheight = PixelToMM(height, pScrn->yDpi);
@@ -78,7 +78,7 @@ Bool
 rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
                RRScreenSizePtr pSize)
 {
-    LLOGLN(10, ("rdpRRSetConfig:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetConfig:"));
     return TRUE;
 }
 
@@ -86,7 +86,7 @@ rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
 Bool
 rdpRRGetInfo(ScreenPtr pScreen, Rotation *pRotations)
 {
-    LLOGLN(10, ("rdpRRGetInfo:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRGetInfo:"));
     *pRotations = RR_Rotate_0;
     return TRUE;
 }
@@ -98,7 +98,7 @@ rdpRRSetPixmapVisitWindow(WindowPtr window, void *data)
 {
     ScreenPtr screen;
 
-    LLOGLN(10, ("rdpRRSetPixmapVisitWindow:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetPixmapVisitWindow:"));
     screen = window->drawable.pScreen;
     if (screen->GetWindowPixmap(window) == data)
     {
@@ -119,7 +119,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     BoxRec box;
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
            width, height, (int)mmWidth, (int)mmHeight));
     dev = rdpGetDevFromScreen(pScreen);
     if (dev->allow_screen_resize == 0)
@@ -127,16 +127,16 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
         if ((width == pScreen->width) && (height == pScreen->height) &&
             (mmWidth == pScreen->mmWidth) && (mmHeight == pScreen->mmHeight))
         {
-            LLOGLN(0, ("rdpRRScreenSetSize: already this size"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: already this size"));
             return TRUE;
         }
-        LLOGLN(0, ("rdpRRScreenSetSize: not allowing resize"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: not allowing resize"));
         return FALSE;
     }
     root = rdpGetRootWindowPtr(pScreen);
     if ((width < 1) || (height < 1))
     {
-        LLOGLN(10, ("  error width %d height %d", width, height));
+        LLOGLN(LOG_LEVEL_TRACE, ("  error width %d height %d", width, height));
         return FALSE;
     }
     dev->width = width;
@@ -171,7 +171,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screenPixmap);
-        LLOGLN(0, ("rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex));
         pScreen->SetScreenPixmap(screenPixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -192,7 +192,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     root->drawable.height = height;
     ResizeChildrenWinSize(root, 0, 0, 0, 0);
     RRGetInfo(pScreen, 1);
-    LLOGLN(0, ("  screen resized to %dx%d", pScreen->width, pScreen->height));
+    LLOGLN(LOG_LEVEL_INFO, ("  screen resized to %dx%d", pScreen->width, pScreen->height));
     RRScreenSizeNotify(pScreen);
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 13, 0, 0, 0)
     xf86EnableDisableFBAccess(pScreen->myNum, FALSE);
@@ -202,7 +202,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     xf86EnableDisableFBAccess(xf86Screens[pScreen->myNum], TRUE);
 #endif
 
-    LLOGLN(0, ("rdpRRScreenSetSize: screenInfo x %d y %d "
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: screenInfo x %d y %d "
            "width %d height %d", screenInfo.x, screenInfo.y,
            screenInfo.width, screenInfo.height));
 
@@ -215,7 +215,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
              int x, int y, Rotation rotation, int numOutputs,
              RROutputPtr *outputs)
 {
-    LLOGLN(10, ("rdpRRCrtcSet:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRCrtcSet:"));
     return TRUE;
 }
 
@@ -223,7 +223,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
 Bool
 rdpRRCrtcSetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
-    LLOGLN(10, ("rdpRRCrtcSetGamma:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRCrtcSetGamma:"));
     return TRUE;
 }
 
@@ -231,7 +231,7 @@ rdpRRCrtcSetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 Bool
 rdpRRCrtcGetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
-    LLOGLN(0, ("rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
            crtc->gammaBlue, crtc->gammaGreen));
     return TRUE;
 }
@@ -241,7 +241,7 @@ Bool
 rdpRROutputSetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property,
                        RRPropertyValuePtr value)
 {
-    LLOGLN(10, ("rdpRROutputSetProperty:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputSetProperty:"));
     return TRUE;
 }
 
@@ -250,7 +250,7 @@ Bool
 rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
                         RRModePtr mode)
 {
-    LLOGLN(10, ("rdpRROutputValidateMode:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputValidateMode:"));
     return TRUE;
 }
 
@@ -258,14 +258,14 @@ rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
 void
 rdpRRModeDestroy(ScreenPtr pScreen, RRModePtr mode)
 {
-    LLOGLN(10, ("rdpRRModeDestroy:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRModeDestroy:"));
 }
 
 /******************************************************************************/
 Bool
 rdpRROutputGetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property)
 {
-    LLOGLN(10, ("rdpRROutputGetProperty:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputGetProperty:"));
     return TRUE;
 }
 
@@ -315,7 +315,7 @@ rdpRRGetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
     BoxRec totalAreaRect;
     BoxRec trackingAreaRect;
 
-    LLOGLN(10, ("rdpRRGetPanning: totalArea %p trackingArea %p border %p",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRGetPanning: totalArea %p trackingArea %p border %p",
                 totalArea, trackingArea, border));
 
     if (!g_panning)
@@ -360,7 +360,7 @@ Bool
 rdpRRSetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
                 BoxPtr trackingArea, INT16 *border)
 {
-    LLOGLN(10, ("rdpRRSetPanning:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetPanning:"));
     return TRUE;
 }
 
@@ -372,7 +372,7 @@ rdpRRAddCrtc(rdpPtr dev)
     RRCrtcPtr crtc = RRCrtcCreate(dev->pScreen, NULL);
     if (crtc == 0)
     {
-        LLOGLN(0, ("rdpRRAddCrtc: RRCrtcCreate failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddCrtc: RRCrtcCreate failed"));
         return 1;
     }
     /* Create and initialise (unused) gamma ramps */
@@ -396,12 +396,12 @@ rdpRRAddOutput(rdpPtr dev, const char *aname)
     output = RROutputCreate(dev->pScreen, aname, strlen(aname), NULL);
     if (output == 0)
     {
-        LLOGLN(0, ("rdpRRAddOutput: RROutputCreate failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddOutput: RROutputCreate failed"));
         return 1;
     }
     if (!RROutputSetClones(output, NULL, 0))
     {
-        LLOGLN(0, ("rdpRRAddOutput: RROutputSetClones failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddOutput: RROutputSetClones failed"));
         return 1;
     }
     return 0;
@@ -418,7 +418,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     char name[64];
     const int vfreq = 50;
 
-    LLOGLN(10, ("rdpRRConnectOutput:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRConnectOutput:"));
     sprintf (name, "%dx%d", width, height);
     modeInfo.width = width;
     modeInfo.height = height;
@@ -429,7 +429,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     mode = RRModeGet(&modeInfo, name);
     if (mode == 0)
     {
-        LLOGLN(0, ("rdpRRConnectOutput: RRModeGet failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RRModeGet failed"));
         return 1;
     }
     /* Don't set the mode for the output unless we need to */
@@ -438,7 +438,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     {
         if (!RROutputSetModes(output, &mode, 1, 0))
         {
-            LLOGLN(0, ("rdpRRConnectOutput: RROutputSetModes failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetModes failed"));
             return 1;
         }
     }
@@ -448,18 +448,18 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     {
         if (!RROutputSetCrtcs(output, &crtc, 1))
         {
-            LLOGLN(0, ("rdpRRConnectOutput: RROutputSetCrtcs failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetCrtcs failed"));
             return 1;
         }
     }
     if (!RROutputSetConnection(output, RR_Connected))
     {
-        LLOGLN(0, ("rdpRRConnectOutput: RROutputSetConnection failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetConnection failed"));
         return 1;
     }
     if (!RROutputSetPhysicalSize(output, mmwidth, mmheight))
     {
-        LLOGLN(0, ("rdpRRConnectOutput: RROutputSetPhysicalSize failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetPhysicalSize failed"));
         return 1;
     }
     RRCrtcNotify(crtc, mode, x, y, RR_Rotate_0, NULL, 1, &output);
@@ -473,17 +473,17 @@ rdpRRDisconnectOutput(RROutputPtr output, RRCrtcPtr crtc)
 {
     if (!RROutputSetModes(output, NULL, 0, 0))
     {
-        LLOGLN(0, ("rdpRRDisconnectOutput: RROutputSetModes failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetModes failed"));
         return 1;
     }
     if (!RROutputSetCrtcs(output, NULL, 0))
     {
-        LLOGLN(0, ("rdpRRDisconnectOutput: RROutputSetCrtcs failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetCrtcs failed"));
         return 1;
     }
     if (!RROutputSetConnection(output, RR_Disconnected))
     {
-        LLOGLN(0, ("rdpRRDisconnectOutput: RROutputSetConnection failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetConnection failed"));
         return 1;
     }
     RRCrtcNotify(crtc, NULL, 0, 0, RR_Rotate_0, NULL, 0, NULL);
@@ -528,7 +528,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
     int rv = 0;
 
     pRRScrPriv = rrGetScrPriv(dev->pScreen);
-    LLOGLN(0, ("rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
            pRRScrPriv->numCrtcs, pRRScrPriv->numOutputs, dev->monitorCount));
     int count = (dev->monitorCount <= 0) ? 1 : dev->monitorCount;
 
@@ -546,7 +546,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
 
     if (rv != 0)
     {
-        LLOGLN(0, ("rdpRRSetRdpOutputs: Failed to add CRTCs / Outputs"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: Failed to add CRTCs / Outputs"));
         return rv;
     }
 
@@ -558,7 +558,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
         height = dev->height;
         mmwidth = dev->pScreen->mmWidth;
         mmheight = dev->pScreen->mmHeight;
-        LLOGLN(0, ("rdpRRSetRdpOutputs: update output %d "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: update output %d "
                "left %d top %d width %d height %d",
                0, left, top, width, height));
         rv = rdpRRConnectOutput(pRRScrPriv->outputs[0],
@@ -577,7 +577,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
             height = dev->minfo[index].bottom - dev->minfo[index].top + 1;
             mmwidth = dev->minfo[index].physical_width;
             mmheight = dev->minfo[index].physical_height;
-            LLOGLN(0, ("rdpRRSetRdpOutputs: update output %d "
+            LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: update output %d "
                    "left %d top %d width %d height %d",
                    index, left, top, width, height));
             rv = rdpRRConnectOutput(pRRScrPriv->outputs[index],
@@ -601,7 +601,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
 
     if (rv != 0)
     {
-        LLOGLN(0, ("rdpRRSetRdpOutputs: rdpRRSetRdpOutputs failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: rdpRRSetRdpOutputs failed"));
     }
     return rv;
 }

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -119,8 +119,9 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     BoxRec box;
     rdpPtr dev;
 
-    LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
-           width, height, (int)mmWidth, (int)mmHeight);
+    LOG(LOG_LEVEL_INFO,
+        "rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
+        width, height, (int)mmWidth, (int)mmHeight);
     dev = rdpGetDevFromScreen(pScreen);
     if (dev->allow_screen_resize == 0)
     {
@@ -171,7 +172,8 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screenPixmap);
-        LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex);
+        LOG(LOG_LEVEL_INFO,
+            "rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex);
         pScreen->SetScreenPixmap(screenPixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -192,7 +194,8 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     root->drawable.height = height;
     ResizeChildrenWinSize(root, 0, 0, 0, 0);
     RRGetInfo(pScreen, 1);
-    LOG(LOG_LEVEL_INFO, "  screen resized to %dx%d", pScreen->width, pScreen->height);
+    LOG(LOG_LEVEL_INFO,
+        "  screen resized to %dx%d", pScreen->width, pScreen->height);
     RRScreenSizeNotify(pScreen);
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 13, 0, 0, 0)
     xf86EnableDisableFBAccess(pScreen->myNum, FALSE);
@@ -203,8 +206,8 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
 #endif
 
     LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: screenInfo x %d y %d "
-           "width %d height %d", screenInfo.x, screenInfo.y,
-           screenInfo.width, screenInfo.height);
+        "width %d height %d", screenInfo.x, screenInfo.y,
+        screenInfo.width, screenInfo.height);
 
     return TRUE;
 }
@@ -232,7 +235,7 @@ Bool
 rdpRRCrtcGetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
     LOG(LOG_LEVEL_INFO, "rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
-           crtc->gammaBlue, crtc->gammaGreen);
+        crtc->gammaBlue, crtc->gammaGreen);
     return TRUE;
 }
 
@@ -315,8 +318,9 @@ rdpRRGetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
     BoxRec totalAreaRect;
     BoxRec trackingAreaRect;
 
-    LOG(LOG_LEVEL_TRACE, "rdpRRGetPanning: totalArea %p trackingArea %p border %p",
-                totalArea, trackingArea, border);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpRRGetPanning: totalArea %p trackingArea %p border %p",
+        totalArea, trackingArea, border);
 
     if (!g_panning)
     {
@@ -528,8 +532,9 @@ rdpRRSetRdpOutputs(rdpPtr dev)
     int rv = 0;
 
     pRRScrPriv = rrGetScrPriv(dev->pScreen);
-    LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
-           pRRScrPriv->numCrtcs, pRRScrPriv->numOutputs, dev->monitorCount);
+    LOG(LOG_LEVEL_INFO,
+        "rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
+        pRRScrPriv->numCrtcs, pRRScrPriv->numOutputs, dev->monitorCount);
     int count = (dev->monitorCount <= 0) ? 1 : dev->monitorCount;
 
     /* Ensure we've got enough CRT controllers and outputs */
@@ -559,8 +564,8 @@ rdpRRSetRdpOutputs(rdpPtr dev)
         mmwidth = dev->pScreen->mmWidth;
         mmheight = dev->pScreen->mmHeight;
         LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: update output %d "
-               "left %d top %d width %d height %d",
-               0, left, top, width, height);
+            "left %d top %d width %d height %d",
+            0, left, top, width, height);
         rv = rdpRRConnectOutput(pRRScrPriv->outputs[0],
                                 pRRScrPriv->crtcs[0],
                                 left, top, width, height,
@@ -578,8 +583,8 @@ rdpRRSetRdpOutputs(rdpPtr dev)
             mmwidth = dev->minfo[index].physical_width;
             mmheight = dev->minfo[index].physical_height;
             LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: update output %d "
-                   "left %d top %d width %d height %d",
-                   index, left, top, width, height);
+                "left %d top %d width %d height %d",
+                index, left, top, width, height);
             rv = rdpRRConnectOutput(pRRScrPriv->outputs[index],
                                     pRRScrPriv->crtcs[index],
                                     left, top, width, height,

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -63,7 +63,7 @@ rdpRRRegisterSize(ScreenPtr pScreen, int width, int height)
     RRScreenSizePtr pSize;
     ScrnInfoPtr pScrn;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRRRegisterSize: width %d height %d", width, height));
+    LOG(LOG_LEVEL_INFO, "rdpRRRegisterSize: width %d height %d", width, height);
     pScrn = xf86Screens[pScreen->myNum];
     mmwidth = PixelToMM(width, pScrn->xDpi);
     mmheight = PixelToMM(height, pScrn->yDpi);
@@ -78,7 +78,7 @@ Bool
 rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
                RRScreenSizePtr pSize)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetConfig:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRSetConfig:");
     return TRUE;
 }
 
@@ -86,7 +86,7 @@ rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
 Bool
 rdpRRGetInfo(ScreenPtr pScreen, Rotation *pRotations)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRGetInfo:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRGetInfo:");
     *pRotations = RR_Rotate_0;
     return TRUE;
 }
@@ -98,7 +98,7 @@ rdpRRSetPixmapVisitWindow(WindowPtr window, void *data)
 {
     ScreenPtr screen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetPixmapVisitWindow:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRSetPixmapVisitWindow:");
     screen = window->drawable.pScreen;
     if (screen->GetWindowPixmap(window) == data)
     {
@@ -119,24 +119,24 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     BoxRec box;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
-           width, height, (int)mmWidth, (int)mmHeight));
+    LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: width %d height %d mmWidth %d mmHeight %d",
+           width, height, (int)mmWidth, (int)mmHeight);
     dev = rdpGetDevFromScreen(pScreen);
     if (dev->allow_screen_resize == 0)
     {
         if ((width == pScreen->width) && (height == pScreen->height) &&
             (mmWidth == pScreen->mmWidth) && (mmHeight == pScreen->mmHeight))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: already this size"));
+            LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: already this size");
             return TRUE;
         }
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: not allowing resize"));
+        LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: not allowing resize");
         return FALSE;
     }
     root = rdpGetRootWindowPtr(pScreen);
     if ((width < 1) || (height < 1))
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("  error width %d height %d", width, height));
+        LOG(LOG_LEVEL_TRACE, "  error width %d height %d", width, height);
         return FALSE;
     }
     dev->width = width;
@@ -171,7 +171,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screenPixmap);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex));
+        LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex);
         pScreen->SetScreenPixmap(screenPixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -192,7 +192,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     root->drawable.height = height;
     ResizeChildrenWinSize(root, 0, 0, 0, 0);
     RRGetInfo(pScreen, 1);
-    LLOGLN(LOG_LEVEL_INFO, ("  screen resized to %dx%d", pScreen->width, pScreen->height));
+    LOG(LOG_LEVEL_INFO, "  screen resized to %dx%d", pScreen->width, pScreen->height);
     RRScreenSizeNotify(pScreen);
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 13, 0, 0, 0)
     xf86EnableDisableFBAccess(pScreen->myNum, FALSE);
@@ -202,9 +202,9 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     xf86EnableDisableFBAccess(xf86Screens[pScreen->myNum], TRUE);
 #endif
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRRScreenSetSize: screenInfo x %d y %d "
+    LOG(LOG_LEVEL_INFO, "rdpRRScreenSetSize: screenInfo x %d y %d "
            "width %d height %d", screenInfo.x, screenInfo.y,
-           screenInfo.width, screenInfo.height));
+           screenInfo.width, screenInfo.height);
 
     return TRUE;
 }
@@ -215,7 +215,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
              int x, int y, Rotation rotation, int numOutputs,
              RROutputPtr *outputs)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRCrtcSet:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRCrtcSet:");
     return TRUE;
 }
 
@@ -223,7 +223,7 @@ rdpRRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
 Bool
 rdpRRCrtcSetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRCrtcSetGamma:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRCrtcSetGamma:");
     return TRUE;
 }
 
@@ -231,8 +231,8 @@ rdpRRCrtcSetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 Bool
 rdpRRCrtcGetGamma(ScreenPtr pScreen, RRCrtcPtr crtc)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
-           crtc->gammaBlue, crtc->gammaGreen));
+    LOG(LOG_LEVEL_INFO, "rdpRRCrtcGetGamma: %p %p %p %p", crtc, crtc->gammaRed,
+           crtc->gammaBlue, crtc->gammaGreen);
     return TRUE;
 }
 
@@ -241,7 +241,7 @@ Bool
 rdpRROutputSetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property,
                        RRPropertyValuePtr value)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputSetProperty:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRROutputSetProperty:");
     return TRUE;
 }
 
@@ -250,7 +250,7 @@ Bool
 rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
                         RRModePtr mode)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputValidateMode:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRROutputValidateMode:");
     return TRUE;
 }
 
@@ -258,14 +258,14 @@ rdpRROutputValidateMode(ScreenPtr pScreen, RROutputPtr output,
 void
 rdpRRModeDestroy(ScreenPtr pScreen, RRModePtr mode)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRModeDestroy:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRModeDestroy:");
 }
 
 /******************************************************************************/
 Bool
 rdpRROutputGetProperty(ScreenPtr pScreen, RROutputPtr output, Atom property)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRROutputGetProperty:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRROutputGetProperty:");
     return TRUE;
 }
 
@@ -315,8 +315,8 @@ rdpRRGetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
     BoxRec totalAreaRect;
     BoxRec trackingAreaRect;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRGetPanning: totalArea %p trackingArea %p border %p",
-                totalArea, trackingArea, border));
+    LOG(LOG_LEVEL_TRACE, "rdpRRGetPanning: totalArea %p trackingArea %p border %p",
+                totalArea, trackingArea, border);
 
     if (!g_panning)
     {
@@ -360,7 +360,7 @@ Bool
 rdpRRSetPanning(ScreenPtr pScreen, RRCrtcPtr crtc, BoxPtr totalArea,
                 BoxPtr trackingArea, INT16 *border)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRSetPanning:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRSetPanning:");
     return TRUE;
 }
 
@@ -372,7 +372,7 @@ rdpRRAddCrtc(rdpPtr dev)
     RRCrtcPtr crtc = RRCrtcCreate(dev->pScreen, NULL);
     if (crtc == 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddCrtc: RRCrtcCreate failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRAddCrtc: RRCrtcCreate failed");
         return 1;
     }
     /* Create and initialise (unused) gamma ramps */
@@ -396,12 +396,12 @@ rdpRRAddOutput(rdpPtr dev, const char *aname)
     output = RROutputCreate(dev->pScreen, aname, strlen(aname), NULL);
     if (output == 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddOutput: RROutputCreate failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRAddOutput: RROutputCreate failed");
         return 1;
     }
     if (!RROutputSetClones(output, NULL, 0))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRAddOutput: RROutputSetClones failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRAddOutput: RROutputSetClones failed");
         return 1;
     }
     return 0;
@@ -418,7 +418,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     char name[64];
     const int vfreq = 50;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpRRConnectOutput:"));
+    LOG(LOG_LEVEL_TRACE, "rdpRRConnectOutput:");
     sprintf (name, "%dx%d", width, height);
     modeInfo.width = width;
     modeInfo.height = height;
@@ -429,7 +429,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     mode = RRModeGet(&modeInfo, name);
     if (mode == 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RRModeGet failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRConnectOutput: RRModeGet failed");
         return 1;
     }
     /* Don't set the mode for the output unless we need to */
@@ -438,7 +438,7 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     {
         if (!RROutputSetModes(output, &mode, 1, 0))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetModes failed"));
+            LOG(LOG_LEVEL_INFO, "rdpRRConnectOutput: RROutputSetModes failed");
             return 1;
         }
     }
@@ -448,18 +448,18 @@ rdpRRConnectOutput(RROutputPtr output, RRCrtcPtr crtc,
     {
         if (!RROutputSetCrtcs(output, &crtc, 1))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetCrtcs failed"));
+            LOG(LOG_LEVEL_INFO, "rdpRRConnectOutput: RROutputSetCrtcs failed");
             return 1;
         }
     }
     if (!RROutputSetConnection(output, RR_Connected))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetConnection failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRConnectOutput: RROutputSetConnection failed");
         return 1;
     }
     if (!RROutputSetPhysicalSize(output, mmwidth, mmheight))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRConnectOutput: RROutputSetPhysicalSize failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRConnectOutput: RROutputSetPhysicalSize failed");
         return 1;
     }
     RRCrtcNotify(crtc, mode, x, y, RR_Rotate_0, NULL, 1, &output);
@@ -473,17 +473,17 @@ rdpRRDisconnectOutput(RROutputPtr output, RRCrtcPtr crtc)
 {
     if (!RROutputSetModes(output, NULL, 0, 0))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetModes failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRDisconnectOutput: RROutputSetModes failed");
         return 1;
     }
     if (!RROutputSetCrtcs(output, NULL, 0))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetCrtcs failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRDisconnectOutput: RROutputSetCrtcs failed");
         return 1;
     }
     if (!RROutputSetConnection(output, RR_Disconnected))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRDisconnectOutput: RROutputSetConnection failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRDisconnectOutput: RROutputSetConnection failed");
         return 1;
     }
     RRCrtcNotify(crtc, NULL, 0, 0, RR_Rotate_0, NULL, 0, NULL);
@@ -528,8 +528,8 @@ rdpRRSetRdpOutputs(rdpPtr dev)
     int rv = 0;
 
     pRRScrPriv = rrGetScrPriv(dev->pScreen);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
-           pRRScrPriv->numCrtcs, pRRScrPriv->numOutputs, dev->monitorCount));
+    LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: numCrtcs %d numOutputs %d monitorCount %d",
+           pRRScrPriv->numCrtcs, pRRScrPriv->numOutputs, dev->monitorCount);
     int count = (dev->monitorCount <= 0) ? 1 : dev->monitorCount;
 
     /* Ensure we've got enough CRT controllers and outputs */
@@ -546,7 +546,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
 
     if (rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: Failed to add CRTCs / Outputs"));
+        LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: Failed to add CRTCs / Outputs");
         return rv;
     }
 
@@ -558,9 +558,9 @@ rdpRRSetRdpOutputs(rdpPtr dev)
         height = dev->height;
         mmwidth = dev->pScreen->mmWidth;
         mmheight = dev->pScreen->mmHeight;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: update output %d "
+        LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: update output %d "
                "left %d top %d width %d height %d",
-               0, left, top, width, height));
+               0, left, top, width, height);
         rv = rdpRRConnectOutput(pRRScrPriv->outputs[0],
                                 pRRScrPriv->crtcs[0],
                                 left, top, width, height,
@@ -577,9 +577,9 @@ rdpRRSetRdpOutputs(rdpPtr dev)
             height = dev->minfo[index].bottom - dev->minfo[index].top + 1;
             mmwidth = dev->minfo[index].physical_width;
             mmheight = dev->minfo[index].physical_height;
-            LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: update output %d "
+            LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: update output %d "
                    "left %d top %d width %d height %d",
-                   index, left, top, width, height));
+                   index, left, top, width, height);
             rv = rdpRRConnectOutput(pRRScrPriv->outputs[index],
                                     pRRScrPriv->crtcs[index],
                                     left, top, width, height,
@@ -601,7 +601,7 @@ rdpRRSetRdpOutputs(rdpPtr dev)
 
     if (rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRRSetRdpOutputs: rdpRRSetRdpOutputs failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRRSetRdpOutputs: rdpRRSetRdpOutputs failed");
     }
     return rv;
 }

--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -130,8 +130,9 @@ rdpRandRGridWriteString(int fd, const char *str)
     written = write(fd, str, to_write);
     if (written != to_write)
     {
-        LOG(LOG_LEVEL_INFO, "rdpRandRGridWriteString: write failed fd %d written %d "
-               "to_write %d", fd, written, to_write);
+        LOG(LOG_LEVEL_INFO,
+            "rdpRandRGridWriteString: write failed fd %d written %d "
+            "to_write %d", fd, written, to_write);
         return 1;
     }
     return 0;
@@ -167,7 +168,7 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     if (fd == -1)
     {
         LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: open %s failed",
-               cmd_file->filename);
+            cmd_file->filename);
         free(cmd_file);
         return 1;
     }
@@ -193,12 +194,12 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     snprintf(cmd_file->cmd, sizeof(cmd_file->cmd),
              "sh %s&", cmd_file->filename);
     LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: running command %s",
-           cmd_file->cmd);
+        cmd_file->cmd);
     system_rv = system(cmd_file->cmd);
     if (system_rv != 0)
     {
         LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: command %s returned %d",
-               cmd_file->cmd, system_rv);
+            cmd_file->cmd, system_rv);
         free(cmd_file);
         return 1;
     }

--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -130,8 +130,8 @@ rdpRandRGridWriteString(int fd, const char *str)
     written = write(fd, str, to_write);
     if (written != to_write)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridWriteString: write failed fd %d written %d "
-               "to_write %d", fd, written, to_write));
+        LOG(LOG_LEVEL_INFO, "rdpRandRGridWriteString: write failed fd %d written %d "
+               "to_write %d", fd, written, to_write);
         return 1;
     }
     return 0;
@@ -150,13 +150,13 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     cmd_file = g_new0(struct cmd_file_t, 1);
     if (cmd_file == NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: alloc failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: alloc failed");
         return 1;
     }
     env = getenv("HOME");
     if (env == NULL)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: getenv HOME failed"));
+        LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: getenv HOME failed");
         free(cmd_file);
         return 1;
     }
@@ -166,8 +166,8 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
               S_IRUSR | S_IWUSR);
     if (fd == -1)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: open %s failed",
-               cmd_file->filename));
+        LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: open %s failed",
+               cmd_file->filename);
         free(cmd_file);
         return 1;
     }
@@ -192,13 +192,13 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     close(fd);
     snprintf(cmd_file->cmd, sizeof(cmd_file->cmd),
              "sh %s&", cmd_file->filename);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: running command %s",
-           cmd_file->cmd));
+    LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: running command %s",
+           cmd_file->cmd);
     system_rv = system(cmd_file->cmd);
     if (system_rv != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: command %s returned %d",
-               cmd_file->cmd, system_rv));
+        LOG(LOG_LEVEL_INFO, "rdpRandRGridUpdateRunCmds: command %s returned %d",
+               cmd_file->cmd, system_rv);
         free(cmd_file);
         return 1;
     }

--- a/module/rdpRandRGrid.c
+++ b/module/rdpRandRGrid.c
@@ -130,7 +130,7 @@ rdpRandRGridWriteString(int fd, const char *str)
     written = write(fd, str, to_write);
     if (written != to_write)
     {
-        LLOGLN(0, ("rdpRandRGridWriteString: write failed fd %d written %d "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridWriteString: write failed fd %d written %d "
                "to_write %d", fd, written, to_write));
         return 1;
     }
@@ -150,13 +150,13 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     cmd_file = g_new0(struct cmd_file_t, 1);
     if (cmd_file == NULL)
     {
-        LLOGLN(0, ("rdpRandRGridUpdateRunCmds: alloc failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: alloc failed"));
         return 1;
     }
     env = getenv("HOME");
     if (env == NULL)
     {
-        LLOGLN(0, ("rdpRandRGridUpdateRunCmds: getenv HOME failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: getenv HOME failed"));
         free(cmd_file);
         return 1;
     }
@@ -166,7 +166,7 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
               S_IRUSR | S_IWUSR);
     if (fd == -1)
     {
-        LLOGLN(0, ("rdpRandRGridUpdateRunCmds: open %s failed",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: open %s failed",
                cmd_file->filename));
         free(cmd_file);
         return 1;
@@ -192,12 +192,12 @@ rdpRandRGridUpdateRunCmds(struct monitors_t *monitors)
     close(fd);
     snprintf(cmd_file->cmd, sizeof(cmd_file->cmd),
              "sh %s&", cmd_file->filename);
-    LLOGLN(0, ("rdpRandRGridUpdateRunCmds: running command %s",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: running command %s",
            cmd_file->cmd));
     system_rv = system(cmd_file->cmd);
     if (system_rv != 0)
     {
-        LLOGLN(0, ("rdpRandRGridUpdateRunCmds: command %s returned %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpRandRGridUpdateRunCmds: command %s returned %d",
                cmd_file->cmd, system_rv));
         free(cmd_file);
         return 1;

--- a/module/rdpSetSpans.c
+++ b/module/rdpSetSpans.c
@@ -59,7 +59,7 @@ void
 rdpSetSpans(DrawablePtr pDrawable, GCPtr pGC, char *psrc,
             DDXPointPtr ppt, int *pwidth, int nspans, int fSorted)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSetSpans:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSetSpans:");
     /* do original call */
     rdpSetSpansOrg(pDrawable, pGC, psrc, ppt, pwidth, nspans, fSorted);
 }

--- a/module/rdpSetSpans.c
+++ b/module/rdpSetSpans.c
@@ -59,7 +59,7 @@ void
 rdpSetSpans(DrawablePtr pDrawable, GCPtr pGC, char *psrc,
             DDXPointPtr ppt, int *pwidth, int nspans, int fSorted)
 {
-    LLOGLN(10, ("rdpSetSpans:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSetSpans:"));
     /* do original call */
     rdpSetSpansOrg(pDrawable, pGC, psrc, ppt, pwidth, nspans, fSorted);
 }

--- a/module/rdpSimd.c
+++ b/module/rdpSimd.c
@@ -322,7 +322,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
 
     dev = XRDPPTR(pScrn);
     /* assign functions */
-    LLOGLN(0, ("rdpSimdInit: assigning yuv functions"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: assigning yuv functions"));
     dev->yv12_to_rgb32 = YV12_to_RGB32;
     dev->i420_to_rgb32 = I420_to_RGB32;
     dev->yuy2_to_rgb32 = YUY2_to_RGB32;
@@ -337,7 +337,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
 #if defined(__x86_64__) || defined(__AMD64__) || defined (_M_AMD64)
         int ax, bx, cx, dx;
         cpuid_amd64(1, 0, &ax, &bx, &cx, &dx);
-        LLOGLN(0, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
                "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx));
         if (dx & (1 << 26)) /* SSE 2 */
         {
@@ -349,12 +349,12 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
             dev->a8r8g8b8_to_nv12_box = a8r8g8b8_to_nv12_box_amd64_sse2_wrap;
             dev->a8r8g8b8_to_nv12_709fr_box = a8r8g8b8_to_nv12_709fr_box_amd64_sse2_wrap;
             dev->a8r8g8b8_to_yuvalp_box = a8r8g8b8_to_yuvalp_box_amd64_sse2_wrap;
-            LLOGLN(0, ("rdpSimdInit: sse2 amd64 yuv functions assigned"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: sse2 amd64 yuv functions assigned"));
         }
 #elif defined(__x86__) || defined(_M_IX86) || defined(__i386__)
         int ax, bx, cx, dx;
         cpuid_x86(1, 0, &ax, &bx, &cx, &dx);
-        LLOGLN(0, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
+        LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
                "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx));
         if (dx & (1 << 26)) /* SSE 2 */
         {
@@ -366,7 +366,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
             dev->a8r8g8b8_to_nv12_box = a8r8g8b8_to_nv12_box_x86_sse2_wrap;
             dev->a8r8g8b8_to_nv12_709fr_box = a8r8g8b8_to_nv12_709fr_box_x86_sse2_wrap;
             dev->a8r8g8b8_to_yuvalp_box = a8r8g8b8_to_yuvalp_box_x86_sse2_wrap;
-            LLOGLN(0, ("rdpSimdInit: sse2 x86 yuv functions assigned"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: sse2 x86 yuv functions assigned"));
         }
 #endif
     }

--- a/module/rdpSimd.c
+++ b/module/rdpSimd.c
@@ -322,7 +322,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
 
     dev = XRDPPTR(pScrn);
     /* assign functions */
-    LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: assigning yuv functions"));
+    LOG(LOG_LEVEL_INFO, "rdpSimdInit: assigning yuv functions");
     dev->yv12_to_rgb32 = YV12_to_RGB32;
     dev->i420_to_rgb32 = I420_to_RGB32;
     dev->yuy2_to_rgb32 = YUY2_to_RGB32;
@@ -337,8 +337,8 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
 #if defined(__x86_64__) || defined(__AMD64__) || defined (_M_AMD64)
         int ax, bx, cx, dx;
         cpuid_amd64(1, 0, &ax, &bx, &cx, &dx);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
-               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx));
+        LOG(LOG_LEVEL_INFO, "rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
+               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
         if (dx & (1 << 26)) /* SSE 2 */
         {
             dev->yv12_to_rgb32 = yv12_to_rgb32_amd64_sse2;
@@ -349,13 +349,13 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
             dev->a8r8g8b8_to_nv12_box = a8r8g8b8_to_nv12_box_amd64_sse2_wrap;
             dev->a8r8g8b8_to_nv12_709fr_box = a8r8g8b8_to_nv12_709fr_box_amd64_sse2_wrap;
             dev->a8r8g8b8_to_yuvalp_box = a8r8g8b8_to_yuvalp_box_amd64_sse2_wrap;
-            LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: sse2 amd64 yuv functions assigned"));
+            LOG(LOG_LEVEL_INFO, "rdpSimdInit: sse2 amd64 yuv functions assigned");
         }
 #elif defined(__x86__) || defined(_M_IX86) || defined(__i386__)
         int ax, bx, cx, dx;
         cpuid_x86(1, 0, &ax, &bx, &cx, &dx);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
-               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx));
+        LOG(LOG_LEVEL_INFO, "rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
+               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
         if (dx & (1 << 26)) /* SSE 2 */
         {
             dev->yv12_to_rgb32 = yv12_to_rgb32_x86_sse2;
@@ -366,7 +366,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
             dev->a8r8g8b8_to_nv12_box = a8r8g8b8_to_nv12_box_x86_sse2_wrap;
             dev->a8r8g8b8_to_nv12_709fr_box = a8r8g8b8_to_nv12_709fr_box_x86_sse2_wrap;
             dev->a8r8g8b8_to_yuvalp_box = a8r8g8b8_to_yuvalp_box_x86_sse2_wrap;
-            LLOGLN(LOG_LEVEL_INFO, ("rdpSimdInit: sse2 x86 yuv functions assigned"));
+            LOG(LOG_LEVEL_INFO, "rdpSimdInit: sse2 x86 yuv functions assigned");
         }
 #endif
     }

--- a/module/rdpSimd.c
+++ b/module/rdpSimd.c
@@ -338,7 +338,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         int ax, bx, cx, dx;
         cpuid_amd64(1, 0, &ax, &bx, &cx, &dx);
         LOG(LOG_LEVEL_INFO, "rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
-               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
+            "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
         if (dx & (1 << 26)) /* SSE 2 */
         {
             dev->yv12_to_rgb32 = yv12_to_rgb32_amd64_sse2;
@@ -355,7 +355,7 @@ rdpSimdInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         int ax, bx, cx, dx;
         cpuid_x86(1, 0, &ax, &bx, &cx, &dx);
         LOG(LOG_LEVEL_INFO, "rdpSimdInit: cpuid ax 1 cx 0 return ax 0x%8.8x bx "
-               "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
+            "0x%8.8x cx 0x%8.8x dx 0x%8.8x", ax, bx, cx, dx);
         if (dx & (1 << 26)) /* SSE 2 */
         {
             dev->yv12_to_rgb32 = yv12_to_rgb32_x86_sse2;

--- a/module/rdpTrapezoids.c
+++ b/module/rdpTrapezoids.c
@@ -69,7 +69,7 @@ rdpTrapezoids(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpTrapezoids:"));
+    LOG(LOG_LEVEL_TRACE, "rdpTrapezoids:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpTrapezoidsCallCount++;

--- a/module/rdpTrapezoids.c
+++ b/module/rdpTrapezoids.c
@@ -69,7 +69,7 @@ rdpTrapezoids(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpTrapezoids:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpTrapezoids:"));
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpTrapezoidsCallCount++;

--- a/module/rdpTriangles.c
+++ b/module/rdpTriangles.c
@@ -69,7 +69,7 @@ rdpTriangles(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(10, ("rdpTriangles:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpTriangles:"));
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpTrianglesCallCount++;

--- a/module/rdpTriangles.c
+++ b/module/rdpTriangles.c
@@ -69,7 +69,7 @@ rdpTriangles(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     BoxRec box;
     RegionRec reg;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpTriangles:"));
+    LOG(LOG_LEVEL_TRACE, "rdpTriangles:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
     dev->counts.rdpTrianglesCallCount++;

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -92,7 +92,7 @@ xrdpVidPutVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(10, ("xrdpVidPutVideo:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutVideo:"));
     return Success;
 }
 
@@ -103,7 +103,7 @@ xrdpVidPutStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(10, ("xrdpVidPutStill:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutStill:"));
     return Success;
 }
 
@@ -114,7 +114,7 @@ xrdpVidGetVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(10, ("xrdpVidGetVideo:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidGetVideo:"));
     return Success;
 }
 
@@ -125,7 +125,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(10, ("FBDevTIVidGetStill:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("FBDevTIVidGetStill:"));
     return Success;
 }
 
@@ -133,7 +133,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
 static void
 xrdpVidStopVideo(ScrnInfoPtr pScrn, pointer data, Bool Cleanup)
 {
-    LLOGLN(10, ("xrdpVidStopVideo:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidStopVideo:"));
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ static int
 xrdpVidSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 value, pointer data)
 {
-    LLOGLN(10, ("xrdpVidSetPortAttribute:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidSetPortAttribute:"));
     return Success;
 }
 
@@ -150,7 +150,7 @@ static int
 xrdpVidGetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 *value, pointer data)
 {
-    LLOGLN(10, ("xrdpVidGetPortAttribute:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidGetPortAttribute:"));
     return Success;
 }
 
@@ -160,7 +160,7 @@ xrdpVidQueryBestSize(ScrnInfoPtr pScrn, Bool motion,
                      short vid_w, short vid_h, short drw_w, short drw_h,
                      unsigned int *p_w, unsigned int *p_h, pointer data)
 {
-    LLOGLN(10, ("xrdpVidQueryBestSize:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryBestSize:"));
 }
 
 /*****************************************************************************/
@@ -396,7 +396,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
 
     oh = (src_w << 16) / dst_w;
     ov = (src_h << 16) / dst_h;
-    LLOGLN(10, ("stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov));
+    LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov));
     iv = ov;
     lndex = src_y;
     last_lndex = -1;
@@ -405,7 +405,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
         if (lndex == last_lndex)
         {
             /* repeat line */
-            LLOGLN(10, ("stretch_RGB32_RGB32: repeat line"));
+            LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: repeat line"));
             dst32 = dst + index * dst_w;
             src32 = dst32 - dst_w;
             g_memcpy(dst32, src32, dst_w * 4);
@@ -440,7 +440,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
         iv += ov;
 
     }
-    LLOGLN(10, ("stretch_RGB32_RGB32: out"));
+    LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: out"));
     return 0;
 }
 
@@ -451,7 +451,7 @@ rdpDeferredXvCleanup(OsTimerPtr timer, CARD32 now, pointer arg)
 {
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpDeferredXvCleanup:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredXvCleanup:"));
     dev = (rdpPtr) arg;
     dev->xv_timer_scheduled = 0;
     dev->xv_data_bytes = 0;
@@ -478,8 +478,8 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     int error;
     GCPtr tempGC;
 
-    LLOGLN(10, ("xrdpVidPutImage: format 0x%8.8x", format));
-    LLOGLN(10, ("xrdpVidPutImage: src_x %d srcy_y %d", src_x, src_y));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: format 0x%8.8x", format));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: src_x %d srcy_y %d", src_x, src_y));
     dev = XRDPPTR(pScrn);
 
     if (dev->xv_timer_scheduled)
@@ -502,7 +502,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
         dev->xv_data = g_new(uint8_t, index);
         if (dev->xv_data == NULL)
         {
-            LLOGLN(0, ("xrdpVidPutImage: memory alloc error"));
+            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidPutImage: memory alloc error"));
             dev->xv_data_bytes = 0;
             return Success;
         }
@@ -516,23 +516,23 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     switch (format)
     {
         case FOURCC_YV12:
-            LLOGLN(10, ("xrdpVidPutImage: FOURCC_YV12"));
+            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_YV12"));
             error = dev->yv12_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_I420:
-            LLOGLN(10, ("xrdpVidPutImage: FOURCC_I420"));
+            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_I420"));
             error = dev->i420_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_YUY2:
-            LLOGLN(10, ("xrdpVidPutImage: FOURCC_YUY2"));
+            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_YUY2"));
             error = dev->yuy2_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_UYVY:
-            LLOGLN(10, ("xrdpVidPutImage: FOURCC_UYVY"));
+            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_UYVY"));
             error = dev->uyvy_to_rgb32(buf, width, height, rgborg32);
             break;
         default:
-            LLOGLN(0, ("xrdpVidPutImage: unknown format 0x%8.8x", format));
+            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidPutImage: unknown format 0x%8.8x", format));
             return Success;
     }
     if (error != 0)
@@ -541,7 +541,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     }
     if ((width == drw_w) && (height == drw_h))
     {
-        LLOGLN(10, ("xrdpVidPutImage: stretch skip"));
+        LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: stretch skip"));
         rgbend32 = rgborg32;
     }
     else
@@ -578,7 +578,7 @@ xrdpVidQueryImageAttributes(ScrnInfoPtr pScrn, int id,
 {
     int size, tmp;
 
-    LLOGLN(10, ("xrdpVidQueryImageAttributes:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryImageAttributes:"));
     /* this is same code as all drivers currently have */
     if (*w > 2046)
     {
@@ -638,10 +638,10 @@ xrdpVidQueryImageAttributes(ScrnInfoPtr pScrn, int id,
             size *= *h;
             break;
         default:
-            LLOGLN(0, ("xrdpVidQueryImageAttributes: Unsupported image"));
+            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidQueryImageAttributes: Unsupported image"));
             return 0;
     }
-    LLOGLN(10, ("xrdpVidQueryImageAttributes: finished size %d id 0x%x", size, id));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryImageAttributes: finished size %d id 0x%x", size, id));
     return size;
 }
 
@@ -694,14 +694,14 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor = glamor_xv_init(pScreen, 16);
         if (adaptor == 0)
         {
-            LLOGLN(0, ("rdpXvInit: glamor_xv_init failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: glamor_xv_init failed"));
             return 0;
         }
         dev->xvPutImage = adaptor->PutImage;
         adaptor->PutImage = xrdpXvPutImageWrap;
         if (!xf86XVScreenInit(pScreen, &adaptor, 1))
         {
-            LLOGLN(0, ("rdpXvInit: xf86XVScreenInit failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVScreenInit failed"));
             return 0;
         }
 #endif
@@ -711,7 +711,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor = xf86XVAllocateVideoAdaptorRec(pScrn);
         if (adaptor == 0)
         {
-            LLOGLN(0, ("rdpXvInit: xf86XVAllocateVideoAdaptorRec failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVAllocateVideoAdaptorRec failed"));
             return 0;
         }
         adaptor->type = XvInputMask | XvImageMask | XvVideoMask | XvStillMask | XvWindowMask | XvPixmapMask;
@@ -726,7 +726,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor->nFormats = T_NUM_FORMATS;
         adaptor->pFormats = &(g_xrdpVidFormats[0]);
         adaptor->pFormats[0].depth = pScrn->depth;
-        LLOGLN(0, ("rdpXvInit: depth %d", pScrn->depth));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: depth %d", pScrn->depth));
         adaptor->nImages = sizeof(g_xrdpVidImages) / sizeof(XF86ImageRec);
         adaptor->pImages = g_xrdpVidImages;
         adaptor->nAttributes = 0;
@@ -746,7 +746,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor->QueryImageAttributes = xrdpVidQueryImageAttributes;
         if (!xf86XVScreenInit(pScreen, &adaptor, 1))
         {
-            LLOGLN(0, ("rdpXvInit: xf86XVScreenInit failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVScreenInit failed"));
             return 0;
         }
         xf86XVFreeVideoAdaptorRec(adaptor);

--- a/module/rdpXv.c
+++ b/module/rdpXv.c
@@ -92,7 +92,7 @@ xrdpVidPutVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutVideo:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidPutVideo:");
     return Success;
 }
 
@@ -103,7 +103,7 @@ xrdpVidPutStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutStill:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidPutStill:");
     return Success;
 }
 
@@ -114,7 +114,7 @@ xrdpVidGetVideo(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidGetVideo:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidGetVideo:");
     return Success;
 }
 
@@ -125,7 +125,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
                 short drw_w, short drw_h, RegionPtr clipBoxes,
                 pointer data, DrawablePtr pDraw)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("FBDevTIVidGetStill:"));
+    LOG(LOG_LEVEL_TRACE, "FBDevTIVidGetStill:");
     return Success;
 }
 
@@ -133,7 +133,7 @@ xrdpVidGetStill(ScrnInfoPtr pScrn, short vid_x, short vid_y,
 static void
 xrdpVidStopVideo(ScrnInfoPtr pScrn, pointer data, Bool Cleanup)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidStopVideo:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidStopVideo:");
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ static int
 xrdpVidSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 value, pointer data)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidSetPortAttribute:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidSetPortAttribute:");
     return Success;
 }
 
@@ -150,7 +150,7 @@ static int
 xrdpVidGetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
                         INT32 *value, pointer data)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidGetPortAttribute:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidGetPortAttribute:");
     return Success;
 }
 
@@ -160,7 +160,7 @@ xrdpVidQueryBestSize(ScrnInfoPtr pScrn, Bool motion,
                      short vid_w, short vid_h, short drw_w, short drw_h,
                      unsigned int *p_w, unsigned int *p_h, pointer data)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryBestSize:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidQueryBestSize:");
 }
 
 /*****************************************************************************/
@@ -396,7 +396,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
 
     oh = (src_w << 16) / dst_w;
     ov = (src_h << 16) / dst_h;
-    LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov));
+    LOG(LOG_LEVEL_TRACE, "stretch_RGB32_RGB32: oh 0x%8.8x ov 0x%8.8x", oh, ov);
     iv = ov;
     lndex = src_y;
     last_lndex = -1;
@@ -405,7 +405,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
         if (lndex == last_lndex)
         {
             /* repeat line */
-            LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: repeat line"));
+            LOG(LOG_LEVEL_TRACE, "stretch_RGB32_RGB32: repeat line");
             dst32 = dst + index * dst_w;
             src32 = dst32 - dst_w;
             g_memcpy(dst32, src32, dst_w * 4);
@@ -440,7 +440,7 @@ stretch_RGB32_RGB32(int *src, int src_width, int src_height,
         iv += ov;
 
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("stretch_RGB32_RGB32: out"));
+    LOG(LOG_LEVEL_TRACE, "stretch_RGB32_RGB32: out");
     return 0;
 }
 
@@ -451,7 +451,7 @@ rdpDeferredXvCleanup(OsTimerPtr timer, CARD32 now, pointer arg)
 {
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredXvCleanup:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredXvCleanup:");
     dev = (rdpPtr) arg;
     dev->xv_timer_scheduled = 0;
     dev->xv_data_bytes = 0;
@@ -478,8 +478,8 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     int error;
     GCPtr tempGC;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: format 0x%8.8x", format));
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: src_x %d srcy_y %d", src_x, src_y));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: format 0x%8.8x", format);
+    LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: src_x %d srcy_y %d", src_x, src_y);
     dev = XRDPPTR(pScrn);
 
     if (dev->xv_timer_scheduled)
@@ -502,7 +502,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
         dev->xv_data = g_new(uint8_t, index);
         if (dev->xv_data == NULL)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidPutImage: memory alloc error"));
+            LOG(LOG_LEVEL_INFO, "xrdpVidPutImage: memory alloc error");
             dev->xv_data_bytes = 0;
             return Success;
         }
@@ -516,23 +516,23 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     switch (format)
     {
         case FOURCC_YV12:
-            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_YV12"));
+            LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: FOURCC_YV12");
             error = dev->yv12_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_I420:
-            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_I420"));
+            LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: FOURCC_I420");
             error = dev->i420_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_YUY2:
-            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_YUY2"));
+            LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: FOURCC_YUY2");
             error = dev->yuy2_to_rgb32(buf, width, height, rgborg32);
             break;
         case FOURCC_UYVY:
-            LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: FOURCC_UYVY"));
+            LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: FOURCC_UYVY");
             error = dev->uyvy_to_rgb32(buf, width, height, rgborg32);
             break;
         default:
-            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidPutImage: unknown format 0x%8.8x", format));
+            LOG(LOG_LEVEL_INFO, "xrdpVidPutImage: unknown format 0x%8.8x", format);
             return Success;
     }
     if (error != 0)
@@ -541,7 +541,7 @@ xrdpVidPutImage(ScrnInfoPtr pScrn,
     }
     if ((width == drw_w) && (height == drw_h))
     {
-        LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidPutImage: stretch skip"));
+        LOG(LOG_LEVEL_TRACE, "xrdpVidPutImage: stretch skip");
         rgbend32 = rgborg32;
     }
     else
@@ -578,7 +578,7 @@ xrdpVidQueryImageAttributes(ScrnInfoPtr pScrn, int id,
 {
     int size, tmp;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryImageAttributes:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidQueryImageAttributes:");
     /* this is same code as all drivers currently have */
     if (*w > 2046)
     {
@@ -638,10 +638,10 @@ xrdpVidQueryImageAttributes(ScrnInfoPtr pScrn, int id,
             size *= *h;
             break;
         default:
-            LLOGLN(LOG_LEVEL_INFO, ("xrdpVidQueryImageAttributes: Unsupported image"));
+            LOG(LOG_LEVEL_INFO, "xrdpVidQueryImageAttributes: Unsupported image");
             return 0;
     }
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpVidQueryImageAttributes: finished size %d id 0x%x", size, id));
+    LOG(LOG_LEVEL_TRACE, "xrdpVidQueryImageAttributes: finished size %d id 0x%x", size, id);
     return size;
 }
 
@@ -694,14 +694,14 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor = glamor_xv_init(pScreen, 16);
         if (adaptor == 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: glamor_xv_init failed"));
+            LOG(LOG_LEVEL_INFO, "rdpXvInit: glamor_xv_init failed");
             return 0;
         }
         dev->xvPutImage = adaptor->PutImage;
         adaptor->PutImage = xrdpXvPutImageWrap;
         if (!xf86XVScreenInit(pScreen, &adaptor, 1))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVScreenInit failed"));
+            LOG(LOG_LEVEL_INFO, "rdpXvInit: xf86XVScreenInit failed");
             return 0;
         }
 #endif
@@ -711,7 +711,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor = xf86XVAllocateVideoAdaptorRec(pScrn);
         if (adaptor == 0)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVAllocateVideoAdaptorRec failed"));
+            LOG(LOG_LEVEL_INFO, "rdpXvInit: xf86XVAllocateVideoAdaptorRec failed");
             return 0;
         }
         adaptor->type = XvInputMask | XvImageMask | XvVideoMask | XvStillMask | XvWindowMask | XvPixmapMask;
@@ -726,7 +726,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor->nFormats = T_NUM_FORMATS;
         adaptor->pFormats = &(g_xrdpVidFormats[0]);
         adaptor->pFormats[0].depth = pScrn->depth;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: depth %d", pScrn->depth));
+        LOG(LOG_LEVEL_INFO, "rdpXvInit: depth %d", pScrn->depth);
         adaptor->nImages = sizeof(g_xrdpVidImages) / sizeof(XF86ImageRec);
         adaptor->pImages = g_xrdpVidImages;
         adaptor->nAttributes = 0;
@@ -746,7 +746,7 @@ rdpXvInit(ScreenPtr pScreen, ScrnInfoPtr pScrn)
         adaptor->QueryImageAttributes = xrdpVidQueryImageAttributes;
         if (!xf86XVScreenInit(pScreen, &adaptor, 1))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpXvInit: xf86XVScreenInit failed"));
+            LOG(LOG_LEVEL_INFO, "rdpXvInit: xf86XVScreenInit failed");
             return 0;
         }
         xf86XVFreeVideoAdaptorRec(adaptor);

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -200,7 +200,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
                 {
                     dev->glamor = TRUE;
                     LOG(LOG_LEVEL_INFO, "rdpPreInit: drm device looks ok, "
-                           "use glamor set");
+                        "use glamor set");
                     break;
                 }
                 token = strtok(NULL, delim);
@@ -299,7 +299,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         }
         xf86DrvMsg(pScrn->scrnIndex, X_INFO, "\tmode \"%s\" ok\n", *modename);
         LOG(LOG_LEVEL_TRACE, "%d %d %d %d", mode->HDisplay, dev->width,
-               mode->VDisplay, dev->height);
+            mode->VDisplay, dev->height);
         if ((mode->HDisplay == dev->width) && (mode->VDisplay == dev->height))
         {
             pScrn->virtualX = mode->HDisplay;
@@ -320,8 +320,9 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     LOG(LOG_LEVEL_TRACE, "rdpPreInit: out fPtr->num_modes %d", dev->num_modes);
     if (!got_res_match)
     {
-        LOG(LOG_LEVEL_INFO, "rdpPreInit: could not find screen resolution %dx%d",
-               dev->width, dev->height);
+        LOG(LOG_LEVEL_INFO,
+            "rdpPreInit: could not find screen resolution %dx%d",
+            dev->width, dev->height);
         return FALSE;
     }
     if (dev->glamor)
@@ -588,8 +589,9 @@ rdpCreateScreenResources(ScreenPtr pScreen)
         PixmapPtr screen_pixmap;
         uint32_t screen_tex;
         old_screen_pixmap = dev->screenSwPixmap;
-        LOG(LOG_LEVEL_INFO, "rdpCreateScreenResources: create screen pixmap w %d h %d",
-               pScreen->width, pScreen->height);
+        LOG(LOG_LEVEL_INFO,
+            "rdpCreateScreenResources: create screen pixmap w %d h %d",
+            pScreen->width, pScreen->height);
         screen_pixmap = pScreen->CreatePixmap(pScreen,
                                               pScreen->width,
                                               pScreen->height,
@@ -600,7 +602,8 @@ rdpCreateScreenResources(ScreenPtr pScreen)
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screen_pixmap);
-        LOG(LOG_LEVEL_INFO, "rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex);
+        LOG(LOG_LEVEL_INFO,
+            "rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex);
         pScreen->SetScreenPixmap(screen_pixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -635,8 +638,9 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     miSetVisualTypes(pScrn->depth, miGetDefaultVisualMask(pScrn->depth),
                      pScrn->rgbBits, TrueColor);
     miSetPixmapDepths();
-    LOG(LOG_LEVEL_INFO, "rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
-           pScrn->virtualX, pScrn->virtualY, pScrn->rgbBits, pScrn->depth);
+    LOG(LOG_LEVEL_INFO,
+        "rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
+        pScrn->virtualX, pScrn->virtualY, pScrn->rgbBits, pScrn->depth);
 
     dev->depth = pScrn->depth;
     dev->paddedWidthInBytes = PixmapBytePad(dev->width, dev->depth);
@@ -935,7 +939,8 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_device, val, 127);
             g_drm_device[127] = 0;
-            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRMDevice xorg.conf value [%s]", val);
+            LOG(LOG_LEVEL_INFO,
+                "rdpProbe: found DRMDevice xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI2");
@@ -948,7 +953,8 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri2 = 0;
             }
-            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRI2 xorg.conf value [%s]", val);
+            LOG(LOG_LEVEL_INFO,
+                "rdpProbe: found DRI2 xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI3");
@@ -961,7 +967,8 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri3 = 0;
             }
-            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRI3 xorg.conf value [%s]", val);
+            LOG(LOG_LEVEL_INFO,
+                "rdpProbe: found DRI3 xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRMAllowList");
@@ -970,7 +977,8 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_allow_list, val, 127);
             g_drm_device[127] = 0;
-            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRMAllowList xorg.conf value [%s]", val);
+            LOG(LOG_LEVEL_INFO,
+                "rdpProbe: found DRMAllowList xorg.conf value [%s]", val);
 #endif
         }
         entity = xf86ClaimFbSlot(drv, 0, dev_sections[i], 1);

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -110,7 +110,7 @@ static XF86ModuleVersionInfo g_VersRec =
 static Bool
 rdpAllocRec(ScrnInfoPtr pScrn)
 {
-    LLOGLN(10, ("rdpAllocRec:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpAllocRec:"));
     if (pScrn->reservedPtr[0] != NULL)
     {
         return TRUE;
@@ -124,7 +124,7 @@ rdpAllocRec(ScrnInfoPtr pScrn)
 static void
 rdpFreeRec(ScrnInfoPtr pScrn)
 {
-    LLOGLN(10, ("rdpFreeRec:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpFreeRec:"));
     if (pScrn->reservedPtr[0] == NULL)
     {
         return;
@@ -148,7 +148,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     DisplayModePtr mode;
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpPreInit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit:"));
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -172,14 +172,14 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     dev->fd = open(g_drm_device, O_RDWR, 0);
     if (dev->fd == -1)
     {
-        LLOGLN(0, ("rdpPreInit: %s open failed", g_drm_device));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: %s open failed", g_drm_device));
     }
     else
     {
         struct drm_version dver;
         char delim[] = " ";
         char *token;
-        LLOGLN(0, ("rdpPreInit: %s open ok, fd %d", g_drm_device, dev->fd));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: %s open ok, fd %d", g_drm_device, dev->fd));
         memset(&dver, 0, sizeof(dver));
         dver.name_len = 256;
         dver.name = g_new0(char, dver.name_len);
@@ -189,17 +189,17 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         dver.desc = g_new0(char, dver.desc_len);
         if (ioctl(dev->fd, DRM_IOCTL_VERSION, &dver) != -1)
         {
-            LLOGLN(0, ("rdpPreInit: name [%s]", dver.name));
-            LLOGLN(0, ("rdpPreInit: date [%s]", dver.date));
-            LLOGLN(0, ("rdpPreInit: desc [%s]", dver.desc));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: name [%s]", dver.name));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: date [%s]", dver.date));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: desc [%s]", dver.desc));
             token = strtok(g_drm_allow_list, delim);
             while (token != NULL)
             {
-                LLOGLN(10, ("rdpPreInit: token [%s]", token));
+                LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit: token [%s]", token));
                 if (strstr(dver.name, token) != NULL)
                 {
                     dev->glamor = TRUE;
-                    LLOGLN(0, ("rdpPreInit: drm device looks ok, "
+                    LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: drm device looks ok, "
                            "use glamor set"));
                     break;
                 }
@@ -207,12 +207,12 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
             }
             if (dev->glamor == FALSE)
             {
-                LLOGLN(0, ("rdpPreInit: unsupported render node"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: unsupported render node"));
             }
         }
         else
         {
-            LLOGLN(0, ("rdpPreInit: DRM_IOCTL_VERSION failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: DRM_IOCTL_VERSION failed"));
         }
         free(dver.name);
         free(dver.date);
@@ -246,33 +246,33 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
                          Support24bppFb | Support32bppFb |
                          SupportConvert32to24 | SupportConvert24to32))
     {
-        LLOGLN(0, ("rdpPreInit: xf86SetDepthBpp failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetDepthBpp failed"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
     xf86PrintDepthBpp(pScrn);
     if (!xf86SetWeight(pScrn, zeros1, zeros1))
     {
-        LLOGLN(0, ("rdpPreInit: xf86SetWeight failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetWeight failed"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
     if (!xf86SetGamma(pScrn, zeros2))
     {
-        LLOGLN(0, ("rdpPreInit: xf86SetGamma failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetGamma failed"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
     if (!xf86SetDefaultVisual(pScrn, -1))
     {
-        LLOGLN(0, ("rdpPreInit: xf86SetDefaultVisual failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetDefaultVisual failed"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
     xf86SetDpi(pScrn, 0, 0);
     if (0 == pScrn->display->modes)
     {
-        LLOGLN(0, ("rdpPreInit: modes error"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: modes error"));
         rdpFreeRec(pScrn);
         return FALSE;
     }
@@ -285,7 +285,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     {
         for (mode = pScrn->monitor->Modes; mode != 0; mode = mode->next)
         {
-            LLOGLN(10, ("%s %s", mode->name, *modename));
+            LLOGLN(LOG_LEVEL_TRACE, ("%s %s", mode->name, *modename));
             if (0 == strcmp(mode->name, *modename))
             {
                 break;
@@ -298,7 +298,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
             continue;
         }
         xf86DrvMsg(pScrn->scrnIndex, X_INFO, "\tmode \"%s\" ok\n", *modename);
-        LLOGLN(10, ("%d %d %d %d", mode->HDisplay, dev->width,
+        LLOGLN(LOG_LEVEL_TRACE, ("%d %d %d %d", mode->HDisplay, dev->width,
                mode->VDisplay, dev->height));
         if ((mode->HDisplay == dev->width) && (mode->VDisplay == dev->height))
         {
@@ -317,10 +317,10 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     }
     pScrn->currentMode = pScrn->modes;
     xf86PrintModes(pScrn);
-    LLOGLN(10, ("rdpPreInit: out fPtr->num_modes %d", dev->num_modes));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit: out fPtr->num_modes %d", dev->num_modes));
     if (!got_res_match)
     {
-        LLOGLN(0, ("rdpPreInit: could not find screen resolution %dx%d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: could not find screen resolution %dx%d",
                dev->width, dev->height));
         return FALSE;
     }
@@ -329,20 +329,20 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
 #if defined(XORGXRDP_GLAMOR)
         if (xf86LoadSubModule(pScrn, GLAMOR_EGL_MODULE_NAME))
         {
-            LLOGLN(0, ("rdpPreInit: glamor module load ok"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor module load ok"));
             if (glamor_egl_init(pScrn, dev->fd))
             {
-                LLOGLN(0, ("rdpPreInit: glamor init ok"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor init ok"));
             }
             else
             {
-                LLOGLN(0, ("rdpPreInit: glamor init failed"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor init failed"));
                 dev->glamor = FALSE;
             }
         }
         else
         {
-            LLOGLN(0, ("rdpPreInit: glamor module load failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor module load failed"));
             dev->glamor = FALSE;
         }
 #endif
@@ -366,7 +366,7 @@ static miPointerSpriteFuncRec g_rdpSpritePointerFuncs =
 static Bool
 rdpSaveScreen(ScreenPtr pScreen, int on)
 {
-    LLOGLN(10, ("rdpSaveScreen:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSaveScreen:"));
     return TRUE;
 }
 
@@ -379,7 +379,7 @@ rdpResizeSession(rdpPtr dev, int width, int height)
     ScrnInfoPtr pScrn;
     Bool ok;
 
-    LLOGLN(0, ("rdpResizeSession: width %d height %d", width, height));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpResizeSession: width %d height %d", width, height));
     pScrn = xf86Screens[dev->pScreen->myNum];
     mmwidth = PixelToMM(width, pScrn->xDpi);
     mmheight = PixelToMM(height, pScrn->yDpi);
@@ -387,11 +387,11 @@ rdpResizeSession(rdpPtr dev, int width, int height)
     ok = TRUE;
     if ((dev->width != width) || (dev->height != height))
     {
-        LLOGLN(0, ("  calling RRScreenSizeSet"));
+        LLOGLN(LOG_LEVEL_INFO, ("  calling RRScreenSizeSet"));
         dev->allow_screen_resize = 1;
         ok = RRScreenSizeSet(dev->pScreen, width, height, mmwidth, mmheight);
         dev->allow_screen_resize = 0;
-        LLOGLN(0, ("  RRScreenSizeSet ok %d", ok));
+        LLOGLN(LOG_LEVEL_INFO, ("  RRScreenSizeSet ok %d", ok));
     }
     return ok;
 }
@@ -403,7 +403,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(10, ("xorgxrdpDamageReport:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageReport:"));
     pScreen = (ScreenPtr)closure;
     dev = rdpGetDevFromScreen(pScreen);
     rdpClientConAddAllReg(dev, pRegion, &(pScreen->root->drawable));
@@ -413,7 +413,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(10, ("xorgxrdpDamageDestroy:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageDestroy:"));
 }
 
 /******************************************************************************/
@@ -451,11 +451,11 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
 
     pScreen = (ScreenPtr) arg;
     dev = rdpGetDevFromScreen(pScreen);
-    LLOGLN(10, ("rdpDeferredRandR:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredRandR:"));
     pRRScrPriv = rrGetScrPriv(pScreen);
     if (pRRScrPriv == 0)
     {
-        LLOGLN(0, ("rdpDeferredRandR: rrGetScrPriv failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredRandR: rrGetScrPriv failed"));
         return 1;
     }
 
@@ -472,18 +472,18 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
     dev->rrGetPanning         = pRRScrPriv->rrGetPanning;
     dev->rrSetPanning         = pRRScrPriv->rrSetPanning;
 
-    LLOGLN(10, ("  rrSetConfig = %p", dev->rrSetConfig));
-    LLOGLN(10, ("  rrGetInfo = %p", dev->rrGetInfo));
-    LLOGLN(10, ("  rrScreenSetSize = %p", dev->rrScreenSetSize));
-    LLOGLN(10, ("  rrCrtcSet = %p", dev->rrCrtcSet));
-    LLOGLN(10, ("  rrCrtcSetGamma = %p", dev->rrCrtcSetGamma));
-    LLOGLN(10, ("  rrCrtcGetGamma = %p", dev->rrCrtcGetGamma));
-    LLOGLN(10, ("  rrOutputSetProperty = %p", dev->rrOutputSetProperty));
-    LLOGLN(10, ("  rrOutputValidateMode = %p", dev->rrOutputValidateMode));
-    LLOGLN(10, ("  rrModeDestroy = %p", dev->rrModeDestroy));
-    LLOGLN(10, ("  rrOutputGetProperty = %p", dev->rrOutputGetProperty));
-    LLOGLN(10, ("  rrGetPanning = %p", dev->rrGetPanning));
-    LLOGLN(10, ("  rrSetPanning = %p", dev->rrSetPanning));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrSetConfig = %p", dev->rrSetConfig));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrGetInfo = %p", dev->rrGetInfo));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrScreenSetSize = %p", dev->rrScreenSetSize));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcSet = %p", dev->rrCrtcSet));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcSetGamma = %p", dev->rrCrtcSetGamma));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcGetGamma = %p", dev->rrCrtcGetGamma));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputSetProperty = %p", dev->rrOutputSetProperty));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputValidateMode = %p", dev->rrOutputValidateMode));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrModeDestroy = %p", dev->rrModeDestroy));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputGetProperty = %p", dev->rrOutputGetProperty));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrGetPanning = %p", dev->rrGetPanning));
+    LLOGLN(LOG_LEVEL_TRACE, ("  rrSetPanning = %p", dev->rrSetPanning));
 
     pRRScrPriv->rrSetConfig          = rdpRRSetConfig;
     pRRScrPriv->rrGetInfo            = rdpRRGetInfo;
@@ -553,7 +553,7 @@ rdpSetPixmapVisitWindow(WindowPtr window, void *data)
 {
     ScreenPtr screen;
 
-    LLOGLN(10, ("rdpSetPixmapVisitWindow:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSetPixmapVisitWindow:"));
     screen = window->drawable.pScreen;
     if (screen->GetWindowPixmap(window) == data)
     {
@@ -571,7 +571,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(10, ("rdpCreateScreenResources:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateScreenResources:"));
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -588,7 +588,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
         PixmapPtr screen_pixmap;
         uint32_t screen_tex;
         old_screen_pixmap = dev->screenSwPixmap;
-        LLOGLN(0, ("rdpCreateScreenResources: create screen pixmap w %d h %d",
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCreateScreenResources: create screen pixmap w %d h %d",
                pScreen->width, pScreen->height));
         screen_pixmap = pScreen->CreatePixmap(pScreen,
                                               pScreen->width,
@@ -600,7 +600,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screen_pixmap);
-        LLOGLN(0, ("rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex));
         pScreen->SetScreenPixmap(screen_pixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -635,23 +635,23 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     miSetVisualTypes(pScrn->depth, miGetDefaultVisualMask(pScrn->depth),
                      pScrn->rgbBits, TrueColor);
     miSetPixmapDepths();
-    LLOGLN(0, ("rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
            pScrn->virtualX, pScrn->virtualY, pScrn->rgbBits, pScrn->depth));
 
     dev->depth = pScrn->depth;
     dev->paddedWidthInBytes = PixmapBytePad(dev->width, dev->depth);
     dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
-    LLOGLN(0, ("rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes));
     dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
     dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
-    LLOGLN(0, ("rdpScreenInit: pfbMemory %p", dev->pfbMemory));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: pfbMemory %p", dev->pfbMemory));
     if (!fbScreenInit(pScreen, dev->pfbMemory,
                       pScrn->virtualX, pScrn->virtualY,
                       pScrn->xDpi, pScrn->yDpi, pScrn->displayWidth,
                       pScrn->bitsPerPixel))
     {
-        LLOGLN(0, ("rdpScreenInit: fbScreenInit failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: fbScreenInit failed"));
         return FALSE;
     }
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 14, 0, 0, 0)
@@ -683,32 +683,32 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
         /* it's not that we don't want dri3, we just want to init it ourself */
         if (glamor_init(pScreen, GLAMOR_USE_EGL_SCREEN | GLAMOR_NO_DRI3))
         {
-            LLOGLN(0, ("rdpScreenInit: glamor_init ok"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: glamor_init ok"));
         }
         else
         {
-            LLOGLN(0, ("rdpScreenInit: glamor_init failed"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: glamor_init failed"));
         }
         if (g_use_dri2)
         {
             if (rdpDri2Init(pScreen) != 0)
             {
-                LLOGLN(0, ("rdpScreenInit: rdpDri2Init failed"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri2Init failed"));
             }
             else
             {
-                LLOGLN(0, ("rdpScreenInit: rdpDri2Init ok"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri2Init ok"));
             }
         }
         if (g_use_dri3)
         {
             if (rdpDri3Init(pScreen) != 0)
             {
-                LLOGLN(0, ("rdpScreenInit: rdpDri3Init failed"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri3Init failed"));
             }
             else
             {
-                LLOGLN(0, ("rdpScreenInit: rdpDri3Init ok"));
+                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri3Init ok"));
             }
         }
 #endif
@@ -744,7 +744,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     }
     if (!vis_found)
     {
-        LLOGLN(0, ("rdpScreenInit: no root visual"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: no root visual"));
         return FALSE;
     }
 
@@ -799,7 +799,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
     if (rdpClientConInit(dev) != 0)
     {
-        LLOGLN(0, ("rdpScreenInit: rdpClientConInit failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpClientConInit failed"));
     }
 
     dev->Bpp_mask = 0x00FFFFFF;
@@ -810,7 +810,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* XVideo */
     if (!rdpXvInit(pScreen, pScrn))
     {
-        LLOGLN(0, ("rdpScreenInit: rdpXvInit failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpXvInit failed"));
     }
 #endif
 
@@ -821,7 +821,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
 #endif
     }
 
-    LLOGLN(0, ("rdpScreenInit: out"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: out"));
     return TRUE;
 }
 
@@ -833,7 +833,7 @@ rdpSwitchMode(int a, DisplayModePtr b, int c)
 rdpSwitchMode(ScrnInfoPtr a, DisplayModePtr b)
 #endif
 {
-    LLOGLN(10, ("rdpSwitchMode:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpSwitchMode:"));
     return TRUE;
 }
 
@@ -845,7 +845,7 @@ rdpAdjustFrame(int a, int b, int c, int d)
 rdpAdjustFrame(ScrnInfoPtr a, int b, int c)
 #endif
 {
-    LLOGLN(10, ("rdpAdjustFrame:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpAdjustFrame:"));
 }
 
 /*****************************************************************************/
@@ -856,7 +856,7 @@ rdpEnterVT(int a, int b)
 rdpEnterVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(10, ("rdpEnterVT:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnterVT:"));
     return TRUE;
 }
 
@@ -868,7 +868,7 @@ rdpLeaveVT(int a, int b)
 rdpLeaveVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(10, ("rdpLeaveVT:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpLeaveVT:"));
 }
 
 /*****************************************************************************/
@@ -879,7 +879,7 @@ rdpValidMode(int a, DisplayModePtr b, Bool c, int d)
 rdpValidMode(ScrnInfoPtr a, DisplayModePtr b, Bool c, int d)
 #endif
 {
-    LLOGLN(10, ("rdpValidMode:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpValidMode:"));
     return 0;
 }
 
@@ -891,7 +891,7 @@ rdpFreeScreen(int a, int b)
 rdpFreeScreen(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(10, ("rdpFreeScreen:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpFreeScreen:"));
 }
 
 /*****************************************************************************/
@@ -906,7 +906,7 @@ rdpProbe(DriverPtr drv, int flags)
     ScrnInfoPtr pscrn;
     const char *val;
 
-    LLOGLN(10, ("rdpProbe:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpProbe:"));
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -914,14 +914,14 @@ rdpProbe(DriverPtr drv, int flags)
     /* fbScreenInit, fbPictureInit, ... */
     if (!xf86LoadDrvSubModule(drv, "fb"))
     {
-        LLOGLN(0, ("rdpProbe: xf86LoadDrvSubModule for fb failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: xf86LoadDrvSubModule for fb failed"));
         return FALSE;
     }
 
     num_dev_sections = xf86MatchDevice(XRDP_DRIVER_NAME, &dev_sections);
     if (num_dev_sections <= 0)
     {
-        LLOGLN(0, ("rdpProbe: xf86MatchDevice failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: xf86MatchDevice failed"));
         return FALSE;
     }
 
@@ -935,7 +935,7 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_device, val, 127);
             g_drm_device[127] = 0;
-            LLOGLN(0, ("rdpProbe: found DRMDevice xorg.conf value [%s]", val));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRMDevice xorg.conf value [%s]", val));
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI2");
@@ -948,7 +948,7 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri2 = 0;
             }
-            LLOGLN(0, ("rdpProbe: found DRI2 xorg.conf value [%s]", val));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRI2 xorg.conf value [%s]", val));
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI3");
@@ -961,7 +961,7 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri3 = 0;
             }
-            LLOGLN(0, ("rdpProbe: found DRI3 xorg.conf value [%s]", val));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRI3 xorg.conf value [%s]", val));
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRMAllowList");
@@ -970,14 +970,14 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_allow_list, val, 127);
             g_drm_device[127] = 0;
-            LLOGLN(0, ("rdpProbe: found DRMAllowList xorg.conf value [%s]", val));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRMAllowList xorg.conf value [%s]", val));
 #endif
         }
         entity = xf86ClaimFbSlot(drv, 0, dev_sections[i], 1);
         pscrn = xf86ConfigFbEntity(pscrn, 0, entity, 0, 0, 0, 0);
         if (pscrn)
         {
-            LLOGLN(10, ("rdpProbe: found screen"));
+            LLOGLN(LOG_LEVEL_TRACE, ("rdpProbe: found screen"));
             found_screen = 1;
             pscrn->driverVersion = XRDP_VERSION;
             pscrn->driverName    = g_xrdp_driver_name;
@@ -1002,7 +1002,7 @@ rdpProbe(DriverPtr drv, int flags)
 static const OptionInfoRec *
 rdpAvailableOptions(int chipid, int busid)
 {
-    LLOGLN(10, ("rdpAvailableOptions:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpAvailableOptions:"));
     return 0;
 }
 
@@ -1018,7 +1018,7 @@ rdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
     int rv;
 
     rv = FALSE;
-    LLOGLN(0, ("rdpDriverFunc: op %d", (int)op));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDriverFunc: op %d", (int)op));
     if (op == GET_REQUIRED_HW_INTERFACES)
     {
         flags = (xorgHWFlags *) ptr;
@@ -1032,7 +1032,7 @@ rdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
 static void
 rdpIdentify(int flags)
 {
-    LLOGLN(10, ("rdpIdentify:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpIdentify:"));
     xf86PrintChipsets(XRDP_DRIVER_NAME, "driver for xrdp", g_Chipsets);
 }
 
@@ -1051,7 +1051,7 @@ _X_EXPORT DriverRec g_DriverRec =
 static pointer
 xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 {
-    LLOGLN(10, ("xrdpdevSetup:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpdevSetup:"));
     if (!g_setup_done)
     {
         g_setup_done = 1;
@@ -1072,7 +1072,7 @@ xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 static void
 xrdpdevTearDown(pointer Module)
 {
-    LLOGLN(10, ("xrdpdevTearDown:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("xrdpdevTearDown:"));
 }
 
 /* <drivername>ModuleData */

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -110,7 +110,7 @@ static XF86ModuleVersionInfo g_VersRec =
 static Bool
 rdpAllocRec(ScrnInfoPtr pScrn)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpAllocRec:"));
+    LOG(LOG_LEVEL_TRACE, "rdpAllocRec:");
     if (pScrn->reservedPtr[0] != NULL)
     {
         return TRUE;
@@ -124,7 +124,7 @@ rdpAllocRec(ScrnInfoPtr pScrn)
 static void
 rdpFreeRec(ScrnInfoPtr pScrn)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpFreeRec:"));
+    LOG(LOG_LEVEL_TRACE, "rdpFreeRec:");
     if (pScrn->reservedPtr[0] == NULL)
     {
         return;
@@ -148,7 +148,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     DisplayModePtr mode;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit:"));
+    LOG(LOG_LEVEL_TRACE, "rdpPreInit:");
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -172,14 +172,14 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     dev->fd = open(g_drm_device, O_RDWR, 0);
     if (dev->fd == -1)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: %s open failed", g_drm_device));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: %s open failed", g_drm_device);
     }
     else
     {
         struct drm_version dver;
         char delim[] = " ";
         char *token;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: %s open ok, fd %d", g_drm_device, dev->fd));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: %s open ok, fd %d", g_drm_device, dev->fd);
         memset(&dver, 0, sizeof(dver));
         dver.name_len = 256;
         dver.name = g_new0(char, dver.name_len);
@@ -189,30 +189,30 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         dver.desc = g_new0(char, dver.desc_len);
         if (ioctl(dev->fd, DRM_IOCTL_VERSION, &dver) != -1)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: name [%s]", dver.name));
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: date [%s]", dver.date));
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: desc [%s]", dver.desc));
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: name [%s]", dver.name);
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: date [%s]", dver.date);
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: desc [%s]", dver.desc);
             token = strtok(g_drm_allow_list, delim);
             while (token != NULL)
             {
-                LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit: token [%s]", token));
+                LOG(LOG_LEVEL_TRACE, "rdpPreInit: token [%s]", token);
                 if (strstr(dver.name, token) != NULL)
                 {
                     dev->glamor = TRUE;
-                    LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: drm device looks ok, "
-                           "use glamor set"));
+                    LOG(LOG_LEVEL_INFO, "rdpPreInit: drm device looks ok, "
+                           "use glamor set");
                     break;
                 }
                 token = strtok(NULL, delim);
             }
             if (dev->glamor == FALSE)
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: unsupported render node"));
+                LOG(LOG_LEVEL_INFO, "rdpPreInit: unsupported render node");
             }
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: DRM_IOCTL_VERSION failed"));
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: DRM_IOCTL_VERSION failed");
         }
         free(dver.name);
         free(dver.date);
@@ -246,33 +246,33 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
                          Support24bppFb | Support32bppFb |
                          SupportConvert32to24 | SupportConvert24to32))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetDepthBpp failed"));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: xf86SetDepthBpp failed");
         rdpFreeRec(pScrn);
         return FALSE;
     }
     xf86PrintDepthBpp(pScrn);
     if (!xf86SetWeight(pScrn, zeros1, zeros1))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetWeight failed"));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: xf86SetWeight failed");
         rdpFreeRec(pScrn);
         return FALSE;
     }
     if (!xf86SetGamma(pScrn, zeros2))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetGamma failed"));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: xf86SetGamma failed");
         rdpFreeRec(pScrn);
         return FALSE;
     }
     if (!xf86SetDefaultVisual(pScrn, -1))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: xf86SetDefaultVisual failed"));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: xf86SetDefaultVisual failed");
         rdpFreeRec(pScrn);
         return FALSE;
     }
     xf86SetDpi(pScrn, 0, 0);
     if (0 == pScrn->display->modes)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: modes error"));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: modes error");
         rdpFreeRec(pScrn);
         return FALSE;
     }
@@ -285,7 +285,7 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     {
         for (mode = pScrn->monitor->Modes; mode != 0; mode = mode->next)
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("%s %s", mode->name, *modename));
+            LOG(LOG_LEVEL_TRACE, "%s %s", mode->name, *modename);
             if (0 == strcmp(mode->name, *modename))
             {
                 break;
@@ -298,8 +298,8 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
             continue;
         }
         xf86DrvMsg(pScrn->scrnIndex, X_INFO, "\tmode \"%s\" ok\n", *modename);
-        LLOGLN(LOG_LEVEL_TRACE, ("%d %d %d %d", mode->HDisplay, dev->width,
-               mode->VDisplay, dev->height));
+        LOG(LOG_LEVEL_TRACE, "%d %d %d %d", mode->HDisplay, dev->width,
+               mode->VDisplay, dev->height);
         if ((mode->HDisplay == dev->width) && (mode->VDisplay == dev->height))
         {
             pScrn->virtualX = mode->HDisplay;
@@ -317,11 +317,11 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
     }
     pScrn->currentMode = pScrn->modes;
     xf86PrintModes(pScrn);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpPreInit: out fPtr->num_modes %d", dev->num_modes));
+    LOG(LOG_LEVEL_TRACE, "rdpPreInit: out fPtr->num_modes %d", dev->num_modes);
     if (!got_res_match)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: could not find screen resolution %dx%d",
-               dev->width, dev->height));
+        LOG(LOG_LEVEL_INFO, "rdpPreInit: could not find screen resolution %dx%d",
+               dev->width, dev->height);
         return FALSE;
     }
     if (dev->glamor)
@@ -329,20 +329,20 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
 #if defined(XORGXRDP_GLAMOR)
         if (xf86LoadSubModule(pScrn, GLAMOR_EGL_MODULE_NAME))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor module load ok"));
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: glamor module load ok");
             if (glamor_egl_init(pScrn, dev->fd))
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor init ok"));
+                LOG(LOG_LEVEL_INFO, "rdpPreInit: glamor init ok");
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor init failed"));
+                LOG(LOG_LEVEL_INFO, "rdpPreInit: glamor init failed");
                 dev->glamor = FALSE;
             }
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpPreInit: glamor module load failed"));
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: glamor module load failed");
             dev->glamor = FALSE;
         }
 #endif
@@ -366,7 +366,7 @@ static miPointerSpriteFuncRec g_rdpSpritePointerFuncs =
 static Bool
 rdpSaveScreen(ScreenPtr pScreen, int on)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSaveScreen:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSaveScreen:");
     return TRUE;
 }
 
@@ -379,7 +379,7 @@ rdpResizeSession(rdpPtr dev, int width, int height)
     ScrnInfoPtr pScrn;
     Bool ok;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpResizeSession: width %d height %d", width, height));
+    LOG(LOG_LEVEL_INFO, "rdpResizeSession: width %d height %d", width, height);
     pScrn = xf86Screens[dev->pScreen->myNum];
     mmwidth = PixelToMM(width, pScrn->xDpi);
     mmheight = PixelToMM(height, pScrn->yDpi);
@@ -387,11 +387,11 @@ rdpResizeSession(rdpPtr dev, int width, int height)
     ok = TRUE;
     if ((dev->width != width) || (dev->height != height))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("  calling RRScreenSizeSet"));
+        LOG(LOG_LEVEL_INFO, "  calling RRScreenSizeSet");
         dev->allow_screen_resize = 1;
         ok = RRScreenSizeSet(dev->pScreen, width, height, mmwidth, mmheight);
         dev->allow_screen_resize = 0;
-        LLOGLN(LOG_LEVEL_INFO, ("  RRScreenSizeSet ok %d", ok));
+        LOG(LOG_LEVEL_INFO, "  RRScreenSizeSet ok %d", ok);
     }
     return ok;
 }
@@ -403,7 +403,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
     rdpPtr dev;
     ScreenPtr pScreen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageReport:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDamageReport:");
     pScreen = (ScreenPtr)closure;
     dev = rdpGetDevFromScreen(pScreen);
     rdpClientConAddAllReg(dev, pRegion, &(pScreen->root->drawable));
@@ -413,7 +413,7 @@ xorgxrdpDamageReport(DamagePtr pDamage, RegionPtr pRegion, void *closure)
 static void
 xorgxrdpDamageDestroy(DamagePtr pDamage, void *closure)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xorgxrdpDamageDestroy:"));
+    LOG(LOG_LEVEL_TRACE, "xorgxrdpDamageDestroy:");
 }
 
 /******************************************************************************/
@@ -451,11 +451,11 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
 
     pScreen = (ScreenPtr) arg;
     dev = rdpGetDevFromScreen(pScreen);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDeferredRandR:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDeferredRandR:");
     pRRScrPriv = rrGetScrPriv(pScreen);
     if (pRRScrPriv == 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDeferredRandR: rrGetScrPriv failed"));
+        LOG(LOG_LEVEL_INFO, "rdpDeferredRandR: rrGetScrPriv failed");
         return 1;
     }
 
@@ -472,18 +472,18 @@ rdpDeferredRandR(OsTimerPtr timer, CARD32 now, pointer arg)
     dev->rrGetPanning         = pRRScrPriv->rrGetPanning;
     dev->rrSetPanning         = pRRScrPriv->rrSetPanning;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrSetConfig = %p", dev->rrSetConfig));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrGetInfo = %p", dev->rrGetInfo));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrScreenSetSize = %p", dev->rrScreenSetSize));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcSet = %p", dev->rrCrtcSet));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcSetGamma = %p", dev->rrCrtcSetGamma));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrCrtcGetGamma = %p", dev->rrCrtcGetGamma));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputSetProperty = %p", dev->rrOutputSetProperty));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputValidateMode = %p", dev->rrOutputValidateMode));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrModeDestroy = %p", dev->rrModeDestroy));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrOutputGetProperty = %p", dev->rrOutputGetProperty));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrGetPanning = %p", dev->rrGetPanning));
-    LLOGLN(LOG_LEVEL_TRACE, ("  rrSetPanning = %p", dev->rrSetPanning));
+    LOG(LOG_LEVEL_TRACE, "  rrSetConfig = %p", dev->rrSetConfig);
+    LOG(LOG_LEVEL_TRACE, "  rrGetInfo = %p", dev->rrGetInfo);
+    LOG(LOG_LEVEL_TRACE, "  rrScreenSetSize = %p", dev->rrScreenSetSize);
+    LOG(LOG_LEVEL_TRACE, "  rrCrtcSet = %p", dev->rrCrtcSet);
+    LOG(LOG_LEVEL_TRACE, "  rrCrtcSetGamma = %p", dev->rrCrtcSetGamma);
+    LOG(LOG_LEVEL_TRACE, "  rrCrtcGetGamma = %p", dev->rrCrtcGetGamma);
+    LOG(LOG_LEVEL_TRACE, "  rrOutputSetProperty = %p", dev->rrOutputSetProperty);
+    LOG(LOG_LEVEL_TRACE, "  rrOutputValidateMode = %p", dev->rrOutputValidateMode);
+    LOG(LOG_LEVEL_TRACE, "  rrModeDestroy = %p", dev->rrModeDestroy);
+    LOG(LOG_LEVEL_TRACE, "  rrOutputGetProperty = %p", dev->rrOutputGetProperty);
+    LOG(LOG_LEVEL_TRACE, "  rrGetPanning = %p", dev->rrGetPanning);
+    LOG(LOG_LEVEL_TRACE, "  rrSetPanning = %p", dev->rrSetPanning);
 
     pRRScrPriv->rrSetConfig          = rdpRRSetConfig;
     pRRScrPriv->rrGetInfo            = rdpRRGetInfo;
@@ -553,7 +553,7 @@ rdpSetPixmapVisitWindow(WindowPtr window, void *data)
 {
     ScreenPtr screen;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSetPixmapVisitWindow:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSetPixmapVisitWindow:");
     screen = window->drawable.pScreen;
     if (screen->GetWindowPixmap(window) == data)
     {
@@ -571,7 +571,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     Bool ret;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpCreateScreenResources:"));
+    LOG(LOG_LEVEL_TRACE, "rdpCreateScreenResources:");
     dev = rdpGetDevFromScreen(pScreen);
     pScreen->CreateScreenResources = dev->CreateScreenResources;
     ret = pScreen->CreateScreenResources(pScreen);
@@ -588,8 +588,8 @@ rdpCreateScreenResources(ScreenPtr pScreen)
         PixmapPtr screen_pixmap;
         uint32_t screen_tex;
         old_screen_pixmap = dev->screenSwPixmap;
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCreateScreenResources: create screen pixmap w %d h %d",
-               pScreen->width, pScreen->height));
+        LOG(LOG_LEVEL_INFO, "rdpCreateScreenResources: create screen pixmap w %d h %d",
+               pScreen->width, pScreen->height);
         screen_pixmap = pScreen->CreatePixmap(pScreen,
                                               pScreen->width,
                                               pScreen->height,
@@ -600,7 +600,7 @@ rdpCreateScreenResources(ScreenPtr pScreen)
             return FALSE;
         }
         screen_tex = glamor_get_pixmap_texture(screen_pixmap);
-        LLOGLN(LOG_LEVEL_INFO, ("rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex));
+        LOG(LOG_LEVEL_INFO, "rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex);
         pScreen->SetScreenPixmap(screen_pixmap);
         if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
         {
@@ -635,23 +635,23 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     miSetVisualTypes(pScrn->depth, miGetDefaultVisualMask(pScrn->depth),
                      pScrn->rgbBits, TrueColor);
     miSetPixmapDepths();
-    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
-           pScrn->virtualX, pScrn->virtualY, pScrn->rgbBits, pScrn->depth));
+    LOG(LOG_LEVEL_INFO, "rdpScreenInit: virtualX %d virtualY %d rgbBits %d depth %d",
+           pScrn->virtualX, pScrn->virtualY, pScrn->rgbBits, pScrn->depth);
 
     dev->depth = pScrn->depth;
     dev->paddedWidthInBytes = PixmapBytePad(dev->width, dev->depth);
     dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
-    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes));
+    LOG(LOG_LEVEL_INFO, "rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes);
     dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
     dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
-    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: pfbMemory %p", dev->pfbMemory));
+    LOG(LOG_LEVEL_INFO, "rdpScreenInit: pfbMemory %p", dev->pfbMemory);
     if (!fbScreenInit(pScreen, dev->pfbMemory,
                       pScrn->virtualX, pScrn->virtualY,
                       pScrn->xDpi, pScrn->yDpi, pScrn->displayWidth,
                       pScrn->bitsPerPixel))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: fbScreenInit failed"));
+        LOG(LOG_LEVEL_INFO, "rdpScreenInit: fbScreenInit failed");
         return FALSE;
     }
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 14, 0, 0, 0)
@@ -683,32 +683,32 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
         /* it's not that we don't want dri3, we just want to init it ourself */
         if (glamor_init(pScreen, GLAMOR_USE_EGL_SCREEN | GLAMOR_NO_DRI3))
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: glamor_init ok"));
+            LOG(LOG_LEVEL_INFO, "rdpScreenInit: glamor_init ok");
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: glamor_init failed"));
+            LOG(LOG_LEVEL_INFO, "rdpScreenInit: glamor_init failed");
         }
         if (g_use_dri2)
         {
             if (rdpDri2Init(pScreen) != 0)
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri2Init failed"));
+                LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpDri2Init failed");
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri2Init ok"));
+                LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpDri2Init ok");
             }
         }
         if (g_use_dri3)
         {
             if (rdpDri3Init(pScreen) != 0)
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri3Init failed"));
+                LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpDri3Init failed");
             }
             else
             {
-                LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpDri3Init ok"));
+                LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpDri3Init ok");
             }
         }
 #endif
@@ -744,7 +744,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     }
     if (!vis_found)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: no root visual"));
+        LOG(LOG_LEVEL_INFO, "rdpScreenInit: no root visual");
         return FALSE;
     }
 
@@ -799,7 +799,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
     if (rdpClientConInit(dev) != 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpClientConInit failed"));
+        LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpClientConInit failed");
     }
 
     dev->Bpp_mask = 0x00FFFFFF;
@@ -810,7 +810,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* XVideo */
     if (!rdpXvInit(pScreen, pScrn))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: rdpXvInit failed"));
+        LOG(LOG_LEVEL_INFO, "rdpScreenInit: rdpXvInit failed");
     }
 #endif
 
@@ -821,7 +821,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
 #endif
     }
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpScreenInit: out"));
+    LOG(LOG_LEVEL_INFO, "rdpScreenInit: out");
     return TRUE;
 }
 
@@ -833,7 +833,7 @@ rdpSwitchMode(int a, DisplayModePtr b, int c)
 rdpSwitchMode(ScrnInfoPtr a, DisplayModePtr b)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpSwitchMode:"));
+    LOG(LOG_LEVEL_TRACE, "rdpSwitchMode:");
     return TRUE;
 }
 
@@ -845,7 +845,7 @@ rdpAdjustFrame(int a, int b, int c, int d)
 rdpAdjustFrame(ScrnInfoPtr a, int b, int c)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpAdjustFrame:"));
+    LOG(LOG_LEVEL_TRACE, "rdpAdjustFrame:");
 }
 
 /*****************************************************************************/
@@ -856,7 +856,7 @@ rdpEnterVT(int a, int b)
 rdpEnterVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnterVT:"));
+    LOG(LOG_LEVEL_TRACE, "rdpEnterVT:");
     return TRUE;
 }
 
@@ -868,7 +868,7 @@ rdpLeaveVT(int a, int b)
 rdpLeaveVT(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpLeaveVT:"));
+    LOG(LOG_LEVEL_TRACE, "rdpLeaveVT:");
 }
 
 /*****************************************************************************/
@@ -879,7 +879,7 @@ rdpValidMode(int a, DisplayModePtr b, Bool c, int d)
 rdpValidMode(ScrnInfoPtr a, DisplayModePtr b, Bool c, int d)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpValidMode:"));
+    LOG(LOG_LEVEL_TRACE, "rdpValidMode:");
     return 0;
 }
 
@@ -891,7 +891,7 @@ rdpFreeScreen(int a, int b)
 rdpFreeScreen(ScrnInfoPtr a)
 #endif
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpFreeScreen:"));
+    LOG(LOG_LEVEL_TRACE, "rdpFreeScreen:");
 }
 
 /*****************************************************************************/
@@ -906,7 +906,7 @@ rdpProbe(DriverPtr drv, int flags)
     ScrnInfoPtr pscrn;
     const char *val;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpProbe:"));
+    LOG(LOG_LEVEL_TRACE, "rdpProbe:");
     if (flags & PROBE_DETECT)
     {
         return FALSE;
@@ -914,14 +914,14 @@ rdpProbe(DriverPtr drv, int flags)
     /* fbScreenInit, fbPictureInit, ... */
     if (!xf86LoadDrvSubModule(drv, "fb"))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: xf86LoadDrvSubModule for fb failed"));
+        LOG(LOG_LEVEL_INFO, "rdpProbe: xf86LoadDrvSubModule for fb failed");
         return FALSE;
     }
 
     num_dev_sections = xf86MatchDevice(XRDP_DRIVER_NAME, &dev_sections);
     if (num_dev_sections <= 0)
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: xf86MatchDevice failed"));
+        LOG(LOG_LEVEL_INFO, "rdpProbe: xf86MatchDevice failed");
         return FALSE;
     }
 
@@ -935,7 +935,7 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_device, val, 127);
             g_drm_device[127] = 0;
-            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRMDevice xorg.conf value [%s]", val));
+            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRMDevice xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI2");
@@ -948,7 +948,7 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri2 = 0;
             }
-            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRI2 xorg.conf value [%s]", val));
+            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRI2 xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRI3");
@@ -961,7 +961,7 @@ rdpProbe(DriverPtr drv, int flags)
             {
                g_use_dri3 = 0;
             }
-            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRI3 xorg.conf value [%s]", val));
+            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRI3 xorg.conf value [%s]", val);
 #endif
         }
         val = xf86FindOptionValue(dev_sections[i]->options, "DRMAllowList");
@@ -970,14 +970,14 @@ rdpProbe(DriverPtr drv, int flags)
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_allow_list, val, 127);
             g_drm_device[127] = 0;
-            LLOGLN(LOG_LEVEL_INFO, ("rdpProbe: found DRMAllowList xorg.conf value [%s]", val));
+            LOG(LOG_LEVEL_INFO, "rdpProbe: found DRMAllowList xorg.conf value [%s]", val);
 #endif
         }
         entity = xf86ClaimFbSlot(drv, 0, dev_sections[i], 1);
         pscrn = xf86ConfigFbEntity(pscrn, 0, entity, 0, 0, 0, 0);
         if (pscrn)
         {
-            LLOGLN(LOG_LEVEL_TRACE, ("rdpProbe: found screen"));
+            LOG(LOG_LEVEL_TRACE, "rdpProbe: found screen");
             found_screen = 1;
             pscrn->driverVersion = XRDP_VERSION;
             pscrn->driverName    = g_xrdp_driver_name;
@@ -1002,7 +1002,7 @@ rdpProbe(DriverPtr drv, int flags)
 static const OptionInfoRec *
 rdpAvailableOptions(int chipid, int busid)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpAvailableOptions:"));
+    LOG(LOG_LEVEL_TRACE, "rdpAvailableOptions:");
     return 0;
 }
 
@@ -1018,7 +1018,7 @@ rdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
     int rv;
 
     rv = FALSE;
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDriverFunc: op %d", (int)op));
+    LOG(LOG_LEVEL_INFO, "rdpDriverFunc: op %d", (int)op);
     if (op == GET_REQUIRED_HW_INTERFACES)
     {
         flags = (xorgHWFlags *) ptr;
@@ -1032,7 +1032,7 @@ rdpDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op, pointer ptr)
 static void
 rdpIdentify(int flags)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpIdentify:"));
+    LOG(LOG_LEVEL_TRACE, "rdpIdentify:");
     xf86PrintChipsets(XRDP_DRIVER_NAME, "driver for xrdp", g_Chipsets);
 }
 
@@ -1051,7 +1051,7 @@ _X_EXPORT DriverRec g_DriverRec =
 static pointer
 xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpdevSetup:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpdevSetup:");
     if (!g_setup_done)
     {
         g_setup_done = 1;
@@ -1072,7 +1072,7 @@ xrdpdevSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 static void
 xrdpdevTearDown(pointer Module)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("xrdpdevTearDown:"));
+    LOG(LOG_LEVEL_TRACE, "xrdpdevTearDown:");
 }
 
 /* <drivername>ModuleData */

--- a/xrdpdev/xrdpdri2.c
+++ b/xrdpdev/xrdpdri2.c
@@ -66,14 +66,14 @@ static DRI2Buffer2Ptr
 rdpDri2CreateBuffer(DrawablePtr drawable, unsigned int attachment,
                     unsigned int format)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CreateBuffer:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2CreateBuffer:");
     return 0;
 }
 
 /*****************************************************************************/
 static void rdpDri2DestroyBuffer(DrawablePtr drawable, DRI2Buffer2Ptr buffer)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2DestroyBuffer:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2DestroyBuffer:");
 }
 
 /*****************************************************************************/
@@ -81,7 +81,7 @@ static void
 rdpDri2CopyRegion(DrawablePtr drawable, RegionPtr pRegion,
                   DRI2BufferPtr destBuffer, DRI2BufferPtr sourceBuffer)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CopyRegion:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2CopyRegion:");
 }
 
 /*****************************************************************************/
@@ -91,7 +91,7 @@ rdpDri2ScheduleSwap(ClientPtr client, DrawablePtr draw,
                     CARD64 *target_msc, CARD64 divisor,
                     CARD64 remainder, DRI2SwapEventPtr func, void *data)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2ScheduleSwap:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2ScheduleSwap:");
     return 0;
 }
 
@@ -99,7 +99,7 @@ rdpDri2ScheduleSwap(ClientPtr client, DrawablePtr draw,
 static int
 rdpDri2GetMSC(DrawablePtr draw, CARD64 *ust, CARD64 *msc)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2GetMSC:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2GetMSC:");
     return 0;
 }
 
@@ -108,7 +108,7 @@ static int
 rdpDri2ScheduleWaitMSC(ClientPtr client, DrawablePtr draw, CARD64 target_msc,
                        CARD64 divisor, CARD64 remainder)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2ScheduleWaitMSC:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2ScheduleWaitMSC:");
     return 0;
 }
 
@@ -117,7 +117,7 @@ static DRI2Buffer2Ptr
 rdpDri2CreateBuffer2(ScreenPtr screen, DrawablePtr drawable,
                      unsigned int attachment, unsigned int format)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CreateBuffer2:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2CreateBuffer2:");
     return 0;
 }
 
@@ -126,7 +126,7 @@ static void
 rdpDri2DestroyBuffer2(ScreenPtr unused, DrawablePtr unused2,
                       DRI2Buffer2Ptr buffer)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2DestroyBuffer2:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2DestroyBuffer2:");
 }
 
 /*****************************************************************************/
@@ -134,7 +134,7 @@ static void
 rdpDri2CopyRegion2(ScreenPtr screen, DrawablePtr drawable, RegionPtr pRegion,
                    DRI2BufferPtr destBuffer, DRI2BufferPtr sourceBuffer)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CopyRegion2:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2CopyRegion2:");
 }
 
 /*****************************************************************************/
@@ -147,7 +147,7 @@ rdpDri2Init(ScreenPtr pScreen)
     const char *driver_names[2] = { NULL, NULL };
 #endif
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2Init:"));
+    LOG(LOG_LEVEL_INFO, "rdpDri2Init:");
     dev = rdpGetDevFromScreen(pScreen);
     if (!dixRegisterPrivateKey(&g_rdpDri2ClientKey,
                                PRIVATE_CLIENT, sizeof(XID)))

--- a/xrdpdev/xrdpdri2.c
+++ b/xrdpdev/xrdpdri2.c
@@ -66,14 +66,14 @@ static DRI2Buffer2Ptr
 rdpDri2CreateBuffer(DrawablePtr drawable, unsigned int attachment,
                     unsigned int format)
 {
-    LLOGLN(0, ("rdpDri2CreateBuffer:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CreateBuffer:"));
     return 0;
 }
 
 /*****************************************************************************/
 static void rdpDri2DestroyBuffer(DrawablePtr drawable, DRI2Buffer2Ptr buffer)
 {
-    LLOGLN(0, ("rdpDri2DestroyBuffer:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2DestroyBuffer:"));
 }
 
 /*****************************************************************************/
@@ -81,7 +81,7 @@ static void
 rdpDri2CopyRegion(DrawablePtr drawable, RegionPtr pRegion,
                   DRI2BufferPtr destBuffer, DRI2BufferPtr sourceBuffer)
 {
-    LLOGLN(0, ("rdpDri2CopyRegion:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CopyRegion:"));
 }
 
 /*****************************************************************************/
@@ -91,7 +91,7 @@ rdpDri2ScheduleSwap(ClientPtr client, DrawablePtr draw,
                     CARD64 *target_msc, CARD64 divisor,
                     CARD64 remainder, DRI2SwapEventPtr func, void *data)
 {
-    LLOGLN(0, ("rdpDri2ScheduleSwap:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2ScheduleSwap:"));
     return 0;
 }
 
@@ -99,7 +99,7 @@ rdpDri2ScheduleSwap(ClientPtr client, DrawablePtr draw,
 static int
 rdpDri2GetMSC(DrawablePtr draw, CARD64 *ust, CARD64 *msc)
 {
-    LLOGLN(0, ("rdpDri2GetMSC:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2GetMSC:"));
     return 0;
 }
 
@@ -108,7 +108,7 @@ static int
 rdpDri2ScheduleWaitMSC(ClientPtr client, DrawablePtr draw, CARD64 target_msc,
                        CARD64 divisor, CARD64 remainder)
 {
-    LLOGLN(0, ("rdpDri2ScheduleWaitMSC:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2ScheduleWaitMSC:"));
     return 0;
 }
 
@@ -117,7 +117,7 @@ static DRI2Buffer2Ptr
 rdpDri2CreateBuffer2(ScreenPtr screen, DrawablePtr drawable,
                      unsigned int attachment, unsigned int format)
 {
-    LLOGLN(0, ("rdpDri2CreateBuffer2:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CreateBuffer2:"));
     return 0;
 }
 
@@ -126,7 +126,7 @@ static void
 rdpDri2DestroyBuffer2(ScreenPtr unused, DrawablePtr unused2,
                       DRI2Buffer2Ptr buffer)
 {
-    LLOGLN(0, ("rdpDri2DestroyBuffer2:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2DestroyBuffer2:"));
 }
 
 /*****************************************************************************/
@@ -134,7 +134,7 @@ static void
 rdpDri2CopyRegion2(ScreenPtr screen, DrawablePtr drawable, RegionPtr pRegion,
                    DRI2BufferPtr destBuffer, DRI2BufferPtr sourceBuffer)
 {
-    LLOGLN(0, ("rdpDri2CopyRegion2:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2CopyRegion2:"));
 }
 
 /*****************************************************************************/
@@ -147,7 +147,7 @@ rdpDri2Init(ScreenPtr pScreen)
     const char *driver_names[2] = { NULL, NULL };
 #endif
 
-    LLOGLN(0, ("rdpDri2Init:"));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri2Init:"));
     dev = rdpGetDevFromScreen(pScreen);
     if (!dixRegisterPrivateKey(&g_rdpDri2ClientKey,
                                PRIVATE_CLIENT, sizeof(XID)))

--- a/xrdpdev/xrdpdri3.c
+++ b/xrdpdev/xrdpdri3.c
@@ -65,9 +65,9 @@ rdpDri3PixmapFromFd(ScreenPtr screen, int fd,
 {
     PixmapPtr rv;
 
-    LLOGLN(10, ("rdpDri3PixmapFromFd:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFd:"));
     rv = glamor_pixmap_from_fd(screen, fd, width, height, stride, depth, bpp);
-    LLOGLN(10, ("rdpDri3PixmapFromFd: fd %d pixmap %p", fd, rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFd: fd %d pixmap %p", fd, rv));
     return rv;
 }
 
@@ -78,9 +78,9 @@ rdpDri3FdFromPixmap(ScreenPtr screen, PixmapPtr pixmap,
 {
     int rv;
 
-    LLOGLN(10, ("rdpDri3FdFromPixmap:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdFromPixmap:"));
     rv = glamor_fd_from_pixmap(screen, pixmap, stride, size);
-    LLOGLN(10, ("rdpDri3FdFromPixmap: fd %d pixmap %p", rv, pixmap));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdFromPixmap: fd %d pixmap %p", rv, pixmap));
     return rv;
 }
 
@@ -91,9 +91,9 @@ rdpDri3OpenClient(ClientPtr client, ScreenPtr screen,
 {
     int fd;
 
-    LLOGLN(10, ("rdpDri3OpenClient:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3OpenClient:"));
     fd = open(g_drm_device, O_RDWR | O_CLOEXEC);
-    LLOGLN(10, ("rdpDri3OpenClient: fd %d", fd));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3OpenClient: fd %d", fd));
     if (fd < 0)
     {
         return BadAlloc;
@@ -113,10 +113,10 @@ rdpDri3PixmapFromFds(ScreenPtr screen, CARD8 num_fds, const int *fds,
 {
     PixmapPtr rv;
 
-    LLOGLN(10, ("rdpDri3PixmapFromFds:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFds:"));
     rv = glamor_pixmap_from_fds(screen, num_fds, fds, width, height, strides,
                                   offsets, depth, bpp, modifier);
-    LLOGLN(10, ("rdpDri3PixmapFromFds: pixmap %p", rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFds: pixmap %p", rv));
     return rv;
 }
 
@@ -128,9 +128,9 @@ rdpDri3FdsFromPixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 {
     int rv;
 
-    LLOGLN(10, ("rdpDri3FdsFromPixmap:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdsFromPixmap:"));
     rv = glamor_fds_from_pixmap(screen, pixmap, fds, strides, offsets, modifier);
-    LLOGLN(10, ("rdpDri3FdsFromPixmap: pixmap %p", pixmap));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdsFromPixmap: pixmap %p", pixmap));
     return rv;
 }
 
@@ -140,9 +140,9 @@ rdpDri3GetFormats(ScreenPtr screen, CARD32 *num_formats, CARD32 **formats)
 {
     int rv;
 
-    LLOGLN(10, ("rdpDri3GetFormats:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetFormats:"));
     rv = glamor_get_formats(screen, num_formats, formats);
-    LLOGLN(10, ("rdpDri3GetFormats: rv %d", rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetFormats: rv %d", rv));
     return rv;
 }
 
@@ -153,9 +153,9 @@ rdpDri3GetModifiers(ScreenPtr screen, uint32_t format,
 {
     int rv;
 
-    LLOGLN(10, ("rdpDri3GetModifiers:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetModifiers:"));
     rv = glamor_get_modifiers(screen, format, num_modifiers, modifiers);
-    LLOGLN(10, ("rdpDri3GetModifiers: rv %d", rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetModifiers: rv %d", rv));
     return rv;
 }
 
@@ -166,9 +166,9 @@ rdpDri3GetDrawableModifiers(DrawablePtr draw, uint32_t format,
 {
     int rv;
 
-    LLOGLN(10, ("rdpDri3GetDrawableModifiers:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetDrawableModifiers:"));
     rv = glamor_get_drawable_modifiers(draw, format, num_modifiers, modifiers);
-    LLOGLN(10, ("rdpDri3GetDrawableModifiers: draw %p rv %d", draw, rv));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetDrawableModifiers: draw %p rv %d", draw, rv));
     return rv;
 }
 
@@ -193,10 +193,10 @@ rdpDri3Init(ScreenPtr pScreen)
     rdp_dri3_info.get_modifiers = rdpDri3GetModifiers;
     rdp_dri3_info.get_drawable_modifiers = rdpDri3GetDrawableModifiers;
 #endif
-    LLOGLN(0, ("rdpDri3Init: rdp_dri3_info.version = %lu", (unsigned long)rdp_dri3_info.version));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpDri3Init: rdp_dri3_info.version = %lu", (unsigned long)rdp_dri3_info.version));
     if (!dri3_screen_init(pScreen, &rdp_dri3_info))
     {
-        LLOGLN(0, ("rdpDri3Init: dri3_screen_init failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("rdpDri3Init: dri3_screen_init failed"));
         return 1;
     }
     return 0;

--- a/xrdpdev/xrdpdri3.c
+++ b/xrdpdev/xrdpdri3.c
@@ -65,9 +65,9 @@ rdpDri3PixmapFromFd(ScreenPtr screen, int fd,
 {
     PixmapPtr rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFd:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3PixmapFromFd:");
     rv = glamor_pixmap_from_fd(screen, fd, width, height, stride, depth, bpp);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFd: fd %d pixmap %p", fd, rv));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3PixmapFromFd: fd %d pixmap %p", fd, rv);
     return rv;
 }
 
@@ -78,9 +78,9 @@ rdpDri3FdFromPixmap(ScreenPtr screen, PixmapPtr pixmap,
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdFromPixmap:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3FdFromPixmap:");
     rv = glamor_fd_from_pixmap(screen, pixmap, stride, size);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdFromPixmap: fd %d pixmap %p", rv, pixmap));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3FdFromPixmap: fd %d pixmap %p", rv, pixmap);
     return rv;
 }
 
@@ -91,9 +91,9 @@ rdpDri3OpenClient(ClientPtr client, ScreenPtr screen,
 {
     int fd;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3OpenClient:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3OpenClient:");
     fd = open(g_drm_device, O_RDWR | O_CLOEXEC);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3OpenClient: fd %d", fd));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3OpenClient: fd %d", fd);
     if (fd < 0)
     {
         return BadAlloc;
@@ -113,10 +113,10 @@ rdpDri3PixmapFromFds(ScreenPtr screen, CARD8 num_fds, const int *fds,
 {
     PixmapPtr rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFds:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3PixmapFromFds:");
     rv = glamor_pixmap_from_fds(screen, num_fds, fds, width, height, strides,
                                   offsets, depth, bpp, modifier);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3PixmapFromFds: pixmap %p", rv));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3PixmapFromFds: pixmap %p", rv);
     return rv;
 }
 
@@ -128,9 +128,9 @@ rdpDri3FdsFromPixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdsFromPixmap:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3FdsFromPixmap:");
     rv = glamor_fds_from_pixmap(screen, pixmap, fds, strides, offsets, modifier);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3FdsFromPixmap: pixmap %p", pixmap));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3FdsFromPixmap: pixmap %p", pixmap);
     return rv;
 }
 
@@ -140,9 +140,9 @@ rdpDri3GetFormats(ScreenPtr screen, CARD32 *num_formats, CARD32 **formats)
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetFormats:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetFormats:");
     rv = glamor_get_formats(screen, num_formats, formats);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetFormats: rv %d", rv));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetFormats: rv %d", rv);
     return rv;
 }
 
@@ -153,9 +153,9 @@ rdpDri3GetModifiers(ScreenPtr screen, uint32_t format,
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetModifiers:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetModifiers:");
     rv = glamor_get_modifiers(screen, format, num_modifiers, modifiers);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetModifiers: rv %d", rv));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetModifiers: rv %d", rv);
     return rv;
 }
 
@@ -166,9 +166,9 @@ rdpDri3GetDrawableModifiers(DrawablePtr draw, uint32_t format,
 {
     int rv;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetDrawableModifiers:"));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetDrawableModifiers:");
     rv = glamor_get_drawable_modifiers(draw, format, num_modifiers, modifiers);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpDri3GetDrawableModifiers: draw %p rv %d", draw, rv));
+    LOG(LOG_LEVEL_TRACE, "rdpDri3GetDrawableModifiers: draw %p rv %d", draw, rv);
     return rv;
 }
 
@@ -193,10 +193,10 @@ rdpDri3Init(ScreenPtr pScreen)
     rdp_dri3_info.get_modifiers = rdpDri3GetModifiers;
     rdp_dri3_info.get_drawable_modifiers = rdpDri3GetDrawableModifiers;
 #endif
-    LLOGLN(LOG_LEVEL_INFO, ("rdpDri3Init: rdp_dri3_info.version = %lu", (unsigned long)rdp_dri3_info.version));
+    LOG(LOG_LEVEL_INFO, "rdpDri3Init: rdp_dri3_info.version = %lu", (unsigned long)rdp_dri3_info.version);
     if (!dri3_screen_init(pScreen, &rdp_dri3_info))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("rdpDri3Init: dri3_screen_init failed"));
+        LOG(LOG_LEVEL_INFO, "rdpDri3Init: dri3_screen_init failed");
         return 1;
     }
     return 0;

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -127,7 +127,7 @@ KbdAddEvent(rdpKeyboard *keyboard, int down, int param1, int param2,
     int rdp_scancode = SCANCODE_FROM_KBD_EVENT(param3, param4);
     int type = down ? KeyPress : KeyRelease;
 
-    LLOGLN(1, ("KbdAddEvent: down=%d RDP scancode=%03x "
+    LLOGLN(LOG_LEVEL_DEBUG, ("KbdAddEvent: down=%d RDP scancode=%03x "
            "PDU keyCode=%04x PDU keyboardFlags=%04x X11 keycode=%04x",
            down, rdp_scancode,
            param3, param4, x_keycode));
@@ -224,7 +224,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     int xkb_state;
 
     xkb_state = XkbStateFieldFromRec(&(keyboard->device->key->xkbInfo->state));
-    LLOGLN(10, ("KbdSync: xkb_state=%04X", xkb_state));
+    LLOGLN(LOG_LEVEL_TRACE, ("KbdSync: xkb_state=%04X", xkb_state));
 
     // Make sure the modifiers are released
     rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -238,7 +238,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // Caps_Lock is a specific modifier */
     if ((!(xkb_state & LockMask)) != (!(param1 & TS_SYNC_CAPS_LOCK)))
     {
-        LLOGLN(0, ("KbdSync: toggling caps lock"));
+        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling caps lock"));
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_caps_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -248,7 +248,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // Num_Lock is normally mapped to mod2 (see 'xmodmap -pm')
     if ((!(xkb_state & Mod2Mask)) != (!(param1 & TS_SYNC_NUM_LOCK)))
     {
-        LLOGLN(0, ("KbdSync: toggling num lock"));
+        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling num lock"));
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_num_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -259,7 +259,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // it ourselves
     if ((!(keyboard->scroll_lock_state)) != (!(param1 & TS_SYNC_SCROLL_LOCK)))
     {
-        LLOGLN(0, ("KbdSync: toggling scroll lock"));
+        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling scroll lock"));
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_scroll_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -277,7 +277,7 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
     rdpKeyboard *keyboard;
 
     keyboard = &(dev->keyboard);
-    LLOGLN(10, ("rdpInputKeyboard:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpInputKeyboard:"));
     switch (msg)
     {
         case 15: /* key down */
@@ -299,21 +299,21 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
 static void
 rdpkeybDeviceOn(void)
 {
-    LLOGLN(10, ("rdpkeybDeviceOn:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybDeviceOn:"));
 }
 
 /******************************************************************************/
 static void
 rdpkeybDeviceOff(void)
 {
-    LLOGLN(10, ("rdpkeybDeviceOff:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybDeviceOff:"));
 }
 
 /******************************************************************************/
 static void
 rdpkeybBell(int volume, DeviceIntPtr pDev, pointer ctrl, int cls)
 {
-    LLOGLN(10, ("rdpkeybBell:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybBell:"));
 }
 
 /******************************************************************************/
@@ -324,7 +324,7 @@ rdpInDeferredRepeatCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     DeviceIntPtr it;
     Bool found;
 
-    LLOGLN(10, ("rdpInDeferredRepeatCallback:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpInDeferredRepeatCallback:"));
     TimerFree(timer);
     pDev = (DeviceIntPtr) arg;
     found = FALSE;
@@ -351,7 +351,7 @@ rdpkeybChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl *ctrl)
 {
     XkbControlsPtr ctrls;
 
-    LLOGLN(10, ("rdpkeybChangeKeyboardControl:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybChangeKeyboardControl:"));
     ctrls = 0;
     if (pDev != 0)
     {
@@ -373,14 +373,14 @@ rdpkeybChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl *ctrl)
     {
         if (ctrls->enabled_ctrls & XkbRepeatKeysMask)
         {
-            LLOGLN(0, ("rdpkeybChangeKeyboardControl: autoRepeat on"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpkeybChangeKeyboardControl: autoRepeat on"));
             /* schedule to turn off the autorepeat after 100 ms so any app
              * polling it will be happy it's on */
             TimerSet(NULL, 0, 100, rdpInDeferredRepeatCallback, pDev);
         }
         else
         {
-            LLOGLN(0, ("rdpkeybChangeKeyboardControl: autoRepeat off"));
+            LLOGLN(LOG_LEVEL_INFO, ("rdpkeybChangeKeyboardControl: autoRepeat off"));
         }
     }
 }
@@ -392,7 +392,7 @@ rdpkeybControl(DeviceIntPtr device, int what)
     DevicePtr pDev;
     rdpPtr dev;
 
-    LLOGLN(0, ("rdpkeybControl: what %d", what));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybControl: what %d", what));
     pDev = (DevicePtr)device;
 
     switch (what)
@@ -432,7 +432,7 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 {
     InputInfoPtr info;
 
-    LLOGLN(0, ("rdpkeybPreInit: drv %p dev %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybPreInit: drv %p dev %p, flags 0x%x",
            drv, dev, flags));
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
@@ -455,7 +455,7 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 static int
 rdpkeybPreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(0, ("rdpkeybPreInit: drv %p info %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybPreInit: drv %p info %p, flags 0x%x",
            drv, info, flags));
     info->device_control = rdpkeybControl;
     info->type_name = g_Keyboard_str;
@@ -469,7 +469,7 @@ rdpkeybPreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 static void
 rdpkeybUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(0, ("rdpkeybUnInit: drv %p info %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybUnInit: drv %p info %p, flags 0x%x",
            drv, info, flags));
     rdpUnregisterInputCallback(rdpInputKeyboard);
 }
@@ -487,7 +487,7 @@ static InputDriverRec rdpkeyb =
 static pointer
 rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(10, ("rdpkeybPlug:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybPlug:"));
     xf86AddInputDriver(&rdpkeyb, module, 0);
     xorgxrdpCheckWrap();
     return module;
@@ -497,7 +497,7 @@ rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpkeybUnplug(pointer p)
 {
-    LLOGLN(10, ("rdpkeybUnplug:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybUnplug:"));
 }
 
 /******************************************************************************/
@@ -532,7 +532,7 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
     if (!InitKeyboardDeviceStruct(keyboard, set, rdpkeybBell,
                                   rdpkeybChangeKeyboardControl))
     {
-        LLOGLN(0, ("reload_xkb: InitKeyboardDeviceStruct failed"));
+        LLOGLN(LOG_LEVEL_INFO, ("reload_xkb: InitKeyboardDeviceStruct failed"));
         return 1;
     }
 
@@ -611,7 +611,7 @@ rdpLoadLayout(rdpKeyboard *keyboard, struct xup_client_info *client_info)
         keyboard->x11_keycode_scroll_lock = SCROLL_LOCK_KEY_CODE;
     }
 
-    LLOGLN(0, ("rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
+    LLOGLN(LOG_LEVEL_INFO, ("rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
                "layout=\"%s\" options=\"%s\"",
                set.rules, set.model, set.variant, set.layout, set.options));
 

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -128,9 +128,9 @@ KbdAddEvent(rdpKeyboard *keyboard, int down, int param1, int param2,
     int type = down ? KeyPress : KeyRelease;
 
     LOG(LOG_LEVEL_DEBUG, "KbdAddEvent: down=%d RDP scancode=%03x "
-           "PDU keyCode=%04x PDU keyboardFlags=%04x X11 keycode=%04x",
-           down, rdp_scancode,
-           param3, param4, x_keycode);
+        "PDU keyCode=%04x PDU keyboardFlags=%04x X11 keycode=%04x",
+        down, rdp_scancode,
+        param3, param4, x_keycode);
 
     if (keyboard->skip_numlock)
     {
@@ -433,7 +433,7 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
     InputInfoPtr info;
 
     LOG(LOG_LEVEL_INFO, "rdpkeybPreInit: drv %p dev %p, flags 0x%x",
-           drv, dev, flags);
+        drv, dev, flags);
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
     info->device_control = rdpkeybControl;
@@ -456,7 +456,7 @@ static int
 rdpkeybPreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LOG(LOG_LEVEL_INFO, "rdpkeybPreInit: drv %p info %p, flags 0x%x",
-           drv, info, flags);
+        drv, info, flags);
     info->device_control = rdpkeybControl;
     info->type_name = g_Keyboard_str;
 
@@ -470,7 +470,7 @@ static void
 rdpkeybUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LOG(LOG_LEVEL_INFO, "rdpkeybUnInit: drv %p info %p, flags 0x%x",
-           drv, info, flags);
+        drv, info, flags);
     rdpUnregisterInputCallback(rdpInputKeyboard);
 }
 
@@ -611,9 +611,10 @@ rdpLoadLayout(rdpKeyboard *keyboard, struct xup_client_info *client_info)
         keyboard->x11_keycode_scroll_lock = SCROLL_LOCK_KEY_CODE;
     }
 
-    LOG(LOG_LEVEL_INFO, "rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
-               "layout=\"%s\" options=\"%s\"",
-               set.rules, set.model, set.variant, set.layout, set.options);
+    LOG(LOG_LEVEL_INFO,
+        "rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
+        "layout=\"%s\" options=\"%s\"",
+        set.rules, set.model, set.variant, set.layout, set.options);
 
     reload_xkb(keyboard->device, &set);
     reload_xkb(inputInfo.keyboard, &set);

--- a/xrdpkeyb/rdpKeyboard.c
+++ b/xrdpkeyb/rdpKeyboard.c
@@ -127,10 +127,10 @@ KbdAddEvent(rdpKeyboard *keyboard, int down, int param1, int param2,
     int rdp_scancode = SCANCODE_FROM_KBD_EVENT(param3, param4);
     int type = down ? KeyPress : KeyRelease;
 
-    LLOGLN(LOG_LEVEL_DEBUG, ("KbdAddEvent: down=%d RDP scancode=%03x "
+    LOG(LOG_LEVEL_DEBUG, "KbdAddEvent: down=%d RDP scancode=%03x "
            "PDU keyCode=%04x PDU keyboardFlags=%04x X11 keycode=%04x",
            down, rdp_scancode,
-           param3, param4, x_keycode));
+           param3, param4, x_keycode);
 
     if (keyboard->skip_numlock)
     {
@@ -224,7 +224,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     int xkb_state;
 
     xkb_state = XkbStateFieldFromRec(&(keyboard->device->key->xkbInfo->state));
-    LLOGLN(LOG_LEVEL_TRACE, ("KbdSync: xkb_state=%04X", xkb_state));
+    LOG(LOG_LEVEL_TRACE, "KbdSync: xkb_state=%04X", xkb_state);
 
     // Make sure the modifiers are released
     rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -238,7 +238,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // Caps_Lock is a specific modifier */
     if ((!(xkb_state & LockMask)) != (!(param1 & TS_SYNC_CAPS_LOCK)))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling caps lock"));
+        LOG(LOG_LEVEL_INFO, "KbdSync: toggling caps lock");
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_caps_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -248,7 +248,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // Num_Lock is normally mapped to mod2 (see 'xmodmap -pm')
     if ((!(xkb_state & Mod2Mask)) != (!(param1 & TS_SYNC_NUM_LOCK)))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling num lock"));
+        LOG(LOG_LEVEL_INFO, "KbdSync: toggling num lock");
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_num_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -259,7 +259,7 @@ KbdSync(rdpKeyboard *keyboard, int param1)
     // it ourselves
     if ((!(keyboard->scroll_lock_state)) != (!(param1 & TS_SYNC_SCROLL_LOCK)))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("KbdSync: toggling scroll lock"));
+        LOG(LOG_LEVEL_INFO, "KbdSync: toggling scroll lock");
         rdpEnqueueKey(keyboard->device, KeyPress,
                       keyboard->x11_keycode_scroll_lock);
         rdpEnqueueKey(keyboard->device, KeyRelease,
@@ -277,7 +277,7 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
     rdpKeyboard *keyboard;
 
     keyboard = &(dev->keyboard);
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpInputKeyboard:"));
+    LOG(LOG_LEVEL_TRACE, "rdpInputKeyboard:");
     switch (msg)
     {
         case 15: /* key down */
@@ -299,21 +299,21 @@ rdpInputKeyboard(rdpPtr dev, int msg, long param1, long param2,
 static void
 rdpkeybDeviceOn(void)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybDeviceOn:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybDeviceOn:");
 }
 
 /******************************************************************************/
 static void
 rdpkeybDeviceOff(void)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybDeviceOff:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybDeviceOff:");
 }
 
 /******************************************************************************/
 static void
 rdpkeybBell(int volume, DeviceIntPtr pDev, pointer ctrl, int cls)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybBell:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybBell:");
 }
 
 /******************************************************************************/
@@ -324,7 +324,7 @@ rdpInDeferredRepeatCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     DeviceIntPtr it;
     Bool found;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpInDeferredRepeatCallback:"));
+    LOG(LOG_LEVEL_TRACE, "rdpInDeferredRepeatCallback:");
     TimerFree(timer);
     pDev = (DeviceIntPtr) arg;
     found = FALSE;
@@ -351,7 +351,7 @@ rdpkeybChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl *ctrl)
 {
     XkbControlsPtr ctrls;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybChangeKeyboardControl:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybChangeKeyboardControl:");
     ctrls = 0;
     if (pDev != 0)
     {
@@ -373,14 +373,14 @@ rdpkeybChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl *ctrl)
     {
         if (ctrls->enabled_ctrls & XkbRepeatKeysMask)
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpkeybChangeKeyboardControl: autoRepeat on"));
+            LOG(LOG_LEVEL_INFO, "rdpkeybChangeKeyboardControl: autoRepeat on");
             /* schedule to turn off the autorepeat after 100 ms so any app
              * polling it will be happy it's on */
             TimerSet(NULL, 0, 100, rdpInDeferredRepeatCallback, pDev);
         }
         else
         {
-            LLOGLN(LOG_LEVEL_INFO, ("rdpkeybChangeKeyboardControl: autoRepeat off"));
+            LOG(LOG_LEVEL_INFO, "rdpkeybChangeKeyboardControl: autoRepeat off");
         }
     }
 }
@@ -392,7 +392,7 @@ rdpkeybControl(DeviceIntPtr device, int what)
     DevicePtr pDev;
     rdpPtr dev;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybControl: what %d", what));
+    LOG(LOG_LEVEL_INFO, "rdpkeybControl: what %d", what);
     pDev = (DevicePtr)device;
 
     switch (what)
@@ -432,8 +432,8 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 {
     InputInfoPtr info;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybPreInit: drv %p dev %p, flags 0x%x",
-           drv, dev, flags));
+    LOG(LOG_LEVEL_INFO, "rdpkeybPreInit: drv %p dev %p, flags 0x%x",
+           drv, dev, flags);
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
     info->device_control = rdpkeybControl;
@@ -455,8 +455,8 @@ rdpkeybPreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 static int
 rdpkeybPreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybPreInit: drv %p info %p, flags 0x%x",
-           drv, info, flags));
+    LOG(LOG_LEVEL_INFO, "rdpkeybPreInit: drv %p info %p, flags 0x%x",
+           drv, info, flags);
     info->device_control = rdpkeybControl;
     info->type_name = g_Keyboard_str;
 
@@ -469,8 +469,8 @@ rdpkeybPreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 static void
 rdpkeybUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpkeybUnInit: drv %p info %p, flags 0x%x",
-           drv, info, flags));
+    LOG(LOG_LEVEL_INFO, "rdpkeybUnInit: drv %p info %p, flags 0x%x",
+           drv, info, flags);
     rdpUnregisterInputCallback(rdpInputKeyboard);
 }
 
@@ -487,7 +487,7 @@ static InputDriverRec rdpkeyb =
 static pointer
 rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybPlug:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybPlug:");
     xf86AddInputDriver(&rdpkeyb, module, 0);
     xorgxrdpCheckWrap();
     return module;
@@ -497,7 +497,7 @@ rdpkeybPlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpkeybUnplug(pointer p)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpkeybUnplug:"));
+    LOG(LOG_LEVEL_TRACE, "rdpkeybUnplug:");
 }
 
 /******************************************************************************/
@@ -532,7 +532,7 @@ reload_xkb(DeviceIntPtr keyboard, XkbRMLVOSet *set)
     if (!InitKeyboardDeviceStruct(keyboard, set, rdpkeybBell,
                                   rdpkeybChangeKeyboardControl))
     {
-        LLOGLN(LOG_LEVEL_INFO, ("reload_xkb: InitKeyboardDeviceStruct failed"));
+        LOG(LOG_LEVEL_INFO, "reload_xkb: InitKeyboardDeviceStruct failed");
         return 1;
     }
 
@@ -611,9 +611,9 @@ rdpLoadLayout(rdpKeyboard *keyboard, struct xup_client_info *client_info)
         keyboard->x11_keycode_scroll_lock = SCROLL_LOCK_KEY_CODE;
     }
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
+    LOG(LOG_LEVEL_INFO, "rdpLoadLayout: rules=\"%s\" model=\"%s\" variant=\"%s\""
                "layout=\"%s\" options=\"%s\"",
-               set.rules, set.model, set.variant, set.layout, set.options));
+               set.rules, set.model, set.variant, set.layout, set.options);
 
     reload_xkb(keyboard->device, &set);
     reload_xkb(inputInfo.keyboard, &set);

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -62,28 +62,28 @@ static char g_xrdp_mouse_name[] = XRDP_MOUSE_NAME;
 static void
 rdpmouseDeviceInit(void)
 {
-    LLOGLN(10, ("rdpmouseDeviceInit:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceInit:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOn(DeviceIntPtr pDev)
 {
-    LLOGLN(10, ("rdpmouseDeviceOn:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceOn:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOff(void)
 {
-    LLOGLN(10, ("rdpmouseDeviceOff:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceOff:"));
 }
 
 /******************************************************************************/
 static void
 rdpmouseCtrl(DeviceIntPtr pDevice, PtrCtrl *pCtrl)
 {
-    LLOGLN(10, ("rdpmouseCtrl:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseCtrl:"));
 }
 
 /******************************************************************************/
@@ -101,7 +101,7 @@ rdpEnqueueMotion(DeviceIntPtr device, int x, int y)
     int flags;
     ValuatorMask *mask;
 
-    LLOGLN(10, ("rdpEnqueueMotion:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnqueueMotion:"));
     mask = valuator_mask_new(2);
     if (mask != NULL)
     {
@@ -119,7 +119,7 @@ rdpEnqueueButton(DeviceIntPtr device, int type, int buttons)
 {
     ValuatorMask *mask;
 
-    LLOGLN(10, ("rdpEnqueueButton:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnqueueButton:"));
     mask = valuator_mask_new(0);
     if (mask != NULL)
     {
@@ -136,7 +136,7 @@ PtrAddEvent(rdpPointer *pointer)
     int type;
     int buttons;
 
-    LLOGLN(10, ("PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y));
+    LLOGLN(LOG_LEVEL_TRACE, ("PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y));
 
     if ((pointer->old_cursor_x != pointer->cursor_x) ||
             (pointer->old_cursor_y != pointer->cursor_y))
@@ -179,7 +179,7 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     int mask_pos;
     int scaled_delta;
 
-    LLOGLN(10, ("PtrAddScrollEvent: vertical %d y %d", vertical, delta));
+    LLOGLN(LOG_LEVEL_TRACE, ("PtrAddScrollEvent: vertical %d y %d", vertical, delta));
 
     scroll_events_mask = valuator_mask_new(NAXES);
     mask_pos = vertical ? 2 : 3;
@@ -210,7 +210,7 @@ rdpInputMouse(rdpPtr dev, int msg,
 {
     rdpPointer *pointer;
 
-    LLOGLN(10, ("rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
                 msg, param1, param2, param3, param4));
     pointer = &(dev->pointer);
     switch (msg)
@@ -315,7 +315,7 @@ rdpmouseControl(DeviceIntPtr device, int what)
     rdpPtr dev;
     int i;
 
-    LLOGLN(0, ("rdpmouseControl: what %d", what));
+    LLOGLN(LOG_LEVEL_INFO, ("rdpmouseControl: what %d", what));
     pDev = (DevicePtr)device;
 
     switch (what)
@@ -392,7 +392,7 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 {
     InputInfoPtr info;
 
-    LLOGLN(0, ("rdpmousePreInit: drv %p dev %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpmousePreInit: drv %p dev %p, flags 0x%x",
                drv, dev, flags));
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
@@ -415,7 +415,7 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 static int
 rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(0, ("rdpmousePreInit: drv %p info %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpmousePreInit: drv %p info %p, flags 0x%x",
                drv, info, flags));
     info->device_control = rdpmouseControl;
     info->type_name = g_Mouse_str;
@@ -428,7 +428,7 @@ rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 static void
 rdpmouseUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(0, ("rdpmouseUnInit: drv %p info %p, flags 0x%x",
+    LLOGLN(LOG_LEVEL_INFO, ("rdpmouseUnInit: drv %p info %p, flags 0x%x",
                drv, info, flags));
     rdpUnregisterInputCallback(rdpInputMouse);
 }
@@ -446,7 +446,7 @@ static InputDriverRec rdpmouse =
 static pointer
 rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(10, ("rdpmousePlug:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmousePlug:"));
     xf86AddInputDriver(&rdpmouse, module, 0);
     return module;
 }
@@ -455,7 +455,7 @@ rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpmouseUnplug(pointer p)
 {
-    LLOGLN(10, ("rdpmouseUnplug:"));
+    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseUnplug:"));
 }
 
 /******************************************************************************/

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -136,7 +136,8 @@ PtrAddEvent(rdpPointer *pointer)
     int type;
     int buttons;
 
-    LOG(LOG_LEVEL_TRACE, "PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y);
+    LOG(LOG_LEVEL_TRACE, "PtrAddEvent: x %d y %d",
+        pointer->cursor_x, pointer->cursor_y);
 
     if ((pointer->old_cursor_x != pointer->cursor_x) ||
             (pointer->old_cursor_y != pointer->cursor_y))
@@ -179,7 +180,8 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     int mask_pos;
     int scaled_delta;
 
-    LOG(LOG_LEVEL_TRACE, "PtrAddScrollEvent: vertical %d y %d", vertical, delta);
+    LOG(LOG_LEVEL_TRACE,
+        "PtrAddScrollEvent: vertical %d y %d", vertical, delta);
 
     scroll_events_mask = valuator_mask_new(NAXES);
     mask_pos = vertical ? 2 : 3;
@@ -210,8 +212,9 @@ rdpInputMouse(rdpPtr dev, int msg,
 {
     rdpPointer *pointer;
 
-    LOG(LOG_LEVEL_TRACE, "rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
-                msg, param1, param2, param3, param4);
+    LOG(LOG_LEVEL_TRACE,
+        "rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
+        msg, param1, param2, param3, param4);
     pointer = &(dev->pointer);
     switch (msg)
     {
@@ -393,7 +396,7 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
     InputInfoPtr info;
 
     LOG(LOG_LEVEL_INFO, "rdpmousePreInit: drv %p dev %p, flags 0x%x",
-               drv, dev, flags);
+        drv, dev, flags);
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
     info->device_control = rdpmouseControl;
@@ -416,7 +419,7 @@ static int
 rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LOG(LOG_LEVEL_INFO, "rdpmousePreInit: drv %p info %p, flags 0x%x",
-               drv, info, flags);
+        drv, info, flags);
     info->device_control = rdpmouseControl;
     info->type_name = g_Mouse_str;
     return 0;
@@ -429,7 +432,7 @@ static void
 rdpmouseUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
     LOG(LOG_LEVEL_INFO, "rdpmouseUnInit: drv %p info %p, flags 0x%x",
-               drv, info, flags);
+        drv, info, flags);
     rdpUnregisterInputCallback(rdpInputMouse);
 }
 

--- a/xrdpmouse/rdpMouse.c
+++ b/xrdpmouse/rdpMouse.c
@@ -62,28 +62,28 @@ static char g_xrdp_mouse_name[] = XRDP_MOUSE_NAME;
 static void
 rdpmouseDeviceInit(void)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceInit:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmouseDeviceInit:");
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOn(DeviceIntPtr pDev)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceOn:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmouseDeviceOn:");
 }
 
 /******************************************************************************/
 static void
 rdpmouseDeviceOff(void)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseDeviceOff:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmouseDeviceOff:");
 }
 
 /******************************************************************************/
 static void
 rdpmouseCtrl(DeviceIntPtr pDevice, PtrCtrl *pCtrl)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseCtrl:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmouseCtrl:");
 }
 
 /******************************************************************************/
@@ -101,7 +101,7 @@ rdpEnqueueMotion(DeviceIntPtr device, int x, int y)
     int flags;
     ValuatorMask *mask;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnqueueMotion:"));
+    LOG(LOG_LEVEL_TRACE, "rdpEnqueueMotion:");
     mask = valuator_mask_new(2);
     if (mask != NULL)
     {
@@ -119,7 +119,7 @@ rdpEnqueueButton(DeviceIntPtr device, int type, int buttons)
 {
     ValuatorMask *mask;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpEnqueueButton:"));
+    LOG(LOG_LEVEL_TRACE, "rdpEnqueueButton:");
     mask = valuator_mask_new(0);
     if (mask != NULL)
     {
@@ -136,7 +136,7 @@ PtrAddEvent(rdpPointer *pointer)
     int type;
     int buttons;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y));
+    LOG(LOG_LEVEL_TRACE, "PtrAddEvent: x %d y %d", pointer->cursor_x, pointer->cursor_y);
 
     if ((pointer->old_cursor_x != pointer->cursor_x) ||
             (pointer->old_cursor_y != pointer->cursor_y))
@@ -179,7 +179,7 @@ PtrAddScrollEvent(rdpPointer *pointer, int vertical, int delta)
     int mask_pos;
     int scaled_delta;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("PtrAddScrollEvent: vertical %d y %d", vertical, delta));
+    LOG(LOG_LEVEL_TRACE, "PtrAddScrollEvent: vertical %d y %d", vertical, delta);
 
     scroll_events_mask = valuator_mask_new(NAXES);
     mask_pos = vertical ? 2 : 3;
@@ -210,8 +210,8 @@ rdpInputMouse(rdpPtr dev, int msg,
 {
     rdpPointer *pointer;
 
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
-                msg, param1, param2, param3, param4));
+    LOG(LOG_LEVEL_TRACE, "rdpInputMouse: msg %d param1 %ld param2 %ld param3 %ld param4 %ld",
+                msg, param1, param2, param3, param4);
     pointer = &(dev->pointer);
     switch (msg)
     {
@@ -315,7 +315,7 @@ rdpmouseControl(DeviceIntPtr device, int what)
     rdpPtr dev;
     int i;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpmouseControl: what %d", what));
+    LOG(LOG_LEVEL_INFO, "rdpmouseControl: what %d", what);
     pDev = (DevicePtr)device;
 
     switch (what)
@@ -392,8 +392,8 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 {
     InputInfoPtr info;
 
-    LLOGLN(LOG_LEVEL_INFO, ("rdpmousePreInit: drv %p dev %p, flags 0x%x",
-               drv, dev, flags));
+    LOG(LOG_LEVEL_INFO, "rdpmousePreInit: drv %p dev %p, flags 0x%x",
+               drv, dev, flags);
     info = xf86AllocateInput(drv, 0);
     info->name = dev->identifier;
     info->device_control = rdpmouseControl;
@@ -415,8 +415,8 @@ rdpmousePreInit(InputDriverPtr drv, IDevPtr dev, int flags)
 static int
 rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpmousePreInit: drv %p info %p, flags 0x%x",
-               drv, info, flags));
+    LOG(LOG_LEVEL_INFO, "rdpmousePreInit: drv %p info %p, flags 0x%x",
+               drv, info, flags);
     info->device_control = rdpmouseControl;
     info->type_name = g_Mouse_str;
     return 0;
@@ -428,8 +428,8 @@ rdpmousePreInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 static void
 rdpmouseUnInit(InputDriverPtr drv, InputInfoPtr info, int flags)
 {
-    LLOGLN(LOG_LEVEL_INFO, ("rdpmouseUnInit: drv %p info %p, flags 0x%x",
-               drv, info, flags));
+    LOG(LOG_LEVEL_INFO, "rdpmouseUnInit: drv %p info %p, flags 0x%x",
+               drv, info, flags);
     rdpUnregisterInputCallback(rdpInputMouse);
 }
 
@@ -446,7 +446,7 @@ static InputDriverRec rdpmouse =
 static pointer
 rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmousePlug:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmousePlug:");
     xf86AddInputDriver(&rdpmouse, module, 0);
     return module;
 }
@@ -455,7 +455,7 @@ rdpmousePlug(pointer module, pointer options, int *errmaj, int *errmin)
 static void
 rdpmouseUnplug(pointer p)
 {
-    LLOGLN(LOG_LEVEL_TRACE, ("rdpmouseUnplug:"));
+    LOG(LOG_LEVEL_TRACE, "rdpmouseUnplug:");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
~~Draft for now - I need to do more testing.~~ Comments welcome.

Following a suggesting from @rowlap, this PR replaces the `LLOGLN()` macro with the `LOG()` macro and levels from xrdp.

The move was largely automated, with some tweaking afterwards to fix indentation. A couple of logging levels have been changed to the new `LOG_LEVEL_WARNING`.

The use of symbolic names illustrates perfectly that logging in this module is currently all over the place!

This can be back-ported to v0.10.x if desired.