### PR TITLE
glamor/dri3: misc fixes for intel xe drm driver

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -32,6 +32,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <randrstr.h>
 #include <damage.h>
 
+struct gbm_device;
+struct gbm_bo;
+
 #include "rdpPri.h"
 
 #include "xup_client_info.h"
@@ -68,6 +71,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     ((_val) < (_lo) ? (_lo) : (_val) > (_hi) ? (_hi) : (_val))
 #define RDPALIGN(_val, _al) ((((uintptr_t)(_val)) + ((_al) - 1)) & ~((_al) - 1))
 
+#define XRDP_FB_ALIGN 16
 #define XRDP_RFX_ALIGN 64
 #define XRDP_H264_ALIGN 16
 
@@ -318,9 +322,14 @@ struct _rdpRec
     int monitorCount;
     /* glamor */
     Bool glamor;
+    struct gbm_device *gbm;
+    struct gbm_bo *gbm_bo;
+    /* nvidia grid */
     Bool nvidia;
     Bool nvidia_grid;
+    /* Bounce buffer for GPU */
     PixmapPtr screenSwPixmap;
+    /* xv */
     void *xvPutImage;
     /* dri */
     int fd;

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -50,6 +50,7 @@ RandR draw calls
 
 #if defined(XORGXRDP_GLAMOR)
 #include <glamor.h>
+#include <gbm.h>
 #endif
 
 static int g_panning = 0;
@@ -91,23 +92,134 @@ rdpRRGetInfo(ScreenPtr pScreen, Rotation *pRotations)
     return TRUE;
 }
 
