### PR TITLE
[V0.10] Code quality: Address Copilot discovered errors

### DIFF
--- a/module/rdpCapture.c
+++ b/module/rdpCapture.c
@@ -1191,13 +1191,13 @@ rdpCaptureSufA2(rdpClientCon *clientCon, RegionPtr in_reg, BoxPtr *out_rects,
     while (index < num_rects)
     {
         rect = psrc_rects[index];
-        LLOGLN(10, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LLOGLN(10, ("old x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
                rect.x2, rect.y2));
         rect.x1 -= rect.x1 & 1;
         rect.y1 -= rect.y1 & 1;
         rect.x2 += rect.x2 & 1;
         rect.y2 += rect.y2 & 1;
-        LLOGLN(10, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.x2,
+        LLOGLN(10, ("new x1 %d y1 %d x2 %d y2 %d", rect.x1, rect.y1,
                rect.x2, rect.y2));
         (*out_rects)[index] = rect;
         index++;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -771,7 +771,7 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
 
     enum shared_memory_status shmemstatus;
 
-    // Updare the rdp size from the client size
+    // Update the rdp size from the client size
     clientCon->rdp_width = width;
     clientCon->rdp_height = height;
 
@@ -812,7 +812,6 @@ rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon)
             break;
         default:
             LLOGLN(0, ("rdpClientConProcessMsgClientInfo: got normal capture"));
-            clientCon->cap_width = width;
             clientCon->cap_width = width;
             clientCon->cap_height = height;
 
@@ -2498,14 +2497,14 @@ rdpClientConRemoveOsBitmap(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LLOGLN(10, ("rdpClientConRemoveOsBitmap: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
-
-    if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
+    if ((rdpindex < 0) || (rdpindex >= clientCon->maxOsBitmaps))
     {
         LLOGLN(10, ("rdpClientConRemoveOsBitmap: test error 2"));
         return 1;
     }
+
+    LLOGLN(10, ("rdpClientConRemoveOsBitmap: index %d stamp %d",
+           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
 
     if (clientCon->osBitmaps[rdpindex].used)
     {
@@ -2544,13 +2543,15 @@ rdpClientConUpdateOsUse(rdpPtr dev, rdpClientCon *clientCon, int rdpindex)
         return 1;
     }
 
-    LLOGLN(10, ("rdpClientConUpdateOsUse: index %d stamp %d",
-           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
-
-    if ((rdpindex < 0) && (rdpindex >= clientCon->maxOsBitmaps))
+    if ((rdpindex < 0) || (rdpindex >= clientCon->maxOsBitmaps))
     {
+        LLOGLN(0, ("rdpClientConUpdateOsUse: bad index %d",
+            rdpindex));
         return 1;
     }
+
+    LLOGLN(10, ("rdpClientConUpdateOsUse: index %d stamp %d",
+           rdpindex, clientCon->osBitmaps[rdpindex].stamp));
 
     if (clientCon->osBitmaps[rdpindex].used)
     {


### PR DESCRIPTION
Following errors were discovered by Copilot
- module/rdpCapture.c b/module/rdpCapture.c
  - Two instances where logged data did not agree with comments.
- module/rdpClientCon.c b/module/rdpClientCon.c
  - Spelling Updare -> Update
  - Double assignment of clientCon->cap_width = width
  - Log message involving array dereference before bounds check in rdpClientConRemoveOsBitmap()
  - Bounds check related to previous error was incorrect
  - The previous two errors also occurred in rdpClientConUpdateOsUse()

(cherry picked from commit 924c9799dd4d4306e3cf032a179f568fb95eea39)