### PR TITLE
[V0.10] Code quality: Address more Copilot issues

### DIFF
--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -722,8 +722,8 @@ rdpClientConAllocateSharedMemory(rdpClientCon *clientCon, int bytes)
     }
     if (g_alloc_shm_map_fd(&shmemptr, &shmemfd, bytes) != 0)
     {
-        LLOGLN(0, ("rdpClientConAllocateSharedMemory: g_alloc_shm_map_fd "
-               "failed"));
+        FatalError("rdpClientConAllocateSharedMemory:"
+                   " g_alloc_shm_map_fd failed");
     }
     clientCon->shmemptr = shmemptr;
     clientCon->shmemfd = shmemfd;
@@ -2230,8 +2230,7 @@ rdpClientConSetCursorShmFd(rdpPtr dev, rdpClientCon *clientCon,
         shmsize = width * height * Bpp + width * height / 8;
         if (g_alloc_shm_map_fd(&addr, &fd, shmsize) != 0)
         {
-            LLOGLN(0, ("rdpClientConSetCursorShmFd: rdpGetShmFd failed"));
-            return 0;
+            FatalError("rdpClientConSetCursorShmFd: g_alloc_shm_map_fd failed");
         }
         shmemptr = (uint8_t *)addr;
         size = 14;

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -983,7 +983,7 @@ rdpProbe(DriverPtr drv, int flags)
         {
 #if defined(XORGXRDP_GLAMOR)
             strncpy(g_drm_allow_list, val, 127);
-            g_drm_device[127] = 0;
+            g_drm_allow_list[127] = 0;
             LLOGLN(0, ("rdpProbe: found DRMAllowList xorg.conf value [%s]", val));
 #endif
         }


### PR DESCRIPTION
- xrdpdev/xrdpdev.c
  - Wrong string terminated

- module/rdpClientCon.c
  - A failure of g_alloc_shm_map_fd() should be treated as fatal, as we're not set up to handle it.

(cherry picked from commit 13b31ff9fa27433994e4473a8180c0529a20a8ad)