### PR TITLE
Update DRMAllowList to include 'xe' driver

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -53,7 +53,7 @@ Section "Device"
     Driver "xrdpdev"
     Option "DRMDevice" "/dev/dri/renderD128"
     Option "DRI3" "1"
-    Option "DRMAllowList" "amdgpu i915 msm radeon"
+    Option "DRMAllowList" "amdgpu i915 xe msm radeon"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
Closes #432

Adds the Intel `xe` DRM driver to the default `DRMAllowList` in `xrdpdev/xorg.conf`. `xe` is the successor to `i915` and the default in-kernel driver for newer Intel discrete GPUs (Arc / Battlemage and newer), which were not covered by the previous default.

### Change

-Option "DRMAllowList" "amdgpu i915 msm radeon"
+Option "DRMAllowList" "amdgpu i915 xe msm radeon"

### Tested environment

* GPU: Intel Arc Pro B50 (Battlemage)
* Kernel DRM driver: `xe`
* xrdp 0.10.6 / xorgxrdp built with `--enable-glamor`