### PR TITLE
CI: Upgrade to latest github action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       CFLAGS: ${{matrix.CFLAGS }}
       XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
       - run: ./bootstrap
@@ -99,11 +99,11 @@ jobs:
         id: os
         run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: sh
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: git clone --depth 1 --branch=devel https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
       - name: Cache xorg-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-xorg-build
         with:

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "timestamp=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
 
@@ -53,7 +53,7 @@ jobs:
           echo "tarball=$TARBALL" >> $GITHUB_ENV
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name:  ${{ github.event.repository.name }}-${{ github.event.inputs.tag }}-${{ env.timestamp }}
           path: "${{ env.tarball }}"


### PR DESCRIPTION
This has been prompted by the following deprecation messages:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4.