-#if defined(XORGXRDP_GLAMOR)
-/*****************************************************************************/
-static int
-rdpRRSetPixmapVisitWindow(WindowPtr window, void *data)
+Bool
+rdpRRScreenDestroyBacking(ScreenPtr pScreen)
 {
-    ScreenPtr screen;
+    rdpPtr dev;
 
-    LOG(LOG_LEVEL_TRACE, "rdpRRSetPixmapVisitWindow:");
-    screen = window->drawable.pScreen;
-    if (screen->GetWindowPixmap(window) == data)
+    LOG(LOG_LEVEL_TRACE, "rdpRRScreenDestroyBacking:");
+    dev = rdpGetDevFromScreen(pScreen);
+    if (dev->pfbMemory_alloc != NULL)
     {
-        screen->SetWindowPixmap(window, screen->GetScreenPixmap(screen));
-        return WT_WALKCHILDREN;
+        free(dev->pfbMemory_alloc);
+        dev->pfbMemory_alloc = NULL;
+        dev->pfbMemory = NULL;
     }
-    return WT_DONTWALKCHILDREN;
-}
+
+    if (dev->glamor)
+    {
+#if defined(XORGXRDP_GLAMOR)
+        if (dev->screenSwPixmap)
+        {
+            pScreen->DestroyPixmap(dev->screenSwPixmap);
+            dev->screenSwPixmap = NULL;
+        }
+        if (dev->gbm_bo)
+        {
+            gbm_bo_destroy(dev->gbm_bo);
+            dev->gbm_bo = NULL;
+        }
 #endif
+    }
+    return TRUE;
+}
+
+Bool
+rdpRRScreenCreateBacking(ScreenPtr pScreen)
+{
+    PixmapPtr screenPixmap;
+    rdpPtr dev;
+    void *old_fbMemory_alloc;
+
+    LOG(LOG_LEVEL_TRACE, "rdpRRAllocatePixmaps:");
+
+    dev = rdpGetDevFromScreen(pScreen);
+    screenPixmap = pScreen->GetScreenPixmap(pScreen);
+    if (screenPixmap == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: GetScreenPixmap failed");
+        return FALSE;
+    }
+
+    /* Only create software pixmap if glamor is enabled and not already created */
+    if (dev->glamor && dev->screenSwPixmap == NULL)
+    {
+        dev->screenSwPixmap = pScreen->CreatePixmap(pScreen,
+                                                    0, 0,
+                                                    pScreen->rootDepth, 0);
+        if (dev->screenSwPixmap == NULL)
+        {
+            LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: CreatePixmap failed");
+            return FALSE;
+        }
+    }
+
+    /* Now let's allocate framebuffers for CPU access */
+    old_fbMemory_alloc = dev->pfbMemory_alloc;
+    dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + XRDP_FB_ALIGN);
+    dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, XRDP_FB_ALIGN);
+
+    /* Update screen pixmap header, only include pixels if no screenSwPixmap */
+    if (!pScreen->ModifyPixmapHeader(screenPixmap, dev->width, dev->height,
+                                        dev->depth, dev->bitsPerPixel,
+                                        dev->paddedWidthInBytes,
+                                        (dev->screenSwPixmap == NULL) ? dev->pfbMemory : NULL))
+    {
+        LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: ModifyPixmapHeader failed");
+        return FALSE;
+    }
+
+    if (dev->screenSwPixmap != NULL)
+    {
+        if (!pScreen->ModifyPixmapHeader(dev->screenSwPixmap, dev->width,
+                                        dev->height, dev->depth, dev->bitsPerPixel,
+                                        dev->paddedWidthInBytes, dev->pfbMemory))
+        {
+            LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: ModifyPixmapHeader for screenSwPixmap failed");
+            return FALSE;
+        }
+    }
+
+    /* Free old framebuffer memory only after new pixmap created */
+    if (old_fbMemory_alloc != NULL)
+    {
+        free(old_fbMemory_alloc);
+    }
+
+#if defined(XORGXRDP_GLAMOR)
+    if (dev->glamor)
+    {
+        struct gbm_bo *bo;
+
+        bo = gbm_bo_create(dev->gbm, dev->width, dev->height,
+                                   GBM_FORMAT_XRGB8888,
+                                   GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+        if (bo == NULL)
+        {
+            LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: gbm_bo_create failed");
+            return FALSE;
+        }
+
+        /* gbm_bo_create() does not allocate the BO with explicit modifiers. */
+        if (!glamor_egl_create_textured_pixmap_from_gbm_bo(screenPixmap, bo,
+                                                           FALSE))
+        {
+            LOG(LOG_LEVEL_ERROR, "rdpRRScreenCreateBacking: glamor_egl_create_textured_pixmap_from_gbm_bo failed");
+            gbm_bo_destroy(bo);
+            return FALSE;
+        }
+
+        /* Destory old bo */
+        if (dev->gbm_bo)
+        {
+            gbm_bo_destroy(dev->gbm_bo);
+        }
+        dev->gbm_bo = bo;
+    }
+#endif
+
+    return TRUE;
+}
 
 /******************************************************************************/
 Bool
@@ -115,7 +227,6 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
                    CARD32 mmWidth, CARD32 mmHeight)
 {
     WindowPtr root;
-    PixmapPtr screenPixmap;
     BoxRec box;
     rdpPtr dev;
 
@@ -148,40 +259,7 @@ rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     pScreen->mmHeight = mmHeight;
     dev->paddedWidthInBytes = PixmapBytePad(dev->width, dev->depth);
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
-    screenPixmap = dev->screenSwPixmap;
-    free(dev->pfbMemory_alloc);
-    dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
-    dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
-    pScreen->ModifyPixmapHeader(screenPixmap, width, height,
-                                -1, -1,
-                                dev->paddedWidthInBytes,
-                                dev->pfbMemory);
-    if (dev->glamor)
-    {
-#if defined(XORGXRDP_GLAMOR)
-        PixmapPtr old_screen_pixmap;
-        uint32_t screen_tex;
-        old_screen_pixmap = pScreen->GetScreenPixmap(pScreen);
-        screenPixmap = pScreen->CreatePixmap(pScreen,
-                                             pScreen->width,
-                                             pScreen->height,
-                                             pScreen->rootDepth,
-                                             GLAMOR_CREATE_NO_LARGE);
-        if (screenPixmap == NULL)
-        {
-            return FALSE;
-        }
-        screen_tex = glamor_get_pixmap_texture(screenPixmap);
-        LOG(LOG_LEVEL_INFO,
-            "rdpRRScreenSetSize: screen_tex 0x%8.8x", screen_tex);
-        pScreen->SetScreenPixmap(screenPixmap);
-        if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
-        {
-            TraverseTree(pScreen->root, rdpRRSetPixmapVisitWindow, old_screen_pixmap);
-        }
-        pScreen->DestroyPixmap(old_screen_pixmap);
-#endif
-    }
+    rdpRRScreenCreateBacking(pScreen);
     box.x1 = 0;
     box.y1 = 0;
     box.x2 = width;
@@ -610,4 +688,3 @@ rdpRRSetRdpOutputs(rdpPtr dev)
     }
     return rv;
 }
