### PR TITLE
Suspend screen rendering for inactive sessions to reduce server CPU usage and network traffic

### DIFF
--- a/module/rdp.h
+++ b/module/rdp.h
@@ -327,6 +327,17 @@ struct _rdpRec
     /* egl */
     void *egl;
     DamagePtr damage;
+    int screen_sleep_mode;
+    int screen_sleep_active;
+    int screen_sleep_time_ms;
+    int screen_sleep_refresh_interval_ms;
+    int screen_sleep_overlay_pending;
+    OsTimerPtr screen_sleep_enter_timer;
+    OsTimerPtr screen_sleep_refresh_timer;
+    OsTimerPtr screen_sleep_resume_timer;
+    int screen_sleep_refresh_pending;
+    CARD32 screen_sleep_start_time_ms;
+    CARD32 last_wakeup_refresh_time_ms;
 };
 typedef struct _rdpRec rdpRec;
 typedef struct _rdpRec * rdpPtr;

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -3885,13 +3885,12 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
     LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback:");
     clientCon->updateScheduled = FALSE;
     if (clientCon->dev->screen_sleep_active &&
-            clientCon->dev->screen_sleep_overlay_pending)
+            clientCon->dev->screen_sleep_overlay_pending > 0)
     {
         if (!clientCon->suppress_output)
         {
             rdpScreenSleepSendSolid(clientCon->dev, clientCon);
-            clientCon->dev->screen_sleep_overlay_pending--;
-            if (clientCon->dev->screen_sleep_overlay_pending > 0)
+            if (--clientCon->dev->screen_sleep_overlay_pending > 0)
             {
                 rdpScreenSleepScheduleForcedUpdate(clientCon, 50);
             }

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -164,7 +164,7 @@ rdpScreenSleepQueueFullRefresh(rdpPtr dev);
 static int
 rdpScreenSleepSendSolid(rdpPtr dev, rdpClientCon *clientCon);
 static int
-rdpScreenSleepForceCaptureStateReset(rdpPtr dev);
+rdpScreenSleepRefreshFramebuffer(rdpPtr dev);
 static const char *
 rdpScreenSleepModeToText(int mode);
 
@@ -222,15 +222,28 @@ parse_screen_sleep_mode(const char *value, int *mode, int *refresh_ms)
         return 0;
     }
 
-    if (strncasecmp(value, "refresh:", 8) == 0)
+    if (strncasecmp(value, "refresh", 7) == 0)
     {
-        errno = 0;
-        refresh_minutes = strtol(value + 8, &endptr, 10);
-        if (errno != 0 || endptr == value + 8 || *endptr != '\0')
+        if (value[7] == ':')
         {
-            return 1;
+            errno = 0;
+            refresh_minutes = strtol(value + 8, &endptr, 10);
+            if (errno != 0 || endptr == value + 8 || *endptr != '\0')
+            {
+                return 1;
+            }
+            if (refresh_minutes < 1 || refresh_minutes > 10080)
+            {
+                /* invalid or zero: default to 5 minutes */
+                refresh_minutes = 5;
+            }
         }
-        if (refresh_minutes < 1 || refresh_minutes > 10080)
+        else if (value[7] == '\0')
+        {
+            /* bare "refresh" - default 5 minutes */
+            refresh_minutes = 5;
+        }
+        else
         {
             return 1;
         }
@@ -365,47 +378,60 @@ rdpScreenSleepScheduleForcedUpdateAll(rdpPtr dev, CARD32 delay_ms)
 }
 
 /*
- * Force the original capture pipeline to rebuild itself by toggling the
- * capture code through a different path and then restoring the original mode.
- * This reuses the existing resize/reconfigure flow which resets shm/capture
- * state and has proven to be the reliable black-screen wake-up path.
+ * Temporarily resize the screen by +/-1 pixel to trigger RRScreenSizeSet.
+ * RRScreenSizeSet broadcasts ConfigureNotify to all top-level windows,
+ * causing every application to redraw itself. This forces the framebuffer
+ * to be repopulated with the latest application content after wake.
+ *
+ * The +/-1 is imperceptible to the user and the resize is immediately
+ * restored. The framebuffer memory is reallocated on each call; any
+ * unredrawn areas appear as black and are filled as applications
+ * process the ConfigureNotify asynchronously.
  */
 static int
-rdpScreenSleepForceCaptureStateReset(rdpPtr dev)
+rdpScreenSleepRefreshFramebuffer(rdpPtr dev)
 {
-    rdpClientCon *clientCon;
-    int original_capture_code;
-    int alternate_capture_code;
+    ScrnInfoPtr pScrn;
+    int orig_width;
+    int orig_height;
 
-    clientCon = dev->clientConHead;
-    while (clientCon != NULL)
+    if (dev->pScreen == NULL)
     {
-        if (clientCon->client_info.display_sizes.session_width > 0 &&
-                clientCon->client_info.display_sizes.session_height > 0)
-        {
-            original_capture_code = clientCon->client_info.capture_code;
-            switch (original_capture_code)
-            {
-                case CC_SUF_RFX:
-                case CC_GFX_PRO:
-                    alternate_capture_code = CC_SUF_A2;
-                    break;
-                case CC_SUF_A2:
-                case CC_GFX_A2:
-                    alternate_capture_code = CC_SUF_RFX;
-                    break;
-                default:
-                    alternate_capture_code = CC_SUF_RFX;
-                    break;
-            }
-
-            clientCon->client_info.capture_code = alternate_capture_code;
-            rdpClientConResizeAllMemoryAreas(dev, clientCon);
-            clientCon->client_info.capture_code = original_capture_code;
-            rdpClientConResizeAllMemoryAreas(dev, clientCon);
-        }
-        clientCon = clientCon->next;
+        return 0;
     }
+
+    pScrn = xf86Screens[dev->pScreen->myNum];
+    orig_width = dev->width;
+    orig_height = dev->height;
+
+    if (orig_width <= 1 || orig_height <= 1)
+    {
+        return 0;
+    }
+
+    dev->allow_screen_resize = 1;
+
+    /* Step 1: shrink by 1 pixel -- triggers ConfigureNotify -> redraw */
+    RRScreenSizeSet(dev->pScreen,
+                    orig_width - 1, orig_height - 1,
+                    PixelToMM(orig_width - 1, pScrn->xDpi),
+                    PixelToMM(orig_height - 1, pScrn->yDpi));
+
+    /* Step 2: restore original size -- triggers second ConfigureNotify -> redraw */
+    RRScreenSizeSet(dev->pScreen,
+                    orig_width, orig_height,
+                    PixelToMM(orig_width, pScrn->xDpi),
+                    PixelToMM(orig_height, pScrn->yDpi));
+
+    dev->allow_screen_resize = 0;
+
+    LOG(LOG_LEVEL_INFO,
+        "rdpScreenSleepRefreshFramebuffer: [Session %s] "
+        "framebuffer refresh via resize %dx%d -> %dx%d -> %dx%d",
+        dev->uds_data,
+        orig_width, orig_height,
+        orig_width - 1, orig_height - 1,
+        orig_width, orig_height);
 
     return 0;
 }
@@ -650,10 +676,7 @@ rdpScreenSleepWake(rdpPtr dev, const char *reason)
     rdpScreenSleepStopRefreshTimer(dev);
     rdpScreenSleepStopResumeTimer(dev);
 
-    if (dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_BLACK)
-    {
-        rdpScreenSleepForceCaptureStateReset(dev);
-    }
+    rdpScreenSleepRefreshFramebuffer(dev);
 
     LOG(LOG_LEVEL_INFO,
         "rdpScreenSleepWake: [Session %s] waking after %u min %u sec, reason=%s",

--- a/module/rdpClientCon.c
+++ b/module/rdpClientCon.c
@@ -29,6 +29,7 @@ Client connection to xrdp
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <signal.h>
 #include <limits.h>
 #include <sys/types.h>
@@ -120,6 +121,547 @@ static int
 rdpSendMemoryAllocationComplete(rdpPtr dev, rdpClientCon *clientCon);
 static int
 rdpSendAccelAssistMonitors(rdpPtr dev, rdpClientCon *clientCon);
+int
+rdpClientConResetClip(rdpPtr dev, rdpClientCon *clientCon);
+int
+rdpClientConSetOpcode(rdpPtr dev, rdpClientCon *clientCon, int opcode);
+static int
+parse_screen_sleep_time_minutes(const char *value, int *sleep_ms);
+static int
+parse_screen_sleep_mode(const char *value, int *mode, int *refresh_ms);
+static int
+rdpScreenSleepStartEnterTimer(rdpPtr dev);
+static int
+rdpScreenSleepStopEnterTimer(rdpPtr dev);
+static int
+rdpScreenSleepStartRefreshTimer(rdpPtr dev);
+static int
+rdpScreenSleepStopRefreshTimer(rdpPtr dev);
+static int
+rdpScreenSleepStartResumeTimer(rdpPtr dev, CARD32 delay_ms);
+static int
+rdpScreenSleepStopResumeTimer(rdpPtr dev);
+static int
+rdpScreenSleepEnter(rdpPtr dev, CARD32 now, const char *caller, int log_message);
+static CARD32
+rdpScreenSleepEnterCallback(OsTimerPtr timer, CARD32 now, pointer arg);
+static CARD32
+rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg);
+static CARD32
+rdpScreenSleepRefreshCallback(OsTimerPtr timer, CARD32 now, pointer arg);
+static CARD32
+rdpScreenSleepResumeCallback(OsTimerPtr timer, CARD32 now, pointer arg);
+static int
+rdpScreenSleepStartWakeRefresh(rdpPtr dev);
+static void
+rdpClientConResizeAllMemoryAreas(rdpPtr dev, rdpClientCon *clientCon);
+static int
+rdpScreenSleepScheduleForcedUpdate(rdpClientCon *clientCon, CARD32 delay_ms);
+static int
+rdpScreenSleepScheduleForcedUpdateAll(rdpPtr dev, CARD32 delay_ms);
+static int
+rdpScreenSleepQueueFullRefresh(rdpPtr dev);
+static int
+rdpScreenSleepSendSolid(rdpPtr dev, rdpClientCon *clientCon);
+static int
+rdpScreenSleepForceCaptureStateReset(rdpPtr dev);
+static const char *
+rdpScreenSleepModeToText(int mode);
+
+static int
+parse_screen_sleep_time_minutes(const char *value, int *sleep_ms)
+{
+    char *endptr;
+    long sleep_minutes;
+
+    if (value == NULL || value[0] == '\0')
+    {
+        *sleep_ms = 0;
+        return 0;
+    }
+
+    errno = 0;
+    sleep_minutes = strtol(value, &endptr, 10);
+    if (errno != 0 || endptr == value || *endptr != '\0')
+    {
+        return 1;
+    }
+
+    if (sleep_minutes < 0 || sleep_minutes > 10080)
+    {
+        return 1;
+    }
+
+    *sleep_ms = (int) sleep_minutes * 60 * 1000;
+    return 0;
+}
+
+static int
+parse_screen_sleep_mode(const char *value, int *mode, int *refresh_ms)
+{
+    char *endptr;
+    long refresh_minutes;
+
+    *mode = XRDP_SCREEN_SLEEP_MODE_BLACK;
+    *refresh_ms = 0;
+
+    if (value == NULL || value[0] == '\0')
+    {
+        return 0;
+    }
+
+    if (strcasecmp(value, "black") == 0)
+    {
+        *mode = XRDP_SCREEN_SLEEP_MODE_BLACK;
+        return 0;
+    }
+
+    if (strcasecmp(value, "last") == 0)
+    {
+        *mode = XRDP_SCREEN_SLEEP_MODE_LAST;
+        return 0;
+    }
+
+    if (strncasecmp(value, "refresh:", 8) == 0)
+    {
+        errno = 0;
+        refresh_minutes = strtol(value + 8, &endptr, 10);
+        if (errno != 0 || endptr == value + 8 || *endptr != '\0')
+        {
+            return 1;
+        }
+        if (refresh_minutes < 1 || refresh_minutes > 10080)
+        {
+            return 1;
+        }
+        *mode = XRDP_SCREEN_SLEEP_MODE_REFRESH;
+        *refresh_ms = (int) refresh_minutes * 60 * 1000;
+        return 0;
+    }
+
+    return 1;
+}
+
+static int
+rdpScreenSleepStopEnterTimer(rdpPtr dev)
+{
+    if (dev->screen_sleep_enter_timer != NULL)
+    {
+        TimerCancel(dev->screen_sleep_enter_timer);
+        TimerFree(dev->screen_sleep_enter_timer);
+        dev->screen_sleep_enter_timer = NULL;
+    }
+
+    return 0;
+}
+
+static int
+rdpScreenSleepStopRefreshTimer(rdpPtr dev)
+{
+    if (dev->screen_sleep_refresh_timer != NULL)
+    {
+        TimerCancel(dev->screen_sleep_refresh_timer);
+        TimerFree(dev->screen_sleep_refresh_timer);
+        dev->screen_sleep_refresh_timer = NULL;
+    }
+
+    return 0;
+}
+
+static int
+rdpScreenSleepStopResumeTimer(rdpPtr dev)
+{
+    if (dev->screen_sleep_resume_timer != NULL)
+    {
+        TimerCancel(dev->screen_sleep_resume_timer);
+        TimerFree(dev->screen_sleep_resume_timer);
+        dev->screen_sleep_resume_timer = NULL;
+    }
+
+    return 0;
+}
+
+static int
+rdpScreenSleepStartEnterTimer(rdpPtr dev)
+{
+    if (dev->screen_sleep_time_ms <= 0)
+    {
+        return 0;
+    }
+
+    dev->screen_sleep_enter_timer = TimerSet(dev->screen_sleep_enter_timer, 0,
+                                             (CARD32) dev->screen_sleep_time_ms,
+                                             rdpScreenSleepEnterCallback, dev);
+    return 0;
+}
+
+static int
+rdpScreenSleepStartResumeTimer(rdpPtr dev, CARD32 delay_ms)
+{
+    dev->screen_sleep_resume_timer =
+        TimerSet(dev->screen_sleep_resume_timer, 0, delay_ms,
+                 rdpScreenSleepResumeCallback, dev);
+    return 0;
+}
+
+static int
+rdpScreenSleepStartRefreshTimer(rdpPtr dev)
+{
+    if (dev->screen_sleep_mode != XRDP_SCREEN_SLEEP_MODE_REFRESH ||
+            dev->screen_sleep_refresh_interval_ms <= 0)
+    {
+        return 0;
+    }
+
+    dev->screen_sleep_refresh_timer =
+        TimerSet(dev->screen_sleep_refresh_timer, 0,
+                 (CARD32) dev->screen_sleep_refresh_interval_ms,
+                 rdpScreenSleepRefreshCallback, dev);
+    return 0;
+}
+
+static const char *
+rdpScreenSleepModeToText(int mode)
+{
+    switch (mode)
+    {
+        case XRDP_SCREEN_SLEEP_MODE_LAST:
+            return "last";
+        case XRDP_SCREEN_SLEEP_MODE_BLACK:
+            return "black";
+        case XRDP_SCREEN_SLEEP_MODE_REFRESH:
+            return "refresh";
+        default:
+            return "unknown";
+    }
+}
+
+static int
+rdpScreenSleepScheduleForcedUpdate(rdpClientCon *clientCon, CARD32 delay_ms)
+{
+    if (clientCon == NULL || !clientCon->connected || clientCon->updateScheduled)
+    {
+        return 0;
+    }
+
+    clientCon->updateTimer = TimerSet(clientCon->updateTimer, 0, delay_ms,
+                                      rdpDeferredUpdateCallback, clientCon);
+    clientCon->updateScheduled = TRUE;
+    return 0;
+}
+
+static int
+rdpScreenSleepScheduleForcedUpdateAll(rdpPtr dev, CARD32 delay_ms)
+{
+    rdpClientCon *clientCon;
+
+    clientCon = dev->clientConHead;
+    while (clientCon != NULL)
+    {
+        rdpScreenSleepScheduleForcedUpdate(clientCon, delay_ms);
+        clientCon = clientCon->next;
+    }
+    return 0;
+}
+
+/*
+ * Force the original capture pipeline to rebuild itself by toggling the
+ * capture code through a different path and then restoring the original mode.
+ * This reuses the existing resize/reconfigure flow which resets shm/capture
+ * state and has proven to be the reliable black-screen wake-up path.
+ */
+static int
+rdpScreenSleepForceCaptureStateReset(rdpPtr dev)
+{
+    rdpClientCon *clientCon;
+    int original_capture_code;
+    int alternate_capture_code;
+
+    clientCon = dev->clientConHead;
+    while (clientCon != NULL)
+    {
+        if (clientCon->client_info.display_sizes.session_width > 0 &&
+                clientCon->client_info.display_sizes.session_height > 0)
+        {
+            original_capture_code = clientCon->client_info.capture_code;
+            switch (original_capture_code)
+            {
+                case CC_SUF_RFX:
+                case CC_GFX_PRO:
+                    alternate_capture_code = CC_SUF_A2;
+                    break;
+                case CC_SUF_A2:
+                case CC_GFX_A2:
+                    alternate_capture_code = CC_SUF_RFX;
+                    break;
+                default:
+                    alternate_capture_code = CC_SUF_RFX;
+                    break;
+            }
+
+            clientCon->client_info.capture_code = alternate_capture_code;
+            rdpClientConResizeAllMemoryAreas(dev, clientCon);
+            clientCon->client_info.capture_code = original_capture_code;
+            rdpClientConResizeAllMemoryAreas(dev, clientCon);
+        }
+        clientCon = clientCon->next;
+    }
+
+    return 0;
+}
+
+static int
+rdpScreenSleepQueueFullRefresh(rdpPtr dev)
+{
+    ScreenPtr pScreen;
+    WindowPtr root;
+    BoxRec box;
+    RegionRec reg;
+
+    if (dev->clientConHead == NULL || dev->pScreen == NULL)
+    {
+        return 0;
+    }
+
+    pScreen = dev->pScreen;
+    root = pScreen->root;
+    if (root == NULL)
+    {
+        return 0;
+    }
+
+    box.x1 = 0;
+    box.y1 = 0;
+    box.x2 = dev->width;
+    box.y2 = dev->height;
+    rdpRegionInit(&reg, &box, 0);
+    rdpClientConAddAllReg(dev, &reg, &(root->drawable));
+    rdpRegionUninit(&reg);
+    return 0;
+}
+
+static int
+rdpScreenSleepSendSolid(rdpPtr dev, rdpClientCon *clientCon)
+{
+    int fgcolor;
+
+    if (!clientCon->connected)
+    {
+        return 0;
+    }
+
+    fgcolor = 0x000000;
+    rdpClientConBeginUpdate(dev, clientCon);
+    rdpClientConResetClip(dev, clientCon);
+    rdpClientConSetOpcode(dev, clientCon, GXcopy);
+    rdpClientConSetFgcolor(dev, clientCon, fgcolor);
+    rdpClientConFillRect(dev, clientCon, 0, 0, clientCon->rdp_width,
+                         clientCon->rdp_height);
+    rdpClientConEndUpdate(dev, clientCon);
+    return 0;
+}
+
+static int
+rdpScreenSleepStartWakeRefresh(rdpPtr dev)
+{
+    dev->screen_sleep_active = 0;
+    dev->screen_sleep_overlay_pending = 0;
+    dev->screen_sleep_refresh_pending = 0;
+    rdpScreenSleepStopEnterTimer(dev);
+    rdpScreenSleepStopRefreshTimer(dev);
+    rdpScreenSleepStopResumeTimer(dev);
+    rdpScreenSleepQueueFullRefresh(dev);
+    rdpScreenSleepStartEnterTimer(dev);
+    return 0;
+}
+
+static int
+rdpScreenSleepEnter(rdpPtr dev, CARD32 now, const char *caller, int log_message)
+{
+    rdpClientCon *clientCon;
+
+    if (dev->screen_sleep_active || dev->screen_sleep_time_ms <= 0)
+    {
+        return 0;
+    }
+
+    dev->screen_sleep_active = 1;
+    if (!dev->screen_sleep_refresh_pending)
+    {
+        dev->screen_sleep_start_time_ms = now;
+    }
+    dev->screen_sleep_overlay_pending =
+        (dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_BLACK) ? 3 : 0;
+    dev->screen_sleep_refresh_pending = 0;
+    rdpScreenSleepStopEnterTimer(dev);
+    rdpScreenSleepStopRefreshTimer(dev);
+    rdpScreenSleepStopResumeTimer(dev);
+
+    clientCon = dev->clientConHead;
+    while (clientCon != NULL)
+    {
+        if (clientCon->updateScheduled && clientCon->updateTimer != NULL)
+        {
+            TimerCancel(clientCon->updateTimer);
+        }
+        clientCon->updateScheduled = FALSE;
+        clientCon = clientCon->next;
+    }
+
+    if (dev->screen_sleep_overlay_pending)
+    {
+        rdpScreenSleepScheduleForcedUpdateAll(dev, 1);
+    }
+    else if (dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_REFRESH)
+    {
+        rdpScreenSleepStartRefreshTimer(dev);
+    }
+
+    if (log_message)
+    {
+        LOG(LOG_LEVEL_INFO,
+            "%s: [Session %s] entering screen sleep after %d minute(s), mode=%s",
+            caller, dev->uds_data, dev->screen_sleep_time_ms / (60 * 1000),
+            rdpScreenSleepModeToText(dev->screen_sleep_mode));
+    }
+
+    return 0;
+}
+
+static CARD32
+rdpScreenSleepEnterCallback(OsTimerPtr timer, CARD32 now, pointer arg)
+{
+    rdpPtr dev;
+
+    (void) timer;
+    dev = (rdpPtr) arg;
+    dev->screen_sleep_enter_timer = NULL;
+    rdpScreenSleepEnter(dev, now, "rdpScreenSleepEnterCallback", 1);
+    return 0;
+}
+
+static CARD32
+rdpScreenSleepRefreshCallback(OsTimerPtr timer, CARD32 now, pointer arg)
+{
+    rdpPtr dev;
+
+    (void) timer;
+    (void) now;
+
+    dev = (rdpPtr) arg;
+    dev->screen_sleep_refresh_timer = NULL;
+
+    if (!dev->screen_sleep_active ||
+            dev->screen_sleep_mode != XRDP_SCREEN_SLEEP_MODE_REFRESH)
+    {
+        return 0;
+    }
+
+    dev->screen_sleep_active = 0;
+    dev->screen_sleep_refresh_pending = 1;
+    dev->screen_sleep_overlay_pending = 0;
+    rdpScreenSleepQueueFullRefresh(dev);
+    rdpScreenSleepStartResumeTimer(dev, 1000);
+    return 0;
+}
+
+static CARD32
+rdpScreenSleepResumeCallback(OsTimerPtr timer, CARD32 now, pointer arg)
+{
+    rdpPtr dev;
+
+    (void) timer;
+    dev = (rdpPtr) arg;
+    dev->screen_sleep_resume_timer = NULL;
+
+    if (dev->screen_sleep_refresh_pending &&
+            dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_REFRESH)
+    {
+        LOG(LOG_LEVEL_INFO,
+            "rdpScreenSleepResumeCallback: [Session %s] auto refresh screen",
+            dev->uds_data);
+        rdpScreenSleepEnter(dev, now, "rdpScreenSleepResumeCallback", 0);
+    }
+    return 0;
+}
+
+int
+rdpScreenSleepBlockUpdates(rdpPtr dev)
+{
+    return (dev != NULL) && dev->screen_sleep_active;
+}
+
+int
+rdpScreenSleepBlockDraws(rdpPtr dev)
+{
+    return (dev != NULL) && dev->screen_sleep_active;
+}
+
+int
+rdpScreenSleepActivity(rdpPtr dev, CARD32 now)
+{
+    if (dev == NULL)
+    {
+        return 0;
+    }
+
+    dev->last_event_time_ms = now;
+    rdpScreenSleepStopResumeTimer(dev);
+    dev->screen_sleep_refresh_pending = 0;
+    if (dev->screen_sleep_time_ms <= 0 || dev->clientConHead == NULL)
+    {
+        return 0;
+    }
+
+    if (!dev->screen_sleep_active)
+    {
+        rdpScreenSleepStopEnterTimer(dev);
+        rdpScreenSleepStartEnterTimer(dev);
+    }
+
+    return 0;
+}
+
+int
+rdpScreenSleepWake(rdpPtr dev, const char *reason)
+{
+    CARD32 now;
+    CARD32 slept_ms;
+    unsigned int slept_s;
+    unsigned int slept_min;
+    unsigned int rem_s;
+
+    if (dev == NULL || !dev->screen_sleep_active)
+    {
+        return 0;
+    }
+
+    now = GetTimeInMillis();
+    slept_ms = now - dev->screen_sleep_start_time_ms;
+    slept_s = slept_ms / 1000;
+    slept_min = slept_s / 60;
+    rem_s = slept_s % 60;
+
+    dev->screen_sleep_active = 0;
+    dev->screen_sleep_overlay_pending = 0;
+    dev->screen_sleep_refresh_pending = 0;
+    dev->screen_sleep_start_time_ms = 0;
+    rdpScreenSleepStopEnterTimer(dev);
+    rdpScreenSleepStopRefreshTimer(dev);
+    rdpScreenSleepStopResumeTimer(dev);
+
+    if (dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_BLACK)
+    {
+        rdpScreenSleepForceCaptureStateReset(dev);
+    }
+
+    LOG(LOG_LEVEL_INFO,
+        "rdpScreenSleepWake: [Session %s] waking after %u min %u sec, reason=%s",
+        dev->uds_data, slept_min, rem_s, reason);
+
+    rdpScreenSleepStartWakeRefresh(dev);
+    return 0;
+}
 
 #if XORG_VERSION_CURRENT < XORG_VERSION_NUMERIC(1, 18, 5, 0, 0)
 
@@ -288,6 +830,8 @@ rdpClientConGotConnection(ScreenPtr pScreen, rdpPtr dev)
 
     clientCon->dirtyRegion = rdpRegionCreate(NullBox, 0);
     clientCon->shmRegion = rdpRegionCreate(NullBox, 0);
+    rdpScreenSleepStopEnterTimer(dev);
+    rdpScreenSleepStartEnterTimer(dev);
 
     return 0;
 }
