### PR TITLE
Code quality: Address more Copilot issues

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -808,9 +808,8 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
     }
     if (g_alloc_shm_map_fd(&shmemptr, &shmemfd, bytes) != 0)
     {
-        LOG(LOG_LEVEL_INFO,
-            "rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
-            "failed");
+        FatalError("rdpClientConAllocateSharedMemory:"
+                   " g_alloc_shm_map_fd failed");
     }
     clientCon->shmemptr = shmemptr;
     clientCon->shmemfd = shmemfd;
@@ -2554,9 +2553,7 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         shmsize = width * height * Bpp + width * height / 8;
         if (g_alloc_shm_map_fd(&addr, &fd, shmsize) != 0)
         {
-            LOG(LOG_LEVEL_INFO,
-                "rdpClientConSetCursorShmFd: rdpGetShmFd failed");
-            return 0;
+            FatalError("rdpClientConSetCursorShmFd: g_alloc_shm_map_fd failed");
         }
         shmemptr = (uint8_t *)addr;
         size = 14;

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -976,7 +976,7 @@ rdpProbe(DriverPtr drv, int flags)
         {
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_allow_list, val, 127);
-            g_drm_device[127] = 0;
+            g_drm_allow_list[127] = 0;
             LOG(LOG_LEVEL_INFO,
                 "rdpProbe: found DRMAllowList xorg.conf value [%s]", val);
 #endif


### PR DESCRIPTION
- xrdpdev/xrdpdev.c
  - Wrong string terminated

- module/rdpClientCon.c
  - A failure of g_alloc_shm_map_fd() should be treated as fatal, as we're not set up to handle it.