-

--- a/module/rdpRandR.h
+++ b/module/rdpRandR.h
@@ -34,6 +34,10 @@ extern _X_EXPORT Bool
 rdpRRSetConfig(ScreenPtr pScreen, Rotation rotateKind, int rate,
                RRScreenSizePtr pSize);
 extern _X_EXPORT Bool
+rdpRRScreenDestroyBacking(ScreenPtr pScreen);
+extern _X_EXPORT Bool
+rdpRRScreenCreateBacking(ScreenPtr pScreen);
+extern _X_EXPORT Bool
 rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
                    CARD32 mmWidth, CARD32 mmHeight);
 extern _X_EXPORT Bool

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -66,9 +66,8 @@ This is the main driver file
 #include "xrdpdri2.h"
 #include "xrdpdri3.h"
 #include "rdpEgl.h"
-#include <drm.h>
+#include <xf86drm.h>
 #include <glamor.h>
-#include <sys/ioctl.h>
 /* use environment variable XORGXRDP_DRM_DEVICE to override
  * also read from xorg.conf file */
 char g_drm_device[128] = "/dev/dri/renderD128";
@@ -169,34 +168,34 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         strncpy(g_drm_device, getenv("XORGXRDP_DRM_DEVICE"), 127);
         g_drm_device[127] = 0;
     }
