### PR TITLE
[V0.10] Update DRMAllowList to include 'xe' driver

### DIFF
--- a/xrdpdev/xorg.conf
+++ b/xrdpdev/xorg.conf
@@ -53,7 +53,7 @@ Section "Device"
     Driver "xrdpdev"
     Option "DRMDevice" "/dev/dri/renderD128"
     Option "DRI3" "1"
-    Option "DRMAllowList" "amdgpu i915 msm radeon"
+    Option "DRMAllowList" "amdgpu i915 xe msm radeon"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
Backport of #433

(cherry picked from commit b90f77103353b30c9f8fd0125f71d7e75a36c369)