@@ -481,6 +1025,16 @@ rdpClientConDisconnect(rdpPtr dev, rdpClientCon *clientCon)
     free(clientCon->osBitmaps);
 
     rdpRemoveClientConFromDev(dev, clientCon);
+    if (dev->clientConHead == NULL)
+    {
+        rdpScreenSleepStopEnterTimer(dev);
+        rdpScreenSleepStopRefreshTimer(dev);
+        rdpScreenSleepStopResumeTimer(dev);
+        dev->screen_sleep_active = 0;
+        dev->screen_sleep_overlay_pending = 0;
+        dev->screen_sleep_refresh_pending = 0;
+        dev->screen_sleep_start_time_ms = 0;
+    }
 
     rdpRegionDestroy(clientCon->dirtyRegion);
     rdpRegionDestroy(clientCon->shmRegion);
@@ -1985,6 +2539,37 @@ rdpClientConInit(rdpPtr dev)
         "rdpClientConInit: kill disconnected [%d] timeout [%d] sec",
         dev->do_kill_disconnected, dev->disconnect_timeout_s);
 
+    ptext = getenv("XRDP_SCREEN_SLEEP_TIME");
+    if (parse_screen_sleep_time_minutes(ptext, &dev->screen_sleep_time_ms) != 0)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "rdpClientConInit: [Session %s] ignoring invalid "
+            "XRDP_SCREEN_SLEEP_TIME '%s'",
+            dev->uds_data, ptext);
+        dev->screen_sleep_time_ms = 0;
+    }
+    ptext = getenv("XRDP_SCREEN_SLEEP_MODE");
+    if (parse_screen_sleep_mode(ptext, &dev->screen_sleep_mode,
+                                &dev->screen_sleep_refresh_interval_ms) != 0)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "rdpClientConInit: [Session %s] ignoring invalid "
+            "XRDP_SCREEN_SLEEP_MODE '%s', using black",
+            dev->uds_data, ptext);
+        dev->screen_sleep_mode = XRDP_SCREEN_SLEEP_MODE_BLACK;
+        dev->screen_sleep_refresh_interval_ms = 0;
+    }
+    LOG(LOG_LEVEL_INFO,
+        "rdpClientConInit: [Session %s] screen sleep timeout [%d] min mode [%s]",
+        dev->uds_data, dev->screen_sleep_time_ms / (60 * 1000),
+        rdpScreenSleepModeToText(dev->screen_sleep_mode));
+    if (dev->screen_sleep_mode == XRDP_SCREEN_SLEEP_MODE_REFRESH)
+    {
+        LOG(LOG_LEVEL_INFO,
+            "rdpClientConInit: [Session %s] screen sleep refresh interval [%d] min",
+            dev->uds_data, dev->screen_sleep_refresh_interval_ms / (60 * 1000));
+    }
+
 
     return 0;
 }