-    dev->fd = open(g_drm_device, O_RDWR, 0);
+    dev->fd = open(g_drm_device, O_RDWR | O_CLOEXEC, 0);
     if (dev->fd == -1)
     {
         LOG(LOG_LEVEL_INFO, "rdpPreInit: %s open failed", g_drm_device);
     }
     else
     {
-        struct drm_version dver;
+        drmVersionPtr dver;
         char delim[] = " ";
         char *token;
+        const char *drm_name;
+        const char *drm_date;
+        const char *drm_desc;
         LOG(LOG_LEVEL_INFO, "rdpPreInit: %s open ok, fd %d", g_drm_device, dev->fd);
-        memset(&dver, 0, sizeof(dver));
-        dver.name_len = 256;
-        dver.name = g_new0(char, dver.name_len);
-        dver.date_len = 256;
-        dver.date = g_new0(char, dver.date_len);
-        dver.desc_len = 256;
-        dver.desc = g_new0(char, dver.desc_len);
-        if (ioctl(dev->fd, DRM_IOCTL_VERSION, &dver) != -1)
+        dver = drmGetVersion(dev->fd);
+        if (dver != NULL)
         {
-            LOG(LOG_LEVEL_INFO, "rdpPreInit: name [%s]", dver.name);
-            LOG(LOG_LEVEL_INFO, "rdpPreInit: date [%s]", dver.date);
-            LOG(LOG_LEVEL_INFO, "rdpPreInit: desc [%s]", dver.desc);
+            drm_name = (dver->name != NULL) ? dver->name : "";
+            drm_date = (dver->date != NULL) ? dver->date : "";
+            drm_desc = (dver->desc != NULL) ? dver->desc : "";
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: name [%s]", drm_name);
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: date [%s]", drm_date);
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: desc [%s]", drm_desc);
             token = strtok(g_drm_allow_list, delim);
             while (token != NULL)
             {
                 LOG(LOG_LEVEL_TRACE, "rdpPreInit: token [%s]", token);
-                if (strstr(dver.name, token) != NULL)
+                if (strstr(drm_name, token) != NULL)
                 {
                     dev->glamor = TRUE;
                     LOG(LOG_LEVEL_INFO, "rdpPreInit: drm device looks ok, "
@@ -212,11 +211,12 @@ rdpPreInit(ScrnInfoPtr pScrn, int flags)
         }
         else
         {
-            LOG(LOG_LEVEL_INFO, "rdpPreInit: DRM_IOCTL_VERSION failed");
+            LOG(LOG_LEVEL_INFO, "rdpPreInit: drmGetVersion failed");
         }
-        free(dver.name);
-        free(dver.date);
-        free(dver.desc);
+        if (dver != NULL)
+        {
+            drmFreeVersion(dver);
+        }
     }
 #endif
 

--- a/xrdpdev/xrdpdev.c
+++ b/xrdpdev/xrdpdev.c
@@ -547,30 +547,13 @@ rdpWakeupHandler1(void *blockData, int result)
     rdpClientConCheck((ScreenPtr)blockData);
 }
 
-#if defined(XORGXRDP_GLAMOR)
-/*****************************************************************************/
-static int
-rdpSetPixmapVisitWindow(WindowPtr window, void *data)
-{
-    ScreenPtr screen;
-
-    LOG(LOG_LEVEL_TRACE, "rdpSetPixmapVisitWindow:");
-    screen = window->drawable.pScreen;
-    if (screen->GetWindowPixmap(window) == data)
-    {
-        screen->SetWindowPixmap(window, screen->GetScreenPixmap(screen));
-        return WT_WALKCHILDREN;
-    }
-    return WT_DONTWALKCHILDREN;
-}
-#endif
-
 /*****************************************************************************/
 static Bool
 rdpCreateScreenResources(ScreenPtr pScreen)
 {
     Bool ret;
     rdpPtr dev;
+    PixmapPtr screenPixmap;
 
     LOG(LOG_LEVEL_TRACE, "rdpCreateScreenResources:");
     dev = rdpGetDevFromScreen(pScreen);
@@ -581,35 +564,18 @@ rdpCreateScreenResources(ScreenPtr pScreen)
     {
         return FALSE;
     }
-    dev->screenSwPixmap = pScreen->GetScreenPixmap(pScreen);
-    if (dev->glamor)
+
+    if (!rdpRRScreenCreateBacking(pScreen))
     {
-#if defined(XORGXRDP_GLAMOR)
-        PixmapPtr old_screen_pixmap;
-        PixmapPtr screen_pixmap;
-        uint32_t screen_tex;
-        old_screen_pixmap = dev->screenSwPixmap;
-        LOG(LOG_LEVEL_INFO,
-            "rdpCreateScreenResources: create screen pixmap w %d h %d",
-            pScreen->width, pScreen->height);
-        screen_pixmap = pScreen->CreatePixmap(pScreen,
-                                              pScreen->width,
-                                              pScreen->height,
-                                              pScreen->rootDepth,
-                                              GLAMOR_CREATE_NO_LARGE);
-        if (screen_pixmap == NULL)
-        {
-            return FALSE;
-        }
-        screen_tex = glamor_get_pixmap_texture(screen_pixmap);
-        LOG(LOG_LEVEL_INFO,
-            "rdpCreateScreenResources: screen_tex 0x%8.8x", screen_tex);
-        pScreen->SetScreenPixmap(screen_pixmap);
-        if ((pScreen->root != NULL) && (pScreen->SetWindowPixmap != NULL))
-        {
-            TraverseTree(pScreen->root, rdpSetPixmapVisitWindow, old_screen_pixmap);
-        }
-#endif
+        LOG(LOG_LEVEL_ERROR, "rdpCreateScreenResources: rdpRRScreenCreateBacking failed");
+        return FALSE;
+    }
+
+    screenPixmap = pScreen->GetScreenPixmap(pScreen);
+    if (screenPixmap == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "rdpCreateScreenResources: GetScreenPixmap failed");
+        return FALSE;
     }
 
     return TRUE;
@@ -647,10 +613,7 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
     dev->bitsPerPixel = rdpBitsPerPixel(dev->depth);
     dev->sizeInBytes = dev->paddedWidthInBytes * dev->height;
     LOG(LOG_LEVEL_INFO, "rdpScreenInit: pfbMemory bytes %d", dev->sizeInBytes);
-    dev->pfbMemory_alloc = g_new0(uint8_t, dev->sizeInBytes + 16);
-    dev->pfbMemory = (uint8_t *) RDPALIGN(dev->pfbMemory_alloc, 16);
-    LOG(LOG_LEVEL_INFO, "rdpScreenInit: pfbMemory %p", dev->pfbMemory);
-    if (!fbScreenInit(pScreen, dev->pfbMemory,
+    if (!fbScreenInit(pScreen, NULL,
                       pScrn->virtualX, pScrn->virtualY,
                       pScrn->xDpi, pScrn->yDpi, pScrn->displayWidth,
                       pScrn->bitsPerPixel))
@@ -688,6 +651,12 @@ rdpScreenInit(ScreenPtr pScreen, int argc, char **argv)
         if (glamor_init(pScreen, GLAMOR_USE_EGL_SCREEN | GLAMOR_NO_DRI3))
         {
             LOG(LOG_LEVEL_INFO, "rdpScreenInit: glamor_init ok");
+            dev->gbm = glamor_egl_get_gbm_device(pScreen);
+            if (dev->gbm == NULL)
+            {
+                LOG(LOG_LEVEL_INFO, "rdpScreenInit: glamor_egl_get_gbm_device failed");
+                return FALSE;
+            }
         }
         else
         {

--- a/xrdpdev/xrdpdri3.c
+++ b/xrdpdev/xrdpdri3.c
@@ -28,9 +28,11 @@ dri3
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 /* this should be before all X11 .h files */
 #include <xorg-server.h>
@@ -39,6 +41,7 @@ dri3
 /* all driver need this */
 #include <xf86.h>
 #include <xf86_OSproc.h>
+#include <xf86drm.h>
 
 #include <mipointer.h>
 #include <fb.h>
@@ -89,15 +92,39 @@ static int
 rdpDri3OpenClient(ClientPtr client, ScreenPtr screen,
                   RRProviderPtr provider, int *pfd)
 {
+    ScrnInfoPtr pScrn;
+    rdpPtr dev;
     int fd;
+    drm_magic_t magic;
 
     LOG(LOG_LEVEL_TRACE, "rdpDri3OpenClient:");
+    pScrn = xf86ScreenToScrn(screen);
+    dev = XRDPPTR(pScrn);
     fd = open(g_drm_device, O_RDWR | O_CLOEXEC);
     LOG(LOG_LEVEL_TRACE, "rdpDri3OpenClient: fd %d", fd);
     if (fd < 0)
     {
         return BadAlloc;
     }
+
+    if (drmGetMagic(fd, &magic) < 0)
+    {
+        if (errno == EACCES)
+        {
+            /* Render nodes are already as authenticated as they should be. */
+            *pfd = fd;
+            return Success;
+        }
+        close(fd);
+        return BadMatch;
+    }
+
+    if (drmAuthMagic(dev->fd, magic) < 0)
+    {
+        close(fd);
+        return BadMatch;
+    }
+
     *pfd = fd;
     return Success;
 }


### PR DESCRIPTION
While getting xorgxrdp working on xe, I hit a few issues in the glamor/DRI3 path.

This series:
- backs the glamor screen pixmap with a GBM BO
- authenticates DRI3 client fds when using a primary DRM node
- switches the DRM version probe to libdrm helpers instead of a raw ioctl

With these patches applied, xorgxrdp works for me on xe.