### PR TITLE
Code quality: Address Copilot discovered errors

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -1305,13 +1305,13 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LOG(LOG_LEVEL_TRACE, "old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
             rect.x2, rect.y2);
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
         rect.y2 += rect.y2 & 1;
-        LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LOG(LOG_LEVEL_TRACE, "new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
             rect.x2, rect.y2);
         (*out_rects)[index] = rect;
         index++;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -863,7 +863,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
 
     LOG(LOG_LEVEL_TRACE, "rdpClientConResizeAllMemoryAreas:");
 
-    // Updare the rdp size from the client size
+    // Update the rdp size from the client size
     clientCon->rdp_width = width;
     clientCon->rdp_height = height;
 
@@ -907,7 +907,6 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
         default:
             LOG(LOG_LEVEL_INFO,
                 "rdpClientConProcessMsgClientInfo: got normal capture");
-            clientCon->cap_width = width;
             clientCon->cap_width = width;
             clientCon->cap_height = height;
 
@@ -2830,14 +2829,14 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: index %d stamp %d",
-        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
-
-    if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
+    if ((rdpindex < 0) || (rdpindex >= clientCon->maxOsBitmaps))
     {
         LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: test error 2");
         return 1;
     }
+
+    LOG(LOG_LEVEL_TRACE, "rdpClientConRemoveOsBitmap: index %d stamp %d",
+        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if (clientCon->osBitmaps[rdpindex].used)
     {
@@ -2876,13 +2875,15 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LOG(LOG_LEVEL_TRACE, "rdpClientConUpdateOsUse: index %d stamp %d",
-        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
-
-    if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
+    if ((rdpindex < 0) || (rdpindex >= clientCon->maxOsBitmaps))
     {
+        LOG(LOG_LEVEL_ERROR, "rdpClientConUpdateOsUse: bad index %d",
+            rdpindex);
         return 1;
     }
+
+    LOG(LOG_LEVEL_TRACE, "rdpClientConUpdateOsUse: index %d stamp %d",
+        rdpindex, clientCon->osBitmaps[rdpindex].stamp);
 
     if (clientCon->osBitmaps[rdpindex].used)
     {


### PR DESCRIPTION
Following errors were discovered by Copilot
- module/rdpCapture.c b/module/rdpCapture.c
    - Two instances where logged data did not agree with comments.
- module/rdpClientCon.c b/module/rdpClientCon.c
    - Spelling Updare -> Update
    - Double assignment of clientCon->cap_width = width
    - Log message involving array dereference before bounds check in
      rdpClientConRemoveOsBitmap)_
    - Bounds check related to previous error was incorrect
    - The previous two errors also occurred in rdpClientConUpdateOsUse()