@@ -1994,6 +2579,10 @@ int
 rdpClientConDeinit(rdpPtr dev)
 {
     LOG(LOG_LEVEL_TRACE, "rdpClientConDeinit:");
+
+    rdpScreenSleepStopEnterTimer(dev);
+    rdpScreenSleepStopRefreshTimer(dev);
+    rdpScreenSleepStopResumeTimer(dev);
 
     while (dev->clientConTail != NULL)
     {
@@ -3295,6 +3884,20 @@ rdpDeferredUpdateCallback(OsTimerPtr timer, CARD32 now, pointer arg)
 
     LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback:");
     clientCon->updateScheduled = FALSE;
+    if (clientCon->dev->screen_sleep_active &&
+            clientCon->dev->screen_sleep_overlay_pending)
+    {
+        if (!clientCon->suppress_output)
+        {
+            rdpScreenSleepSendSolid(clientCon->dev, clientCon);
+            clientCon->dev->screen_sleep_overlay_pending--;
+            if (clientCon->dev->screen_sleep_overlay_pending > 0)
+            {
+                rdpScreenSleepScheduleForcedUpdate(clientCon, 50);
+            }
+        }
+        return 0;
+    }
     if (clientCon->suppress_output)
     {
         LOG(LOG_LEVEL_TRACE, "rdpDeferredUpdateCallback: suppress_output set");
@@ -3389,6 +3992,10 @@ rdpScheduleDeferredUpdate(rdpClientCon *clientCon)
     {
         return;
     }
+    if (rdpScreenSleepBlockUpdates(clientCon->dev))
+    {
+        return;
+    }
     curTime = (uint32_t) GetTimeInMillis();
     /* use two separate delays in order to limit the update rate and wait a bit
        for more changes before sending an update. Always waiting the longer
@@ -3417,6 +4024,10 @@ rdpClientConAddDirtyScreenReg(rdpPtr dev, rdpClientCon *clientCon,
                               RegionPtr reg)
 {
     LOG(LOG_LEVEL_TRACE, "rdpClientConAddDirtyScreenReg:");
+    if (rdpScreenSleepBlockUpdates(dev))
+    {
+        return 0;
+    }
     rdpRegionUnion(clientCon->dirtyRegion, clientCon->dirtyRegion, reg);
     rdpScheduleDeferredUpdate(clientCon);
     return 0;
@@ -3480,6 +4091,10 @@ rdpClientConAddAllReg(rdpPtr dev, RegionPtr reg, DrawablePtr pDrawable)
 
     drw_is_vis = XRDP_DRAWABLE_IS_VISIBLE(dev, pDrawable);
     if (!drw_is_vis)
+    {
+        return 0;
+    }
+    if (rdpScreenSleepBlockUpdates(dev))
     {
         return 0;
     }

--- a/module/rdpClientCon.h
+++ b/module/rdpClientCon.h
@@ -30,6 +30,10 @@ Client connection to xrdp
 
 #include "xup_client_info.h"
 
+#define XRDP_SCREEN_SLEEP_MODE_LAST 0
+#define XRDP_SCREEN_SLEEP_MODE_BLACK 1
+#define XRDP_SCREEN_SLEEP_MODE_REFRESH 2
+
 /* used in rdpGlyphs.c */
 struct font_cache
 {
@@ -155,6 +159,14 @@ extern _X_EXPORT int
 rdpClientConInit(rdpPtr dev);
 extern _X_EXPORT int
 rdpClientConDeinit(rdpPtr dev);
+extern _X_EXPORT int
+rdpScreenSleepWake(rdpPtr dev, const char *reason);
+extern _X_EXPORT int
+rdpScreenSleepBlockUpdates(rdpPtr dev);
+extern _X_EXPORT int
+rdpScreenSleepBlockDraws(rdpPtr dev);
+extern _X_EXPORT int
+rdpScreenSleepActivity(rdpPtr dev, CARD32 now);
 
 extern _X_EXPORT int
 rdpClientConDeleteOsSurface(rdpPtr dev, rdpClientCon *clientCon, int rdpindex);

--- a/module/rdpComposite.c
+++ b/module/rdpComposite.c
@@ -75,6 +75,10 @@ rdpComposite(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
     LOG(LOG_LEVEL_TRACE, "rdpComposite:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
+    if (rdpScreenSleepBlockDraws(dev))
+    {
+        return;
+    }
     dev->counts.rdpCompositeCallCount++;
     box.x1 = xDst + pDst->pDrawable->x;
     box.y1 = yDst + pDst->pDrawable->y;

--- a/module/rdpCopyArea.c
+++ b/module/rdpCopyArea.c
@@ -70,6 +70,10 @@ rdpCopyArea(DrawablePtr pSrc, DrawablePtr pDst, GCPtr pGC,
 
     LOG(LOG_LEVEL_TRACE, "rdpCopyArea:");
     dev = rdpGetDevFromScreen(pGC->pScreen);
+    if (rdpScreenSleepBlockDraws(dev))
+    {
+        return NULL;
+    }
     dev->counts.rdpCopyAreaCallCount++;
     box.x1 = dstx + pDst->x;
     box.y1 = dsty + pDst->y;

--- a/module/rdpFillSpans.c
+++ b/module/rdpFillSpans.c
@@ -36,6 +36,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <xf86_OSproc.h>
 
 #include "rdp.h"
+#include "rdpClientCon.h"
 #include "rdpDraw.h"
 #include "rdpMisc.h"
 #include "rdpFillSpans.h"
@@ -57,7 +58,14 @@ void
 rdpFillSpans(DrawablePtr pDrawable, GCPtr pGC, int nInit,
              DDXPointPtr pptInit, int *pwidthInit, int fSorted)
 {
+    rdpPtr dev;
+
     LOG(LOG_LEVEL_TRACE, "rdpFillSpans:");
+    dev = rdpGetDevFromScreen(pGC->pScreen);
+    if (rdpScreenSleepBlockDraws(dev))
+    {
+        return;
+    }
     /* do original call */
     rdpFillSpansOrg(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted);
 }

--- a/module/rdpGlyphs.c
+++ b/module/rdpGlyphs.c
@@ -41,6 +41,7 @@ glyph (font) calls
 #include <glyphstr.h>
 
 #include "rdp.h"
+#include "rdpClientCon.h"
 #include "rdpGlyphs.h"
 #include "rdpDraw.h"
 #include "rdpMisc.h"
@@ -98,6 +99,10 @@ rdpGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     LOG(LOG_LEVEL_TRACE, "rdpGlyphs:");
     pScreen = pDst->pDrawable->pScreen;
     dev = rdpGetDevFromScreen(pScreen);
+    if (rdpScreenSleepBlockDraws(dev))
+    {
+        return;
+    }
     ps = GetPictureScreen(pScreen);
     rdpGlyphsOrg(ps, dev, op, pSrc, pDst, maskFormat, xSrc, ySrc,
                  nlists, lists, glyphs);

--- a/module/rdpInput.c
+++ b/module/rdpInput.c
@@ -36,11 +36,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <xf86_OSproc.h>
 
 #include "rdp.h"
+#include "rdpClientCon.h"
 #include "rdpDraw.h"
 #include "rdpInput.h"
 #include "rdpMisc.h"
 
 #define MAX_INPUT_PROC 4
+#define WAKE_REFRESH_DEBOUNCE_MS 300
 
 struct input_proc_list
 {
@@ -49,6 +51,22 @@ struct input_proc_list
 };
 
 static struct input_proc_list g_input_proc[MAX_INPUT_PROC];
+
+static void
+check_wake_up(rdpPtr dev, CARD32 now)
+{
+    if (!dev->screen_sleep_active)
+    {
+        return;
+    }
+
+    if ((now - (unsigned int) dev->last_wakeup_refresh_time_ms) >=
+            WAKE_REFRESH_DEBOUNCE_MS)
+    {
+        dev->last_wakeup_refresh_time_ms = now;
+        rdpScreenSleepWake(dev, "user reinput");
+    }
+}
 
 /******************************************************************************/
 int
@@ -94,7 +112,11 @@ rdpInputKeyboardEvent(rdpPtr dev, int msg,
                       long param1, long param2,
                       long param3, long param4)
 {
-    dev->last_event_time_ms = GetTimeInMillis();
+    CARD32 now;
+
+    now = GetTimeInMillis();
+    check_wake_up(dev, now);
+    rdpScreenSleepActivity(dev, now);
 
     if (g_input_proc[0].proc != 0)
     {
@@ -109,7 +131,11 @@ rdpInputMouseEvent(rdpPtr dev, int msg,
                    long param1, long param2,
                    long param3, long param4)
 {
-    dev->last_event_time_ms = GetTimeInMillis();
+    CARD32 now;
+
+    now = GetTimeInMillis();
+    check_wake_up(dev, now);
+    rdpScreenSleepActivity(dev, now);
 
     if (g_input_proc[1].proc != 0)
     {

--- a/module/rdpPutImage.c
+++ b/module/rdpPutImage.c
@@ -73,6 +73,10 @@ rdpPutImage(DrawablePtr pDst, GCPtr pGC, int depth, int x, int y,
     LOG(LOG_LEVEL_TRACE, "rdpPutImage:");
     pScreen = pGC->pScreen;
     dev = rdpGetDevFromScreen(pGC->pScreen);
+    if (rdpScreenSleepBlockDraws(dev))
+    {
+        return;
+    }
     if ((x == 0) && (y == 0) && (w == 4) && (h == 4) && (depth >= 24) &&
         (pDst->type == DRAWABLE_PIXMAP))
     {

--- a/module/rdpRandR.c
+++ b/module/rdpRandR.c
@@ -109,7 +109,6 @@ rdpRRSetPixmapVisitWindow(WindowPtr window, void *data)
 }
 #endif
 
-/******************************************************************************/
 Bool
 rdpRRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
                    CARD32 mmWidth, CARD32 mmHeight)
@@ -610,4 +609,3 @@ rdpRRSetRdpOutputs(rdpPtr dev)
     }
     return rv;
 }
-


### PR DESCRIPTION
## Summary

This change adds a screen-sleep mechanism for idle xorgxrdp sessions.

When a session stays idle for a configured amount of time, xorgxrdp stops sending display updates. Once user activity is detected again, display updates resume and a refresh is forced.

## Why

In long-lived remote desktop sessions, the server can continue spending CPU time and network bandwidth on screen updates even when the user is idle.

This feature can save a significant amount of server CPU usage and network traffic in long-connection scenarios.

The effect is especially noticeable in these cases:

- With H.264 encoding, the CPU savings are more obvious. sleep single-user session cpu 65%->1%
- With RFX encoding, the network traffic savings are more obvious. sleep single-user session network traffic 50Mb->0.1Mb
- The benefit is even greater in multi-user deployments.

## Behavior

- No change unless the feature is enabled by xrdp.
- While user is not operating the session for a long time (the duration can be set), display updates are paused.xorgxrdp encoding CPU time and session network traffic are paused.
- When users return and resume keyboard or mouse interaction, the session wakes up and immediately displays the latest screen.

## Notes

A companion xrdp PR adds the sesman configuration and passes the configured timeout to xorgxrdp.
xrdp https://github.com/neutrinolabs/xrdp/pull/3775


Is this optimization plan feasible?