### PR TITLE
[V0.10] CI: Upgrade to latest github action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       XRDP_CFLAGS: -I${{ github.workspace }}/xrdp/common
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: sudo scripts/install_xorgxrdp_build_dependencies_with_apt.sh ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: git clone --depth 1 --branch=v0.10 https://github.com/neutrinolabs/xrdp.git ${{ github.workspace}}/xrdp
       - run: ./bootstrap


### PR DESCRIPTION
This has been prompted by the following deprecation messages:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4.